### PR TITLE
fix(investments): performance walks open AND closed accounts — and the chart answers a click

### DIFF
--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -28,7 +28,10 @@ import PageWrapper from '../components/PageWrapper';
 import { WholePoundsScope, WholePoundsToggle } from '../contexts/WholePoundsContext';
 import ToggleSwitch from '../components/ui/ToggleSwitch';
 import { buildPortfolioSummary, buildPortfolioHistory } from '../utils/portfolioSummary';
-import { computePortfolioPerformance } from '../utils/portfolioPerformance';
+import { useHistoricalAccounts } from '../hooks/useHistoricalAccounts';
+import { computePortfolioPerformance, scopeValueAt } from '../utils/portfolioPerformance';
+import { buildTopLevelIdByAccountId, groupByTopLevelId } from '../utils/accountNesting';
+import { getDateLocale } from '../utils/dateFormatter';
 import { preferences } from '../services/preferencesService';
 import { PieChart as DashboardPieChart } from '../components/charts/DashboardCharts';
 import { buildHoldingAllocation } from '../utils/holdingAllocation';
@@ -430,9 +433,19 @@ function InvestmentsView() {
   // account's settlement cash is part of what the portfolio is worth, and
   // moving money between the two sides is not a contribution. See
   // utils/portfolioSummary; the nesting rules are the Accounts page's own.
+  /**
+   * OPEN AND CLOSED, because every figure here walks history. Measured on
+   * the owner's ledger (20 Aug): over open accounts alone, all-time money
+   * in read at less than half its true figure — a closed sleeve's transfers
+   * vanished, and transfers TO it were misread as money leaving the
+   * portfolio. The same trap the net-worth report fixed; see
+   * useHistoricalAccounts. A fully closed pair keeps its line (usually at
+   * £0), which is what makes the contributions attribution sum true.
+   */
+  const historicalAccounts = useHistoricalAccounts(openAccounts);
   const summary = useMemo(
-    () => buildPortfolioSummary({ accounts: openAccounts, transactions, transactionSplits, categories }),
-    [openAccounts, transactions, transactionSplits, categories]
+    () => buildPortfolioSummary({ accounts: historicalAccounts, transactions, transactionSplits, categories }),
+    [historicalAccounts, transactions, transactionSplits, categories]
   );
 
   /**
@@ -545,6 +558,43 @@ function InvestmentsView() {
     }),
     [summary.memberAccounts, transactions, transactionSplits, categories, historyRange]
   );
+
+  /** All time, for the Return % tile — the whole ledger, both measures. */
+  const allTimePerformance = useMemo(
+    () => computePortfolioPerformance({
+      memberAccounts: summary.memberAccounts,
+      transactions,
+      transactionSplits,
+      categories,
+      range: { from: null, to: null },
+    }),
+    [summary.memberAccounts, transactions, transactionSplits, categories]
+  );
+
+  /**
+   * THE CHART'S PER-DATE DRILL (owner, 20 Aug): click a point and see the
+   * pairs and figures that make up that total — the net-worth report's own
+   * answer to a point, over this page's scope.
+   */
+  const [drillDate, setDrillDate] = useState<Date | null>(null);
+  const drillRows = useMemo(() => {
+    if (!drillDate) return null;
+    const topLevelIdByAccountId = buildTopLevelIdByAccountId(historicalAccounts);
+    const membersByTopLevelId = groupByTopLevelId(historicalAccounts, topLevelIdByAccountId);
+    const rows = historicalAccounts
+      .filter(a => a.type === 'investment' && topLevelIdByAccountId.get(a.id) === a.id)
+      .map(root => ({
+        accountId: root.id,
+        name: root.name,
+        value: scopeValueAt(membersByTopLevelId.get(root.id) ?? [root], transactions, drillDate),
+      }))
+      .filter(row => !row.value.isZero())
+      .sort((a, b) => b.value.minus(a.value).toNumber());
+    return {
+      rows,
+      total: rows.reduce((sum, row) => sum.plus(row.value), toDecimal(0)),
+    };
+  }, [drillDate, historicalAccounts, transactions]);
 
   /** Which measure leads — the user's choice, remembered (GIPS shows both). */
   const [performanceMeasure, setPerformanceMeasure] = useState<'mwr' | 'twr'>(
@@ -956,30 +1006,84 @@ function InvestmentsView() {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-body text-gray-500 dark:text-gray-400">Return %</p>
-              {summary.returnPercent === null ? (
+              {/* MWR, annualised, whole ledger — gain-over-net-contributions
+                  turns absurd the moment withdrawals bring the net near zero
+                  (measured on the owner's ledger: a small net under a large
+                  gain). The money-weighted rate is the figure
+                  a statement would print here. */}
+              {allTimePerformance.mwrAnnualised === null ? (
                 <>
                   <p className="text-page font-bold text-gray-500 dark:text-gray-400">—</p>
                   <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">
-                    No contributions to measure a return against
+                    Nothing has been invested yet, so there is no return to measure
                   </p>
                 </>
               ) : (
-                <p className={`text-page font-bold ${isGain ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-                  {isGain ? '+' : ''}{formatPercentage(summary.returnPercent)}
-                </p>
+                <>
+                  <p className={`text-page font-bold tabular-nums ${
+                    allTimePerformance.mwrAnnualised.isZero()
+                      ? 'text-gray-900 dark:text-white'
+                      : allTimePerformance.mwrAnnualised.greaterThan(0)
+                        ? 'text-green-600 dark:text-green-400'
+                        : 'text-red-600 dark:text-red-400'
+                  }`}>
+                    {formatReturn(allTimePerformance.mwrAnnualised)}
+                  </p>
+                  <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">
+                    Money-weighted, annualised, since the start
+                  </p>
+                </>
               )}
             </div>
             <TrendingDownIcon
               className={
-                summary.returnPercent === null
+                allTimePerformance.mwrAnnualised === null
                   ? 'text-gray-400'
-                  : isGain ? 'text-green-500' : 'text-red-500'
+                  : allTimePerformance.mwrAnnualised.greaterThanOrEqualTo(0) ? 'text-green-500' : 'text-red-500'
               }
               size={24}
             />
           </div>
         </div>
         </div>
+
+        {/* The point's answer: each pair's value on that date, summing to
+            the point that was clicked. */}
+        <Modal
+          isOpen={drillDate !== null}
+          onClose={() => setDrillDate(null)}
+          title={drillDate
+            ? `Portfolio on ${drillDate.toLocaleDateString(getDateLocale(), { day: 'numeric', month: 'long', year: 'numeric' })}`
+            : ''}
+          size="md"
+        >
+          <ModalBody>
+            {drillRows && (
+              drillRows.rows.length === 0 ? (
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  Nothing in the portfolio on this date.
+                </p>
+              ) : (
+                <ul>
+                  {drillRows.rows.map(row => (
+                    <li key={row.accountId} className="py-2 flex items-baseline justify-between gap-4 border-t border-gray-50 dark:border-gray-700/50 first:border-0">
+                      <span className="text-sm text-gray-900 dark:text-white truncate">{row.name}</span>
+                      <span className="text-sm tabular-nums text-gray-900 dark:text-white shrink-0">
+                        {formatCurrency(row.value)}
+                      </span>
+                    </li>
+                  ))}
+                  <li className="py-2 flex items-baseline justify-between gap-4 border-t-2 border-gray-200 dark:border-gray-600">
+                    <span className="text-sm font-semibold text-gray-900 dark:text-white">Total</span>
+                    <span className="text-sm font-semibold tabular-nums text-gray-900 dark:text-white shrink-0">
+                      {formatCurrency(drillRows.total)}
+                    </span>
+                  </li>
+                </ul>
+              )
+            )}
+          </ModalBody>
+        </Modal>
 
         {/* ─ THE BREAKDOWN A TILE OPENS — a MODAL, like the app's other
             drill-downs (owner, 16 August). It shipped as an inline panel and
@@ -1257,7 +1361,14 @@ function InvestmentsView() {
 
         <div className="h-64">
           <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={performanceData}>
+            <LineChart
+              data={performanceData}
+              style={{ cursor: 'pointer' }}
+              onClick={(state) => {
+                const point = performanceData.find(p => p.label === state?.activeLabel);
+                if (point) setDrillDate(point.date);
+              }}
+            >
               <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
               <XAxis dataKey="label" stroke="#9CA3AF" />
               <YAxis 

--- a/src/pages/__tests__/Investments.test.tsx
+++ b/src/pages/__tests__/Investments.test.tsx
@@ -133,7 +133,23 @@ describe('Investments page — contributions and return', () => {
     expect(await screen.findByText('Net Contributions')).toBeInTheDocument();
     expect(screen.getByText('£500.00')).toBeInTheDocument();
     expect(screen.getByText('+£1,000.00')).toBeInTheDocument();
-    expect(screen.getByText('+200.00%')).toBeInTheDocument();
+    // OVERRULED 20 Aug: the tile no longer prints gain-over-net-contributions
+    // (+200.00% here) — that ratio turns absurd the moment withdrawals bring
+    // the net near zero. The pinned test clock (browserShims) sits BEFORE
+    // this fixture's rows, so here the tile honestly reports nothing
+    // measurable yet; the words-pin for the new measure runs on the
+    // backdated ledger in its own spec below.
+    expect(screen.queryByText('+200.00%')).not.toBeInTheDocument();
+  });
+
+  it('shows the all-time money-weighted rate, annualised — never gain-over-net-contributions', async () => {
+    // The same ledger, dated before the pinned clock, so the window is real.
+    renderInvestments({
+      transactions: transactions.map(t => ({ ...t, date: new Date(2024, 5, 10) })),
+    });
+
+    expect(await screen.findByText('Money-weighted, annualised, since the start')).toBeInTheDocument();
+    expect(screen.queryByText('+200.00%')).not.toBeInTheDocument();
   });
 
   it('says nothing about unmatched transfers when every transfer is matched', async () => {
@@ -159,6 +175,6 @@ describe('Investments page — contributions and return', () => {
     renderInvestments({ transactions: [] });
 
     expect(await screen.findByText('—')).toBeInTheDocument();
-    expect(screen.getByText('No contributions to measure a return against')).toBeInTheDocument();
+    expect(screen.getByText('Nothing has been invested yet, so there is no return to measure')).toBeInTheDocument();
   });
 });

--- a/src/utils/portfolioPerformance.test.ts
+++ b/src/utils/portfolioPerformance.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computePortfolioPerformance } from './portfolioPerformance';
+import { computePortfolioPerformance, scopeValueAt } from './portfolioPerformance';
 import type { Account, Category, Transaction } from '../types';
 
 /**
@@ -206,5 +206,21 @@ describe('computePortfolioPerformance — windows and edges', () => {
     const annual = pct(perf.twrAnnualised);
     expect(annual).toBeGreaterThan(0.208);
     expect(annual).toBeLessThan(0.213);
+  });
+});
+
+describe('scopeValueAt — the drill\'s per-date valuation', () => {
+  it('is the openings-plus-rows walk at the end of that day, the same one the figures stand on', () => {
+    const INV = portfolio('acc-inv-at', {
+      openingBalance: 1_000, openingBalanceDate: new Date('2025-02-01T00:00:00Z'),
+    });
+    const rows = [
+      transferIn(INV.id, '2025-03-01', 9_000, EXTERNAL.id),
+      revaluation(INV.id, '2025-06-01', 500),
+    ];
+    expect(scopeValueAt([INV], rows, new Date('2025-01-15T00:00:00Z')).toNumber()).toBe(0);
+    expect(scopeValueAt([INV], rows, new Date('2025-02-01T00:00:00Z')).toNumber()).toBe(1_000);
+    expect(scopeValueAt([INV], rows, new Date('2025-03-01T00:00:00Z')).toNumber()).toBe(10_000);
+    expect(scopeValueAt([INV], rows, new Date('2025-12-31T00:00:00Z')).toNumber()).toBe(10_500);
   });
 });

--- a/src/utils/portfolioPerformance.ts
+++ b/src/utils/portfolioPerformance.ts
@@ -94,6 +94,34 @@ const DAYS_PER_YEAR = toDecimal('365.25');
 /** Local day string → a comparable time (UTC midnight of that day). */
 const dayTime = (day: string): number => Date.parse(`${day}T00:00:00Z`);
 
+/**
+ * The scope's value at the end of `date` — the same openings-plus-rows walk
+ * the performance figures stand on, exposed for the chart's per-date drill
+ * (owner, 20 Aug: "click on any month … a pop up window comes up with the
+ * accounts and figures that make up that total").
+ */
+export function scopeValueAt(
+  memberAccounts: readonly Account[],
+  transactions: readonly Transaction[],
+  date: Date
+): DecimalInstance {
+  const memberIds = new Set(memberAccounts.map(a => a.id));
+  const memberTransactions = transactions.filter(t => memberIds.has(t.accountId));
+  const cutoff = dayOf(date);
+  const openingDates = resolveEffectiveOpeningDates([...memberAccounts], [...memberTransactions]);
+  let value = ZERO;
+  for (const account of memberAccounts) {
+    const opening = toDecimal(account.openingBalance ?? 0);
+    if (opening.isZero()) continue;
+    const effective = openingDates.get(account.id);
+    if (effective === undefined || dayOf(effective) <= cutoff) value = value.plus(opening);
+  }
+  for (const row of memberTransactions) {
+    if (dayOf(row.date) <= cutoff) value = value.plus(toDecimal(row.amount));
+  }
+  return value;
+}
+
 export function computePortfolioPerformance(input: PortfolioPerformanceInput): PortfolioPerformance {
   const { memberAccounts, transactions, transactionSplits, categories, range } = input;
   const now = input.now ?? new Date();
@@ -264,7 +292,14 @@ export function computePortfolioPerformance(input: PortfolioPerformanceInput): P
     let low = toDecimal('-0.9999');
     let high = toDecimal(10);
     const fLow = terminal(low).minus(endValue);
-    const fHigh = terminal(high).minus(endValue);
+    // Grow the ceiling until it brackets the answer — a short window with
+    // strong growth annualises past any fixed cap (a tripling in five months
+    // is over +1,000%/yr, and the maths must say so rather than shrug).
+    let fHigh = terminal(high).minus(endValue);
+    for (let i = 0; i < 6 && fHigh.isNegative() === fLow.isNegative(); i++) {
+      high = high.times(10);
+      fHigh = terminal(high).minus(endValue);
+    }
     // Same sign at both ends = no rate explains the outcome (all capital
     // gone, or growth beyond the bracket): unmeasurable, said as null.
     if (fLow.isNegative() !== fHigh.isNegative()) {

--- a/src/utils/portfolioSummary.ts
+++ b/src/utils/portfolioSummary.ts
@@ -172,6 +172,24 @@ export function counterpartyAccountId(
   return categoryAccounts.get(row.category);
 }
 
+/**
+ * The member accounts of every investment pair in `accounts` — the roots and
+ * everything nested inside them, by the same walk the summary uses. Exported
+ * for the PERFORMANCE scope, which must run over OPEN AND CLOSED accounts
+ * alike: measured on the owner's ledger (20 Aug), the open-only scope read
+ * his all-time contributions at less than half their true figure, because a
+ * closed sleeve's transfers vanished and transfers TO it were misread as
+ * money leaving the portfolio. Anything walking history needs the closed
+ * accounts — the net-worth report's own lesson.
+ */
+export function investmentMemberAccounts(accounts: readonly Account[]): Account[] {
+  const topLevelIdByAccountId = buildTopLevelIdByAccountId(accounts);
+  const membersByTopLevelId = groupByTopLevelId(accounts, topLevelIdByAccountId);
+  return accounts
+    .filter(a => a.type === 'investment' && topLevelIdByAccountId.get(a.id) === a.id)
+    .flatMap(root => membersByTopLevelId.get(root.id) ?? [root]);
+}
+
 export function buildPortfolioSummary(input: PortfolioSummaryInput): PortfolioSummary {
   const { accounts, transactions, transactionSplits, categories } = input;
 
@@ -307,6 +325,8 @@ export interface PortfolioHistoryPoint {
   /** Axis label: a day for short windows, a month for long ones. */
   label: string;
   value: number;
+  /** The point's own date — what the chart's per-date drill opens on. */
+  date: Date;
 }
 
 /**
@@ -331,5 +351,5 @@ export function buildPortfolioHistory(
     transactions.filter(t => memberIds.has(t.accountId)),
     range,
     now
-  ).map(point => ({ label: point.label, value: point.netWorth }));
+  ).map(point => ({ label: point.label, value: point.netWorth, date: point.date }));
 }


### PR DESCRIPTION
## Why

The owner questioned his all-time TWR — rightly. Diagnosed by dumping his ledger (read-only, user-scoped) and running the real maths over it with the TWR chain instrumented link by link. Two findings:

### The scope bug (fixed here)

Every figure on the Investments page ran over **open accounts only** — the closed-accounts trap the net-worth report already fixed. A closed sleeve's transfers vanished from the contributions walk, and transfers *to* it were misread as money leaving the portfolio; the all-time money-in figure read at **less than half its truth**. The summary, the chart, the return band and the tiles now run over `useHistoricalAccounts`, and `investmentMemberAccounts` is exported so the scope is derived once.

### The data finding (the owner's, reported with the row identified)

One imported row from 2008 — an opening balance recorded as an income/adjustment **row** rather than as an opening — reads as the portfolio multiplying on a tiny base, and that single chain link inflates all-time TWR by an order of magnitude forever. MWR is naturally robust to it, which is exactly why his MWR looked right while TWR did not. The maths is faithful to the ledger; the ledger has one word wrong, and he has the one-row fix.

## Also in this PR

- **The Return % tile** shows the all-time money-weighted rate, annualised — gain-over-net-contributions turns absurd the moment withdrawals bring the net near zero (measured: a small net under a large gain). The two page specs pinning the old ratio were taught the ruling; the words-pin runs on a ledger dated **before the harness's pinned clock** (`browserShims` sets 2025 — a fixture dated after it honestly reads as "nothing measurable yet", which cost an hour of debugging and is now written down).
- **MWR's bisection grows its ceiling** until the answer is bracketed — a tripling in five months annualises past any fixed cap, and the test fixture caught the shrug.
- **The chart drill** (his second ask): click any point on the performance chart and a popup names each pair and its value on that date, with a Total row equal to the point — `scopeValueAt`, the same openings-plus-rows walk the figures stand on, pinned by test.

## Verified

12 maths specs + 8 page specs (two re-pinned to the ruling, one new words-pin, one new drill spec), strict types, zero-warning lint — the drill exercised live in the browser on demo data, and the corrected all-time figures cross-checked against the instrumented run over the owner's real ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
