### PR TITLE
feat(transfers): Transfer Links under Manage — and a closed counterpart is named, never blanked

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,7 @@ const Accounts = lazyWithPreload(() => import(/* webpackChunkName: "accounts", w
 const Find = lazyWithPreload(() => import(/* webpackChunkName: "find" */ './pages/Find'));
 const Reconciliation = lazyWithPreload(() => import(/* webpackChunkName: "reconciliation" */ './pages/Reconciliation'));
 const Categorisation = lazyWithPreload(() => import(/* webpackChunkName: "categorisation" */ './pages/Categorisation'));
+const TransferLinks = lazyWithPreload(() => import(/* webpackChunkName: "transfer-links" */ './pages/TransferLinks'));
 const Investments = lazyWithPreload(() => import(/* webpackChunkName: "investments" */ './pages/Investments'));
 const Budget = lazyWithPreload(() => import(/* webpackChunkName: "budget", webpackPreload: true */ './pages/Budget'));
 const Calendar = lazyWithPreload(() => import(/* webpackChunkName: "calendar" */ './pages/Calendar'));
@@ -238,6 +239,11 @@ function App(): React.JSX.Element {
                           <Route path="categorisation" element={
                             <ProtectedSuspense>
                               <Categorisation />
+                            </ProtectedSuspense>
+                          } />
+                          <Route path="transfer-links" element={
+                            <ProtectedSuspense>
+                              <TransferLinks />
                             </ProtectedSuspense>
                           } />
                           <Route path="investments" element={

--- a/src/components/EditTransactionModal.tsx
+++ b/src/components/EditTransactionModal.tsx
@@ -30,6 +30,7 @@ import AccountSelector from './common/AccountSelector';
 import DatePicker from './common/DatePicker';
 import { useToast } from '../contexts/ToastContext';
 import CategorySelector from './CategorySelector';
+import { useHistoricalAccounts } from '../hooks/useHistoricalAccounts';
 import TagSelector from './TagSelector';
 import { getCurrencySymbol } from '../utils/currency';
 import { Modal, ModalBody, ModalFooter } from './common/Modal';
@@ -516,12 +517,37 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
   // sits in. The option carries 'transfer:<id>' because the target rides in
   // the category field until save resolves it. `institution` comes along so
   // the picker can band and find them by bank, as the Accounts page does.
-  const transferTargetOptions = useMemo(
-    () => accounts
+  /**
+   * Open AND closed accounts, for NAMING only: a transfer whose other side
+   * sits in a closed account must still say which account that is — the
+   * owner's 2016 row read "Transfer" with an empty picker, which looked
+   * one-sided when it was merely pointed at a closed account (20 Aug).
+   */
+  const historicalAccounts = useHistoricalAccounts(accounts);
+
+  const transferTargetOptions = useMemo(() => {
+    const open = accounts
       .filter(a => a.isActive !== false && a.id !== formData.accountId)
-      .map(a => ({ id: `transfer:${a.id}`, name: a.name, type: a.type, institution: a.institution })),
-    [accounts, formData.accountId]
-  );
+      .map(a => ({ id: `transfer:${a.id}`, name: a.name, type: a.type, institution: a.institution }));
+    // The row's CURRENT counterpart joins the list even when closed — the
+    // picker must show the truth about this transfer, though closed accounts
+    // are not offered as new targets.
+    const currentId = formData.category.startsWith('transfer:')
+      ? formData.category.slice('transfer:'.length)
+      : transaction?.transferAccountId;
+    if (currentId && !open.some(o => o.id === `transfer:${currentId}`) && currentId !== formData.accountId) {
+      const closed = historicalAccounts.find(a => a.id === currentId);
+      if (closed) {
+        open.unshift({
+          id: `transfer:${closed.id}`,
+          name: `${closed.name} (closed)`,
+          type: closed.type,
+          institution: closed.institution,
+        });
+      }
+    }
+    return open;
+  }, [accounts, historicalAccounts, formData.accountId, formData.category, transaction]);
 
   // Helper function to format number with commas
   const formatWithCommas = (value: string | number): string => {
@@ -830,8 +856,8 @@ export default function EditTransactionModal({ isOpen, onClose, transaction, def
   // Money's "go to the other half of this transfer". Both legs are linked, so
   // the button appears on each and points back at the other.
   const otherSide = useMemo(
-    () => resolveTransferOtherSide(transaction, transactions, accounts),
-    [transaction, transactions, accounts]
+    () => resolveTransferOtherSide(transaction, transactions, historicalAccounts),
+    [transaction, transactions, historicalAccounts]
   );
 
   /**

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -422,11 +422,12 @@ export default function Layout(): React.JSX.Element {
                 { to: '/settings/categories', icon: TagIcon, label: 'Categories' },
                 { to: '/settings/payees', icon: UsersIcon, label: 'Payees' },
                 { to: '/settings/tags', icon: HashIcon, label: 'Tags' },
+                { to: '/transfer-links', icon: ArrowRightLeftIcon, label: 'Transfer Links' },
                 { to: '/enhanced-import', icon: UploadIcon, label: 'Import Data' },
                 { to: '/export-manager', icon: DownloadIcon, label: 'Export Data' },
                 { to: '/documents', icon: FolderIcon, label: 'Documents' },
               ]}
-              activePaths={['/settings/categories', '/settings/tags', '/settings/payees', '/enhanced-import', '/export-manager', '/documents']}
+              activePaths={['/settings/categories', '/settings/tags', '/settings/payees', '/enhanced-import', '/export-manager', '/documents', '/transfer-links']}
               openDropdown={openDropdown}
               setOpenDropdown={setOpenDropdown}
             />
@@ -712,6 +713,7 @@ export default function Layout(): React.JSX.Element {
                       <SidebarLink to="/settings/categories" icon={TagIcon} label="Categories" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
                       <SidebarLink to="/settings/payees" icon={UsersIcon} label="Payees" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
                       <SidebarLink to="/settings/tags" icon={HashIcon} label="Tags" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
+                      <SidebarLink to="/transfer-links" icon={ArrowRightLeftIcon} label="Transfer Links" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
                       {/* "Import Data", as the desktop menu names it — one
                           page, one name, whichever menu found it. */}
                       <SidebarLink to="/enhanced-import" icon={UploadIcon} label="Import Data" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />

--- a/src/components/TransferSweepModal.tsx
+++ b/src/components/TransferSweepModal.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { Modal, ModalBody, ModalFooter } from './common/Modal';
 import { useApp } from '../contexts/AppContextSupabase';
+import { useHistoricalAccounts } from '../hooks/useHistoricalAccounts';
 import { useToast } from '../contexts/ToastContext';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { useReferenceRates } from '../hooks/useReferenceRates';
@@ -277,12 +278,21 @@ function compareFindings(
 
 export default function TransferSweepModal({ isOpen, onClose }: Props): React.JSX.Element {
   const {
-    transactions, categories, accounts, transactionSplits, linkTransferPair,
+    transactions, categories, accounts: openAccounts, transactionSplits, linkTransferPair,
     linkSplitLineTransfer, repairClaimedTransfer, setTransactionArchived, updateTransaction,
     updateAccount, refreshAccountsAndTransactions, refreshCategories,
     suggestionDismissals, suggestionDismissalsStatus, refreshSuggestionDismissals,
     dismissSuggestion, restoreSuggestion,
   } = useApp();
+
+  /**
+   * Open AND closed accounts (owner, 20 Aug: "Would we be able to read the
+   * transactions of closed accounts for this?" — yes): the ledger already
+   * holds every closed account's rows, and this sweep has always matched
+   * across them; what it could not do was NAME a closed account, so a real
+   * pair's row read "Unknown account". The matching itself is unchanged.
+   */
+  const accounts = useHistoricalAccounts(openAccounts);
   const { formatCurrency } = useCurrencyDecimal();
   // Asked for only while the sweep is open, and used for nothing but ORDER —
   // see useReferenceRates. If it never arrives the same rows are offered, sorted

--- a/src/components/__tests__/Layout.test.tsx
+++ b/src/components/__tests__/Layout.test.tsx
@@ -315,11 +315,14 @@ describe('Layout — the Plan menu and split triggers', () => {
     renderWithProviders(<Layout />);
 
     // Manage is data admin. Investments is not admin, and Tags was standing in
-    // front of Payees, which is the one people open most.
+    // front of Payees, which is the one people open most. Transfer Links
+    // joined 20 Aug (owner: "a page under 'Manage' just like Payees") —
+    // beside its fellow tidy-up chores, before the data doors.
     expect(openMenuItems('Manage')).toEqual([
       'Categories',
       'Payees',
       'Tags',
+      'Transfer Links',
       'Import Data',
       'Export Data',
       'Documents',

--- a/src/desktop/MountedLedger.tsx
+++ b/src/desktop/MountedLedger.tsx
@@ -72,6 +72,7 @@ const AccountTransactions = lazyWithPreload(() => import(/* webpackChunkName: "a
 const Find = lazyWithPreload(() => import(/* webpackChunkName: "find" */ '../pages/Find'));
 const Reconciliation = lazyWithPreload(() => import(/* webpackChunkName: "reconciliation" */ '../pages/Reconciliation'));
 const Categorisation = lazyWithPreload(() => import(/* webpackChunkName: "categorisation" */ '../pages/Categorisation'));
+const TransferLinks = lazyWithPreload(() => import(/* webpackChunkName: "transfer-links" */ '../pages/TransferLinks'));
 const Budget = lazyWithPreload(() => import(/* webpackChunkName: "budget" */ '../pages/Budget'));
 const Calendar = lazyWithPreload(() => import(/* webpackChunkName: "calendar" */ '../pages/Calendar'));
 const RecurringPayments = lazyWithPreload(() => import(/* webpackChunkName: "recurring-payments" */ '../pages/RecurringPayments'));
@@ -235,6 +236,7 @@ export default function MountedLedger(): ReactElement {
     'transactions-comparison': <LegacyTransactionsRedirect />,
     reconciliation: page(<Reconciliation />),
     categorisation: page(<Categorisation />),
+    'transfer-links': page(<TransferLinks />),
     budget: page(<Budget />),
     calendar: page(<Calendar />),
     'recurring-payments': page(<RecurringPayments />),

--- a/src/desktop/__tests__/desktopRouter.test.tsx
+++ b/src/desktop/__tests__/desktopRouter.test.tsx
@@ -185,7 +185,10 @@ describe('the desktop router', () => {
     // FORTY-THREE: `forecast` joined on 19 Aug — the scenario tool's base
     // table (docs/forecast-direction.md step 4), as local as the register it
     // reviews.
-    expect(mounted.length).toBe(43);
+    // FORTY-FOUR: `transfer-links` joined on 20 Aug — the audit-trail chore
+    // as its own Manage page (the sweep it opens reads the open file's rows,
+    // closed accounts included).
+    expect(mounted.length).toBe(44);
 
     // EMPTY, and the list is kept rather than deleted — `routes.ts` says why:
     // this is one of three ANSWERS a route can have, not an exception to a rule,

--- a/src/desktop/routes.ts
+++ b/src/desktop/routes.ts
@@ -179,6 +179,7 @@ export const DESKTOP_ROUTES = [
   { path: 'transactions-comparison', at: 'transactions-comparison', title: 'Find' },
   { path: 'reconciliation', at: 'reconciliation', title: 'Reconcile' },
   { path: 'categorisation', at: 'categorisation', title: 'Categorise' },
+  { path: 'transfer-links', at: 'transfer-links', title: 'Transfer Links' },
   { path: 'budget', at: 'budget', title: 'Budget' },
   { path: 'calendar', at: 'calendar', title: 'Calendar' },
   // Plan's third page. Detection reads the open ledger's own rows and the

--- a/src/pages/TransferLinks.tsx
+++ b/src/pages/TransferLinks.tsx
@@ -1,0 +1,132 @@
+import React, { useMemo, useState } from 'react';
+import PageWrapper from '../components/PageWrapper';
+import { useApp } from '../contexts/AppContextSupabase';
+import { useHistoricalAccounts } from '../hooks/useHistoricalAccounts';
+import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
+import { toDecimal } from '../utils/decimal';
+import { buildCategoryKindLookup, classifyFlow } from '../utils/incomeExpense';
+import { transferCategoryAccounts } from '../utils/portfolioSummary';
+import TransferSweepModal from '../components/TransferSweepModal';
+
+/**
+ * Transfer Links — the audit-trail chore, as its own Manage page.
+ *
+ * The owner's ask (20 Aug): "from an audit trail point of view … every
+ * transfer in reality should be linked. I would like to set a page up under
+ * 'Manage' just like we have done for Payees, and Category tidy up etc. To
+ * be able to try and 'link' old transfers to one another. Would we be able
+ * to read the transactions of closed accounts for this?" — yes: the ledger
+ * holds every closed account's rows, and the sweep beneath this page runs
+ * over all of them.
+ *
+ * TWO KINDS OF ONE-SIDEDNESS, and this page says which is which:
+ *
+ *  - NEW transfers are never one-sided — the quick-add and the editor mint
+ *    the counterpart through createTransferCounterpart. One-sided legs are
+ *    IMPORTED history (Money/QIF/OFX), where only one bank's statement
+ *    carried the movement.
+ *  - A leg can also merely LOOK one-sided: filed under "To/From <account>"
+ *    with the counterpart account closed, the editor's picker used to show
+ *    an empty box (the owner's 2016 example). Naming is fixed in the editor;
+ *    linking the actual rows is this page's job.
+ *
+ * The heavy machinery is the existing TransferSweepModal — pair matching,
+ * split-line matches, stranded findings, refusals remembered — reached from
+ * here as a first-class door rather than from inside Categorisation alone.
+ * The figures above the door are counted from the same classification the
+ * sweep uses, so the door never promises work the sweep cannot see.
+ */
+export default function TransferLinks(): React.JSX.Element {
+  const { transactions, categories, accounts: openAccounts } = useApp();
+  const accounts = useHistoricalAccounts(openAccounts);
+  const { formatCurrency } = useCurrencyDecimal();
+  const [showSweep, setShowSweep] = useState(false);
+
+  const survey = useMemo(() => {
+    const kinds = buildCategoryKindLookup(categories);
+    const hintAccounts = transferCategoryAccounts(categories);
+    const openIds = new Set(openAccounts.map(a => a.id));
+    const knownIds = new Set(accounts.map(a => a.id));
+
+    let unlinked = 0;
+    let hinted = 0;
+    let onClosed = 0;
+    let magnitude = toDecimal(0);
+    for (const row of transactions) {
+      if (row.linkedTransferId) continue;
+      if (classifyFlow(row, kinds) !== 'transfer') continue;
+      unlinked += 1;
+      magnitude = magnitude.plus(toDecimal(row.amount).abs());
+      if (row.transferAccountId || hintAccounts.has(row.category)) hinted += 1;
+      if (knownIds.has(row.accountId) && !openIds.has(row.accountId)) onClosed += 1;
+    }
+    return { unlinked, hinted, onClosed, magnitude };
+  }, [transactions, categories, openAccounts, accounts]);
+
+  return (
+    <PageWrapper title="Transfer Links">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
+          <h2 className="text-label uppercase tracking-wider font-medium text-gray-500 dark:text-gray-400">
+            Every transfer should have two sides
+          </h2>
+          <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">
+            New transfers always get both sides — the app writes the matching
+            row in the other account as you save. One-sided legs come from
+            imported history, where only one bank&rsquo;s statement carried the
+            movement. Until a leg is linked, the performance and contribution
+            figures treat it as money crossing into or out of your accounts
+            from outside — which overstates both directions when its other
+            half is really sitting in another of your own accounts. Closed
+            accounts are included throughout.
+          </p>
+        </div>
+
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
+          {survey.unlinked === 0 ? (
+            <p className="text-body text-gray-700 dark:text-gray-300">
+              Every transfer in your ledger has its other side. Nothing to do here.
+            </p>
+          ) : (
+            <>
+              <p className="text-body text-gray-900 dark:text-white">
+                <span className="font-bold tabular-nums">{survey.unlinked.toLocaleString()}</span>
+                {' '}transfer {survey.unlinked === 1 ? 'leg has' : 'legs have'} no linked other side
+                — {formatCurrency(survey.magnitude)} of movement resting on the
+                outside-money assumption.
+              </p>
+              <ul className="mt-2 space-y-1 text-dense text-gray-500 dark:text-gray-400">
+                {survey.hinted > 0 && (
+                  <li>
+                    {survey.hinted.toLocaleString()} name the account they moved to or from —
+                    the sweep can hunt their other sides there first.
+                  </li>
+                )}
+                {survey.onClosed > 0 && (
+                  <li>
+                    {survey.onClosed.toLocaleString()} sit in closed accounts — read, matched
+                    and linkable like any other.
+                  </li>
+                )}
+              </ul>
+              <button
+                type="button"
+                onClick={() => setShowSweep(true)}
+                className="mt-4 px-4 py-2 bg-[#1a2332] text-white text-body font-medium rounded-lg hover:bg-[#2d3a4d] transition-colors shadow-sm"
+              >
+                Find and link the pairs
+              </button>
+              <p className="mt-2 text-dense text-gray-500 dark:text-gray-400">
+                Nothing links without your tick — the sweep proposes
+                equal-and-opposite pairs, you review, it links what you accept
+                and remembers what you refuse.
+              </p>
+            </>
+          )}
+        </div>
+
+        <TransferSweepModal isOpen={showSweep} onClose={() => setShowSweep(false)} />
+      </div>
+    </PageWrapper>
+  );
+}


### PR DESCRIPTION
## What this is

The owner, after refiling history: **"from an audit trail point of view … every transfer in reality should be linked. I would like to set a page up under 'Manage' just like we have done for Payees … Would we be able to read the transactions of closed accounts for this?"** — yes, and his own 2016 example turned out to be a second bug hiding in plain sight.

## The page — Manage → Transfer Links

Beside Payees and Tags. It says which one-sidedness is which (**new transfers always mint both sides** via createTransferCounterpart; one-sided legs are **imported history**, where only one bank's statement carried the movement), counts the unlinked legs — how many name their other account, how many sit in **closed accounts** — states the consequence (an unlinked leg rests on the outside-money assumption the performance figures disclose), and opens the **existing sweep**: pair matching, split-line matches, stranded findings, refusals remembered. Nothing links without a tick. The Manage-order ratchet was taught the new entry.

## Closed accounts, throughout

- The **sweep** resolves names over open **and** closed accounts (`useHistoricalAccounts`). The matching always crossed them — the rows were there; the *names* were not.
- The **editor's Transfer To picker** shows the row's current counterpart even when that account is closed, labelled **"(closed)"** — the owner's 2016 row read "Transfer" with an empty picker, which looked one-sided when it was merely pointed at a closed account. Displayed truthfully; closed accounts are still not offered as new targets.

## Desktop

Route 44 (`transfer-links`), mounted in MountedLedger, the router ratchet told why.

## Verified

Desktop-router ratchet (44), transfer-jump suite, sweep dismissals suite, full page sweep (570 specs), Layout menu-order spec re-pinned, strict types, zero-warning lint — and the page + Manage menu placement exercised live in the browser (demo's ledger is fully linked, so it shows the clean state honestly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)