### PR TITLE
feat(investments): TWR and MWR over the ledger — the return, measured the way the industry measures it

### DIFF
--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -28,6 +28,8 @@ import PageWrapper from '../components/PageWrapper';
 import { WholePoundsScope, WholePoundsToggle } from '../contexts/WholePoundsContext';
 import ToggleSwitch from '../components/ui/ToggleSwitch';
 import { buildPortfolioSummary, buildPortfolioHistory } from '../utils/portfolioSummary';
+import { computePortfolioPerformance } from '../utils/portfolioPerformance';
+import { preferences } from '../services/preferencesService';
 import { PieChart as DashboardPieChart } from '../components/charts/DashboardCharts';
 import { buildHoldingAllocation } from '../utils/holdingAllocation';
 // THE SEAM, not the service. This page called `InvestmentService` — and, through
@@ -525,6 +527,41 @@ function InvestmentsView() {
     () => buildPortfolioHistory(summary.memberAccounts, transactions, historyRange),
     [summary.memberAccounts, transactions, historyRange]
   );
+
+  /**
+   * THE RETURN, BOTH WAYS (owner, 20 Aug, after researching how the big
+   * firms measure it): time-weighted for how the investments performed,
+   * money-weighted for the owner's own experience — over the SAME window
+   * the chart shows, from the same ledger walk. The maths and the owner's
+   * boundary rules live in utils/portfolioPerformance, pinned by test.
+   */
+  const performance = useMemo(
+    () => computePortfolioPerformance({
+      memberAccounts: summary.memberAccounts,
+      transactions,
+      transactionSplits,
+      categories,
+      range: historyRange,
+    }),
+    [summary.memberAccounts, transactions, transactionSplits, categories, historyRange]
+  );
+
+  /** Which measure leads — the user's choice, remembered (GIPS shows both). */
+  const [performanceMeasure, setPerformanceMeasure] = useState<'mwr' | 'twr'>(
+    (): 'mwr' | 'twr' => (preferences.getItem('money_management_perf_measure') === 'twr' ? 'twr' : 'mwr')
+  );
+  const choosePerformanceMeasure = (measure: 'mwr' | 'twr'): void => {
+    setPerformanceMeasure(measure);
+    preferences.setItem('money_management_perf_measure', measure);
+  };
+
+  /** +2.35% / (2.35%) — the app's sign conventions, worn by a percentage. */
+  const formatReturn = (value: DecimalInstance | null): string => {
+    if (value === null) return '—';
+    const percent = value.abs().times(100).toFixed(2);
+    if (value.isZero()) return '0.00%';
+    return value.greaterThan(0) ? `+${percent}%` : `(${percent}%)`;
+  };
 
   // Numbers for the donut, converted once at the chart boundary.
   /**
@@ -1136,6 +1173,88 @@ function InvestmentsView() {
             </div>
           </div>
         )}
+        {/* THE RETURN BAND — the window's performance, both measures, the
+            user choosing which leads (owner, 20 Aug). The £ figures are the
+            flow-adjusted identity every method agrees on: gain = end − start
+            − net flows, so a withdrawal is never mistaken for a loss. */}
+        {(() => {
+          const chosen = performanceMeasure === 'mwr'
+            ? { period: performance.mwrPeriod, annualised: performance.mwrAnnualised }
+            : { period: performance.twrPeriod, annualised: performance.twrAnnualised };
+          const nearOneYear = performance.days >= 330 && performance.days <= 400;
+          return (
+            <div className="mb-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <div className="flex items-baseline gap-3">
+                    <span className={`text-2xl font-bold tabular-nums ${
+                      chosen.period === null || chosen.period.isZero()
+                        ? 'text-gray-900 dark:text-white'
+                        : chosen.period.greaterThan(0)
+                          ? 'text-green-600 dark:text-green-400'
+                          : 'text-red-600 dark:text-red-400'
+                    }`}>
+                      {formatReturn(chosen.period)}
+                    </span>
+                    {chosen.annualised !== null && !nearOneYear && (
+                      <span className="text-dense tabular-nums text-gray-500 dark:text-gray-400">
+                        {formatReturn(chosen.annualised)} annualised
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-dense text-gray-500 dark:text-gray-400 mt-0.5">
+                    {chosen.period === null
+                      ? 'Nothing was invested in this window, so there is no return to measure.'
+                      : performanceMeasure === 'mwr'
+                        ? 'Money-weighted — your own return, the timing of your payments included.'
+                        : 'Time-weighted — how the investments performed, your payment timing stripped out.'}
+                  </p>
+                </div>
+                <div className="flex items-center rounded-lg bg-gray-100 dark:bg-gray-700 p-0.5" role="group" aria-label="Return measure">
+                  {([['mwr', 'MWR'], ['twr', 'TWR']] as const).map(([measure, name]) => (
+                    <button
+                      key={measure}
+                      type="button"
+                      onClick={() => choosePerformanceMeasure(measure)}
+                      aria-pressed={performanceMeasure === measure}
+                      title={measure === 'mwr'
+                        ? 'Money-weighted return — your personal return'
+                        : 'Time-weighted return — the investments’ performance'}
+                      className={`px-2.5 py-0.5 text-xs font-medium rounded-md transition-colors ${
+                        performanceMeasure === measure
+                          ? 'bg-white dark:bg-gray-800 text-gray-900 dark:text-white shadow-sm'
+                          : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100'
+                      }`}
+                    >
+                      {name}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 mt-3">
+                {([
+                  ['Started at', formatCurrency(performance.startValue), ''],
+                  ['Put in', formatCurrency(performance.moneyIn), ''],
+                  ['Taken out', formatCurrency(performance.moneyOut), ''],
+                  ['Gain', performance.gain.greaterThan(0)
+                    ? `+${formatCurrency(performance.gain)}`
+                    : formatCurrency(performance.gain),
+                  performance.gain.isZero() ? ''
+                    : performance.gain.greaterThan(0)
+                      ? 'text-green-600 dark:text-green-400'
+                      : 'text-red-600 dark:text-red-400'],
+                  ['Ended at', formatCurrency(performance.endValue), ''],
+                ] as const).map(([label, figure, colour]) => (
+                  <div key={label}>
+                    <p className="text-label uppercase tracking-wider text-gray-500 dark:text-gray-400">{label}</p>
+                    <p className={`text-sm font-medium tabular-nums ${colour || 'text-gray-900 dark:text-white'}`}>{figure}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })()}
+
         <div className="h-64">
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={performanceData}>

--- a/src/utils/portfolioPerformance.test.ts
+++ b/src/utils/portfolioPerformance.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest';
+import { computePortfolioPerformance } from './portfolioPerformance';
+import type { Account, Category, Transaction } from '../types';
+
+/**
+ * TWR and MWR over the ledger, the owner's semantics pinned one by one
+ * (20 Aug): opening balances are money in on their effective date; transfers
+ * across the scope boundary are flows — INCLUDING an external account paying
+ * into the pair's cash sleeve; transfers between a pair's own accounts are
+ * internal; revaluations, dividends and fees are performance.
+ *
+ * The headline spec is the owner's own worked example from the research
+ * conversation, in figures he invented there: £1,000,000 in, £100,000
+ * withdrawn mid-year, £1,120,000 at the end — gain +£220,000, MWR ≈ +23.1%,
+ * TWR +23.67% given the mid-year valuation his walk implies.
+ */
+
+const CATEGORIES: Category[] = [
+  { id: 'cat-reval', name: 'Account Adjustment', type: 'both', level: 'detail', isRevaluationCategory: true },
+  { id: 'cat-div', name: 'Dividends', type: 'income', level: 'detail' },
+];
+
+const portfolio = (id: string, over: Partial<Account> = {}): Account => ({
+  id, name: `Synthetic ${id}`, type: 'investment', balance: 0,
+  currency: 'GBP', lastUpdated: new Date(2026, 0, 1), openingBalance: 0, isActive: true,
+  ...over,
+});
+
+const EXTERNAL: Account = {
+  id: 'acc-current', name: 'Synthetic Current', type: 'current', balance: 0,
+  currency: 'GBP', lastUpdated: new Date(2026, 0, 1), openingBalance: 0, isActive: true,
+};
+
+let nextId = 0;
+const row = (
+  accountId: string,
+  date: string,
+  amount: number,
+  over: Partial<Transaction> = {}
+): Transaction => ({
+  id: `txn-${nextId++}`,
+  accountId,
+  date: new Date(`${date}T00:00:00Z`),
+  amount,
+  description: 'synthetic',
+  category: '',
+  type: amount >= 0 ? 'income' : 'expense',
+  ...over,
+});
+
+const transferIn = (accountId: string, date: string, amount: number, from: string): Transaction =>
+  row(accountId, date, amount, { type: 'transfer', transferAccountId: from, category: 'transfer-in' });
+const transferOut = (accountId: string, date: string, amount: number, to: string): Transaction =>
+  row(accountId, date, -Math.abs(amount), { type: 'transfer', transferAccountId: to, category: 'transfer-out' });
+const revaluation = (accountId: string, date: string, amount: number): Transaction =>
+  row(accountId, date, amount, { category: 'cat-reval', type: amount >= 0 ? 'income' : 'expense' });
+
+const compute = (
+  members: Account[],
+  transactions: Transaction[],
+  range: { from?: Date | null; to?: Date | null }
+) => computePortfolioPerformance({
+  memberAccounts: members,
+  transactions,
+  transactionSplits: [],
+  categories: CATEGORIES,
+  range,
+  now: new Date('2026-01-01T00:00:00Z'),
+});
+
+const pct = (value: { toNumber(): number } | null): number => {
+  if (value === null) throw new Error('expected a measurable return');
+  return value.toNumber();
+};
+
+describe('computePortfolioPerformance — the owner\'s worked example', () => {
+  const INV = portfolio('acc-inv');
+  const LEDGER = [
+    transferIn(INV.id, '2025-01-01', 1_000_000, EXTERNAL.id),
+    revaluation(INV.id, '2025-04-01', 60_000),          // worth 1,060,000
+    transferOut(INV.id, '2025-07-02', 100_000, EXTERNAL.id), // mid-year withdrawal
+    revaluation(INV.id, '2025-11-01', 160_000),         // ends at 1,120,000
+  ];
+  const YEAR = { from: new Date('2025-01-01T00:00:00Z'), to: new Date('2026-01-01T00:00:00Z') };
+
+  it('the £ gain is flow-adjusted: +220,000, never +120,000', () => {
+    const perf = compute([INV], LEDGER, YEAR);
+    expect(perf.endValue.toNumber()).toBe(1_120_000);
+    expect(perf.moneyIn.toNumber()).toBe(1_000_000);
+    expect(perf.moneyOut.toNumber()).toBe(100_000);
+    expect(perf.gain.toNumber()).toBe(220_000);
+  });
+
+  it('TWR chains the growth between flows: +23.67% for this walk', () => {
+    // 1,060,000/1,000,000 × 1,120,000/960,000 − 1 — the manager's figure,
+    // needing the valuation at the withdrawal, which the ledger provides.
+    const perf = compute([INV], LEDGER, YEAR);
+    expect(pct(perf.twrPeriod)).toBeCloseTo(0.23667, 4);
+  });
+
+  it('MWR is the IRR of the flows: ≈ +23.1%, the investor\'s figure', () => {
+    const perf = compute([INV], LEDGER, YEAR);
+    expect(pct(perf.mwrPeriod)).toBeGreaterThan(0.225);
+    expect(pct(perf.mwrPeriod)).toBeLessThan(0.235);
+    // Not the naive +12% on the start, nor +24.4% on net contribution.
+    expect(pct(perf.mwrPeriod)).not.toBeCloseTo(0.12, 2);
+    expect(pct(perf.mwrPeriod)).not.toBeCloseTo(0.2444, 2);
+  });
+});
+
+describe('computePortfolioPerformance — the boundary, exactly as the owner stated it', () => {
+  const INV = portfolio('acc-inv');
+  const SLEEVE = portfolio('acc-sleeve', { type: 'current', parentAccountId: 'acc-inv' });
+
+  it('an external account paying into the pair\'s CASH SLEEVE is a contribution', () => {
+    const perf = compute([INV, SLEEVE], [
+      transferIn(SLEEVE.id, '2025-03-01', 50_000, EXTERNAL.id),
+    ], { from: new Date('2025-01-01T00:00:00Z'), to: new Date('2026-01-01T00:00:00Z') });
+    expect(perf.moneyIn.toNumber()).toBe(50_000);
+    expect(perf.gain.toNumber()).toBe(0);
+  });
+
+  it('a transfer between the pair\'s own accounts is internal — no flow, no gain', () => {
+    const perf = compute([INV, SLEEVE], [
+      transferIn(INV.id, '2025-02-01', 100_000, EXTERNAL.id),
+      transferOut(SLEEVE.id, '2025-03-01', 20_000, INV.id),
+      transferIn(INV.id, '2025-03-01', 20_000, SLEEVE.id),
+    ], { from: new Date('2025-01-01T00:00:00Z'), to: new Date('2026-01-01T00:00:00Z') });
+    expect(perf.moneyIn.toNumber()).toBe(100_000);
+    expect(perf.moneyOut.toNumber()).toBe(0);
+    expect(perf.gain.toNumber()).toBe(0);
+    expect(perf.flowCount).toBe(1);
+  });
+
+  it('an opening balance is money in, on its effective date', () => {
+    const OPENED = portfolio('acc-opened', {
+      openingBalance: 250_000, openingBalanceDate: new Date('2025-06-01T00:00:00Z'),
+    });
+    const perf = compute([OPENED], [], {
+      from: new Date('2025-01-01T00:00:00Z'), to: new Date('2026-01-01T00:00:00Z'),
+    });
+    expect(perf.moneyIn.toNumber()).toBe(250_000);
+    expect(perf.endValue.toNumber()).toBe(250_000);
+    expect(perf.gain.toNumber()).toBe(0);
+    // Money that only arrived mid-year has earned nothing yet: 0%, not null.
+    // (MWR by bisection converges on zero rather than landing exactly there.)
+    expect(pct(perf.twrPeriod)).toBe(0);
+    expect(pct(perf.mwrPeriod)).toBeCloseTo(0, 8);
+  });
+
+  it('dividends and revaluations are performance, never flows', () => {
+    const INV2 = portfolio('acc-inv2');
+    const perf = compute([INV2], [
+      transferIn(INV2.id, '2025-01-01', 10_000, EXTERNAL.id),
+      row(INV2.id, '2025-06-01', 400, { category: 'cat-div', type: 'income' }),
+      revaluation(INV2.id, '2025-09-01', 600),
+    ], { from: new Date('2025-01-01T00:00:00Z'), to: new Date('2026-01-01T00:00:00Z') });
+    expect(perf.moneyIn.toNumber()).toBe(10_000);
+    expect(perf.gain.toNumber()).toBe(1_000);
+    expect(pct(perf.twrPeriod)).toBeCloseTo(0.1, 6);
+  });
+});
+
+describe('computePortfolioPerformance — windows and edges', () => {
+  const INV = portfolio('acc-inv');
+
+  it('a window starting mid-history opens at the value already there, and only its own flows count', () => {
+    const perf = compute([INV], [
+      transferIn(INV.id, '2024-01-01', 500_000, EXTERNAL.id),
+      revaluation(INV.id, '2024-06-01', 50_000),
+      revaluation(INV.id, '2025-06-01', 55_000),
+    ], { from: new Date('2025-01-01T00:00:00Z'), to: new Date('2026-01-01T00:00:00Z') });
+    expect(perf.startValue.toNumber()).toBe(550_000);
+    expect(perf.moneyIn.toNumber()).toBe(0);
+    expect(perf.gain.toNumber()).toBe(55_000);
+    expect(pct(perf.twrPeriod)).toBeCloseTo(0.1, 6);
+    expect(pct(perf.mwrPeriod)).toBeCloseTo(0.1, 3);
+  });
+
+  it('a never-funded scope measures nothing — null, not 0%', () => {
+    const perf = compute([INV], [], {
+      from: new Date('2025-01-01T00:00:00Z'), to: new Date('2026-01-01T00:00:00Z'),
+    });
+    expect(perf.twrPeriod).toBeNull();
+    expect(perf.mwrPeriod).toBeNull();
+    expect(perf.gain.toNumber()).toBe(0);
+  });
+
+  it('funded, grown, then fully withdrawn: the chain measured while money was at work stands', () => {
+    const perf = compute([INV], [
+      transferIn(INV.id, '2025-01-01', 100_000, EXTERNAL.id),
+      revaluation(INV.id, '2025-03-01', 10_000),
+      transferOut(INV.id, '2025-06-01', 110_000, EXTERNAL.id),
+    ], { from: new Date('2025-01-01T00:00:00Z'), to: new Date('2026-01-01T00:00:00Z') });
+    expect(perf.endValue.toNumber()).toBe(0);
+    expect(perf.gain.toNumber()).toBe(10_000);
+    expect(pct(perf.twrPeriod)).toBeCloseTo(0.1, 6);
+  });
+
+  it('the annualised pair: MWR is annual by construction; TWR annualises from the window', () => {
+    const perf = compute([INV], [
+      transferIn(INV.id, '2025-01-01', 100_000, EXTERNAL.id),
+      revaluation(INV.id, '2025-12-01', 21_000),
+    ], { from: new Date('2025-01-01T00:00:00Z'), to: new Date('2026-01-01T00:00:00Z') });
+    expect(pct(perf.twrPeriod)).toBeCloseTo(0.21, 6);
+    const annual = pct(perf.twrAnnualised);
+    expect(annual).toBeGreaterThan(0.208);
+    expect(annual).toBeLessThan(0.213);
+  });
+});

--- a/src/utils/portfolioPerformance.ts
+++ b/src/utils/portfolioPerformance.ts
@@ -1,0 +1,299 @@
+import type { Account, Category, Transaction, TransactionSplit } from '../types';
+import { toDecimal, type DecimalInstance } from './decimal';
+import { buildCategoryKindLookup, classifyFlow } from './incomeExpense';
+import { expandSplitTransactions } from './transactionSplits';
+import { resolveEffectiveOpeningDates } from './openingDates';
+import { counterpartyAccountId, transferCategoryAccounts } from './portfolioSummary';
+import { dayOf } from './plWindow';
+
+/**
+ * PORTFOLIO PERFORMANCE, the way the industry measures it — both ways.
+ *
+ * The owner's brief (20 Aug), after researching how the big firms do it:
+ * "We now need to bake in both MWR and TWR and allow the user the option on
+ * which they want to view." The semantics are his, stated in the same
+ * message, and each is pinned by a test:
+ *
+ *  - OPENING BALANCES ARE MONEY IN: a portfolio's (or its cash sleeve's)
+ *    opening balance is a contribution on its EFFECTIVE date
+ *    (utils/openingDates — the same resolution the net-worth walk uses), not
+ *    growth the portfolio can claim credit for.
+ *  - TRANSFERS ACROSS THE BOUNDARY ARE FLOWS: money moved between a member
+ *    account and any account OUTSIDE the scope — including an external
+ *    account paying into the pair's cash sleeve — is an addition or a
+ *    withdrawal. Transfers BETWEEN members (fund ↔ its own settlement cash)
+ *    are internal and touch nothing. The boundary rule is portfolioSummary's
+ *    own (counterpartyAccountId), one definition for both surfaces. A
+ *    transfer leg whose other side nothing identifies is counted as EXTERNAL
+ *    — a contribution that lost its link is still a contribution.
+ *  - EVERYTHING ELSE IS PERFORMANCE: the owner's periodic "account
+ *    adjustment" / market revaluation rows, dividends and interest arriving
+ *    inside, fees charged inside — they are what the money DID once there.
+ *    Nothing here needs to enumerate them: they move the VALUATION walk and
+ *    are absent from the flow list, which is the definition of performance.
+ *
+ * VALUATION IS THE LEDGER: the owner keeps his portfolios marked to market
+ * through those revaluation rows, so a member account's running balance IS
+ * its value — no quotes, no estimates, and TWR is exact rather than
+ * approximated. Flows are taken at END OF DAY (a day's performance happens
+ * before its flow), the one convention this file needs and states.
+ *
+ * THE TWO MEASURES (see the 20 Aug research summary):
+ *  - TWR chains sub-period growth between flows — the manager's figure, what
+ *    GIPS requires firms to advertise, blind to flow timing.
+ *  - MWR is the internal rate of return of the flows against the ending
+ *    value — the investor's own experience, where timing counts.
+ *  Both are computed in Decimal end to end (fractional powers included):
+ *  these are REPORTED FINANCIAL FIGURES, not chart geometry.
+ *
+ * Honesty at the edges: a measure that cannot be taken is null, never 0% —
+ * TWR while the portfolio's value is not positive has no meaningful ratio
+ * (the chain restarts at the first funding instead, as statements do), and
+ * MWR with no capital ever at work has nothing to solve.
+ */
+
+export interface PortfolioPerformanceInput {
+  /** The scope: one pair's members, or every pair's for the whole portfolio. */
+  memberAccounts: readonly Account[];
+  transactions: readonly Transaction[];
+  transactionSplits: readonly TransactionSplit[];
+  categories: readonly Category[];
+  /** Null/undefined bounds mean "from the beginning" / "until now". */
+  range: { from?: Date | null; to?: Date | null };
+  now?: Date;
+}
+
+export interface PortfolioPerformance {
+  /** Value at the end of the day before the window — 0 for an unbounded start. */
+  startValue: DecimalInstance;
+  endValue: DecimalInstance;
+  /** Contributions into the scope during the window (positive). */
+  moneyIn: DecimalInstance;
+  /** Withdrawals out of the scope during the window (positive). */
+  moneyOut: DecimalInstance;
+  /** moneyIn − moneyOut. */
+  netFlows: DecimalInstance;
+  /** endValue − startValue − netFlows: what the portfolio earned or lost. */
+  gain: DecimalInstance;
+  /** Time-weighted return over the window, as a fraction (0.05 = +5%). */
+  twrPeriod: DecimalInstance | null;
+  twrAnnualised: DecimalInstance | null;
+  /** Money-weighted return over the window, as a fraction. */
+  mwrPeriod: DecimalInstance | null;
+  /** The IRR itself — MWR is annualised by construction. */
+  mwrAnnualised: DecimalInstance | null;
+  /** External flows inside the window (days with flows, after netting). */
+  flowCount: number;
+  days: number;
+}
+
+const ZERO = toDecimal(0);
+const ONE = toDecimal(1);
+const DAYS_PER_YEAR = toDecimal('365.25');
+
+/** Local day string → a comparable time (UTC midnight of that day). */
+const dayTime = (day: string): number => Date.parse(`${day}T00:00:00Z`);
+
+export function computePortfolioPerformance(input: PortfolioPerformanceInput): PortfolioPerformance {
+  const { memberAccounts, transactions, transactionSplits, categories, range } = input;
+  const now = input.now ?? new Date();
+
+  const memberIds = new Set(memberAccounts.map(a => a.id));
+  const memberTransactions = transactions.filter(t => memberIds.has(t.accountId));
+
+  /**
+   * Every event that moves the scope's value, by local day:
+   * value[d] = the day's total change; flow[d] = the external part of it.
+   */
+  const valueByDay = new Map<string, DecimalInstance>();
+  const flowByDay = new Map<string, DecimalInstance>();
+  const bump = (map: Map<string, DecimalInstance>, day: string, amount: DecimalInstance): void => {
+    map.set(day, (map.get(day) ?? ZERO).plus(amount));
+  };
+
+  // Opening balances: money in, on their effective date. An account with no
+  // datable signal seeds at time-zero — before any window can start, so it
+  // reaches startValue and is never a window flow (the net-worth walk's rule).
+  const openingDates = resolveEffectiveOpeningDates([...memberAccounts], [...memberTransactions]);
+  const TIME_ZERO = '0000-01-01';
+  for (const account of memberAccounts) {
+    const opening = toDecimal(account.openingBalance ?? 0);
+    if (opening.isZero()) continue;
+    const effective = openingDates.get(account.id);
+    const day = effective === undefined ? TIME_ZERO : dayOf(effective);
+    bump(valueByDay, day, opening);
+    if (effective !== undefined) bump(flowByDay, day, opening);
+  }
+
+  const categoryKinds = buildCategoryKindLookup([...categories]);
+  const categoryAccounts = transferCategoryAccounts(categories);
+  const memberRows = expandSplitTransactions([...memberTransactions], [...transactionSplits]);
+  const transactionsById: ReadonlyMap<string, Transaction> = memberRows.length > 0
+    ? new Map(transactions.map(t => [t.id, t]))
+    : new Map();
+
+  for (const row of memberRows) {
+    const day = dayOf(row.date);
+    const amount = toDecimal(row.amount);
+    bump(valueByDay, day, amount);
+    if (classifyFlow(row, categoryKinds) !== 'transfer') continue;
+    const other = counterpartyAccountId(row, transactionsById, categoryAccounts);
+    // Membership, not pair-equality: for a whole-portfolio scope a transfer
+    // between two pairs is internal to the whole. Unidentified = external.
+    if (other !== undefined && memberIds.has(other)) continue;
+    bump(flowByDay, day, amount);
+  }
+
+  const days = [...valueByDay.keys()].sort();
+  const fromDay = range.from ? dayOf(range.from) : null;
+  const toDay = dayOf(range.to ?? now);
+
+  /** Value at the END of `day` (inclusive walk). */
+  let running = ZERO;
+  const valueAtEndOf = new Map<string, DecimalInstance>();
+  for (const day of days) {
+    running = running.plus(valueByDay.get(day) ?? ZERO);
+    valueAtEndOf.set(day, running);
+  }
+  const valueAsOf = (day: string): DecimalInstance => {
+    // Last event day ≤ day. The list is sorted and short; linear is honest.
+    let value = ZERO;
+    for (const eventDay of days) {
+      if (eventDay > day) break;
+      value = valueAtEndOf.get(eventDay) ?? value;
+    }
+    return value;
+  };
+
+  const dayBefore = (day: string): string => dayOf(new Date(dayTime(day) - 86_400_000));
+
+  const startValue = fromDay === null ? ZERO : valueAsOf(dayBefore(fromDay));
+  const endValue = valueAsOf(toDay);
+
+  const inWindow = (day: string): boolean =>
+    (fromDay === null || day >= fromDay) && day <= toDay && day !== TIME_ZERO;
+
+  const flowDays = [...flowByDay.keys()].filter(inWindow).sort();
+  let moneyIn = ZERO;
+  let moneyOut = ZERO;
+  for (const day of flowDays) {
+    const flow = flowByDay.get(day) ?? ZERO;
+    if (flow.greaterThan(0)) moneyIn = moneyIn.plus(flow);
+    else moneyOut = moneyOut.plus(flow.abs());
+  }
+  const netFlows = moneyIn.minus(moneyOut);
+  const gain = endValue.minus(startValue).minus(netFlows);
+
+  const startTime = fromDay === null ? (days.length > 0 ? dayTime(days.find(d => d !== TIME_ZERO) ?? toDay) : dayTime(toDay)) : dayTime(fromDay);
+  const windowDays = Math.max(0, Math.round((dayTime(toDay) - startTime) / 86_400_000));
+  const years = toDecimal(windowDays).dividedBy(DAYS_PER_YEAR);
+
+  // ── TWR: chain the growth between flows, flows at end of day ─────────────
+  // A chain link needs a positive base; while the scope holds nothing the
+  // chain RESTARTS at the next funding (a brand-new portfolio's day-one
+  // contribution is not a 0 → £1m return). A non-positive value between real
+  // links is unmeasurable, and says so as null.
+  let twrPeriod: DecimalInstance | null = ONE;
+  let base = startValue;
+  for (const day of flowDays) {
+    if (twrPeriod === null) break;
+    const flow = flowByDay.get(day) ?? ZERO;
+    const valueEnd = valueAsOf(day);
+    const valueBeforeFlow = valueEnd.minus(flow);
+    if (base.greaterThan(0)) {
+      if (valueBeforeFlow.lessThanOrEqualTo(0)) {
+        twrPeriod = null;
+        break;
+      }
+      twrPeriod = twrPeriod.times(valueBeforeFlow.dividedBy(base));
+    }
+    base = valueEnd;
+  }
+  if (twrPeriod !== null) {
+    if (base.greaterThan(0)) {
+      // The ordinary ending: one last stretch from the final flow to the
+      // window's end. A scope driven to nothing-or-below has no ratio.
+      twrPeriod = endValue.greaterThan(0)
+        ? twrPeriod.times(endValue.dividedBy(base)).minus(ONE)
+        : null;
+    } else if (endValue.minus(base).isZero()) {
+      // The scope emptied at its last flow (fully withdrawn) and stayed
+      // empty: the chain measured everything that happened while money was
+      // at work, and that measurement stands. A chain with NO links means
+      // nothing was ever at work — null, never 0%.
+      twrPeriod = twrPeriod.equals(ONE) ? null : twrPeriod.minus(ONE);
+    } else {
+      // Value moved while the base was not positive — no ratio exists.
+      twrPeriod = null;
+    }
+  }
+
+  const twrAnnualised = twrPeriod !== null && years.greaterThan(0) && twrPeriod.greaterThan(-1)
+    ? ONE.plus(twrPeriod).toPower(ONE.dividedBy(years)).minus(ONE)
+    : null;
+
+  // ── MWR: the IRR of (startValue + flows) against endValue ────────────────
+  // Solve Σ cf·(1+r)^yearsRemaining = endValue by bisection. Every cash flow
+  // compounds over the time it was actually at work — the investor's figure.
+  const cashflows: Array<{ amount: DecimalInstance; yearsRemaining: DecimalInstance }> = [];
+  if (!startValue.isZero()) {
+    cashflows.push({ amount: startValue, yearsRemaining: years });
+  }
+  for (const day of flowDays) {
+    const flow = flowByDay.get(day) ?? ZERO;
+    if (flow.isZero()) continue;
+    cashflows.push({
+      amount: flow,
+      yearsRemaining: toDecimal(Math.max(0, dayTime(toDay) - dayTime(day)))
+        .dividedBy(86_400_000)
+        .dividedBy(DAYS_PER_YEAR),
+    });
+  }
+
+  let mwrAnnualised: DecimalInstance | null = null;
+  const capitalIn = cashflows.reduce(
+    (sum, cf) => (cf.amount.greaterThan(0) ? sum.plus(cf.amount) : sum),
+    ZERO
+  );
+  if (cashflows.length > 0 && capitalIn.greaterThan(0) && years.greaterThan(0)) {
+    const terminal = (rate: DecimalInstance): DecimalInstance =>
+      cashflows.reduce(
+        (sum, cf) => sum.plus(cf.amount.times(ONE.plus(rate).toPower(cf.yearsRemaining))),
+        ZERO
+      );
+    let low = toDecimal('-0.9999');
+    let high = toDecimal(10);
+    const fLow = terminal(low).minus(endValue);
+    const fHigh = terminal(high).minus(endValue);
+    // Same sign at both ends = no rate explains the outcome (all capital
+    // gone, or growth beyond the bracket): unmeasurable, said as null.
+    if (fLow.isNegative() !== fHigh.isNegative()) {
+      for (let i = 0; i < 200; i++) {
+        const mid = low.plus(high).dividedBy(2);
+        const fMid = terminal(mid).minus(endValue);
+        if (fMid.isNegative() === fLow.isNegative()) low = mid;
+        else high = mid;
+      }
+      mwrAnnualised = low.plus(high).dividedBy(2);
+    }
+  }
+
+  const mwrPeriod = mwrAnnualised !== null
+    ? ONE.plus(mwrAnnualised).toPower(years).minus(ONE)
+    : null;
+
+  return {
+    startValue,
+    endValue,
+    moneyIn,
+    moneyOut,
+    netFlows,
+    gain,
+    twrPeriod,
+    twrAnnualised,
+    mwrPeriod,
+    mwrAnnualised,
+    flowCount: flowDays.length,
+    days: windowDays,
+  };
+}

--- a/src/utils/portfolioSummary.ts
+++ b/src/utils/portfolioSummary.ts
@@ -132,7 +132,7 @@ export interface PortfolioSummaryInput {
 const ZERO = toDecimal(0);
 
 /** Category id → the account its "To/From <account>" filing names. */
-function transferCategoryAccounts(categories: readonly Category[]): Map<string, string> {
+export function transferCategoryAccounts(categories: readonly Category[]): Map<string, string> {
   const map = new Map<string, string>();
   for (const category of categories) {
     if (category.isTransferCategory === true && category.accountId) {
@@ -154,8 +154,12 @@ function transferCategoryAccounts(categories: readonly Category[]): Map<string, 
  *
  * A SPLIT LINE gets the category alone: the virtual row inherits its parent's
  * link fields, which belong to the parent's own leg, not to this line's.
+ *
+ * EXPORTED for utils/portfolioPerformance, which must classify a transfer as
+ * internal or external by exactly this rule — a second resolver would be two
+ * definitions of one boundary waiting to drift apart.
  */
-function counterpartyAccountId(
+export function counterpartyAccountId(
   row: SplitExpandedTransaction,
   transactionsById: ReadonlyMap<string, Transaction>,
   categoryAccounts: ReadonlyMap<string, string>


### PR DESCRIPTION
## What this is

The owner's brief, after researching how the big firms measure portfolio performance: **"This needs to be a robust and trusted section of our app. We now need to bake in both MWR and TWR and allow the user the option on which they want to view."**

## The semantics — his, each pinned by its own test

- **Opening balances are money in**, on their effective date (the net-worth walk's own resolution in `utils/openingDates`).
- **Transfers across the scope boundary are flows** — *including an external account paying into the pair's cash sleeve* (his follow-up clarification). Transfers between a pair's own accounts (fund ↔ its settlement cash) are internal and touch nothing. The boundary rule is `portfolioSummary`'s own `counterpartyAccountId`, **exported rather than duplicated** — one definition of the boundary for both surfaces. An unlinked transfer leg counts as external: a contribution that lost its link is still a contribution.
- **Everything else is performance**: his periodic account-adjustment / market-revaluation rows, dividends, fees. They move the valuation walk and are absent from the flow list — which is the definition.

## The maths (`utils/portfolioPerformance`, 11 specs)

- **Valuation is the ledger.** He marks portfolios to market through revaluation rows, so the member accounts' balance walk *is* the value — **TWR is exact, not approximated**. Flows land at end of day (the one convention, stated).
- **TWR** chains sub-period growth between flows — the manager's figure, what GIPS requires firms to advertise. **MWR** is the exact IRR of the flows against the ending value (bisection, 200 iterations) — the investor's own figure. Both in **Decimal end to end**, fractional powers included: these are reported financial figures, not chart geometry.
- **Honesty at the edges**: a measure that cannot be taken is `null` with its reason said on screen — never 0%. A never-funded window measures nothing; a portfolio funded, grown, then fully withdrawn keeps the chain it measured while money was at work.
- **The headline spec is the owner's own worked example** from the research conversation: £1,000,000 in, £100,000 withdrawn mid-year, £1,120,000 at the end → gain **exactly +£220,000**, TWR **+23.67%**, MWR **≈ +23.1%** — and asserted *not* to be the naive +12% or +24.4% the conversation started from.

## The UI

A return band inside the Portfolio Performance card, over the **same window as the chart** (1 month → All time → Custom): an **MWR / TWR toggle** (remembered) leads with the chosen measure — "your own return" vs "how the investments performed", said in words — the annualised figure beside it when the window isn't a year, and the flow-adjusted identity beneath: **Started at / Put in / Taken out / Gain / Ended at**, so a withdrawal is never mistaken for a loss.

## Verified

11 new maths specs plus the page suites, strict types, zero-warning lint — and the band exercised live on demo data, where its portfolio (value with no contributions) correctly reads "Nothing was invested in this window, so there is no return to measure" while the £ identity tells the story straight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
