### PR TITLE
feat(investments+ui): the tiles follow the window and the scope — and drill-downs everywhere climb one depth ladder

### DIFF
--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -4,6 +4,7 @@ import { useApp } from '../contexts/AppContextSupabase';
 import { useToast } from '../contexts/ToastContext';
 import { dataPort } from '@data';
 import { preserveDemoParam } from '../utils/navigation';
+import { DEPTH_LEVEL_1, DEPTH_LEVEL_2 } from '../styles/depthShading';
 import { WholePoundsScope, WholePoundsToggle } from '../contexts/WholePoundsContext';
 import AddAccountModal from '../components/AddAccountModal';
 import AccountSettingsModal from '../components/AccountSettingsModal';
@@ -2109,7 +2110,7 @@ function AccountsList() {
           onClick={() => toggleGroupCollapsed(collapseKeyFor(group.kind, group.label))}
           aria-expanded={isExpanded}
           aria-controls={regionId}
-          className="w-full bg-surface-secondary dark:bg-gray-700/50 border-b border-line dark:border-gray-700 px-4 sm:px-6 py-2.5 text-left transition-colors duration-state hover:bg-surface-tertiary dark:hover:bg-gray-700"
+          className={`w-full ${DEPTH_LEVEL_1} border-b border-line dark:border-gray-700 px-4 sm:px-6 py-2.5 text-left transition-colors duration-state hover:bg-gray-200 dark:hover:bg-gray-600`}
         >
           {/* ONE ROW AT EVERY WIDTH, so the total is on the right on a
               phone too. It was `flex-col sm:flex-row`, which below sm stacked
@@ -2268,7 +2269,7 @@ function AccountsList() {
                         onClick={() => toggleGroupCollapsed(subBandCollapseKeyFor(group.label, sub.label))}
                         aria-expanded={sub.isExpanded}
                         aria-controls={subRegionId}
-                        className="w-full text-left flex items-center justify-between gap-2 mt-4 first:mt-0 border-t-2 first:border-t-0 border-b border-line dark:border-gray-700 bg-surface-secondary dark:bg-gray-700/50 hover:bg-surface-tertiary dark:hover:bg-gray-700 transition-colors duration-state px-4 sm:px-6 py-2"
+                        className={`w-full text-left flex items-center justify-between gap-2 mt-4 first:mt-0 border-t-2 first:border-t-0 border-b border-line dark:border-gray-700 ${DEPTH_LEVEL_2} hover:bg-surface-tertiary dark:hover:bg-gray-700 transition-colors duration-state px-4 sm:px-6 py-2`}
                       >
                         <p className="flex items-center gap-2 min-w-0 text-body uppercase font-bold tracking-wide text-gray-900 dark:text-white truncate">
                           <ChevronRightIcon
@@ -2314,7 +2315,10 @@ function AccountsList() {
           <p className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
             {account.name}
           </p>
-          {account.institution && (
+          {/* Only when the list is NOT banded by institution — under an
+              institution sub-band the heading already says it, and the open
+              list dropped the same duplicate (owner, 20 Aug). */}
+          {account.institution && !grouping.byInstitution && (
             <p className="text-xs text-gray-400 dark:text-gray-500 truncate">
               {account.institution}
             </p>
@@ -3054,13 +3058,13 @@ function AccountsList() {
               ) : (
                 closedAccountBands.groups.map(group => (
                   <div key={`${group.kind}:${group.label}`}>
-                    <p className="px-4 pt-3 pb-1 text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                    <p className={`px-4 py-2 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400 ${DEPTH_LEVEL_1}`}>
                       {group.title}
                     </p>
                     {group.subGroups ? (
                       group.subGroups.map(sub => (
                         <div key={sub.label}>
-                          <p className="pl-8 pr-4 pt-2 pb-1 text-[11px] font-medium uppercase tracking-wide text-gray-400/90 dark:text-gray-500/90">
+                          <p className={`pl-8 pr-4 py-1.5 text-[11px] font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400 ${DEPTH_LEVEL_2}`}>
                             {sub.title}
                           </p>
                           <div className="divide-y divide-gray-100 dark:divide-gray-700">

--- a/src/pages/Forecast.tsx
+++ b/src/pages/Forecast.tsx
@@ -10,6 +10,7 @@ import { buildPlWindow, bucketIndexOf, dayOf } from '../utils/plWindow';
 import type { PlWindowKind } from '../utils/plWindow';
 import { ArrowDownIcon, ArrowUpIcon, ChevronDownIcon, ChevronRightIcon } from '../components/icons';
 import { WholePoundsScope, WholePoundsToggle } from '../contexts/WholePoundsContext';
+import { DEPTH_LEVEL_1, DEPTH_LEVEL_2, DEPTH_LEVEL_2_STICKY } from '../styles/depthShading';
 import { dataPort } from '@data';
 import type { ForecastAdjustment, Transaction } from '../types';
 
@@ -436,7 +437,7 @@ function ForecastStatement(): React.JSX.Element {
         {/* A row that FOLDS wears a quiet band (owner, 19 Aug: "anything…
             that has a drop down arrow should have its row highlighted
             slightly") — the same band its table-mode twin wears. */}
-        <div className="flex items-baseline justify-between gap-4 py-2 px-2 -mx-2 rounded bg-gray-50 dark:bg-gray-700">
+        <div className={`flex items-baseline justify-between gap-4 py-2 px-2 -mx-2 rounded ${DEPTH_LEVEL_1}`}>
           <button
             type="button"
             onClick={() => toggleSection(side)}
@@ -479,7 +480,7 @@ function ForecastStatement(): React.JSX.Element {
                 const groupOpen = !closedGroups.has(groupKey);
                 return (
                   <li key={entry.key} className="border-t border-gray-50 dark:border-gray-700/50 first:border-0">
-                    <div className="flex items-baseline justify-between gap-4 px-2 -mx-2 rounded bg-gray-50 dark:bg-gray-700">
+                    <div className={`flex items-baseline justify-between gap-4 px-2 -mx-2 rounded ${DEPTH_LEVEL_2}`}>
                       <button
                         type="button"
                         onClick={() => toggleGroup(groupKey)}
@@ -587,8 +588,8 @@ function ForecastStatement(): React.JSX.Element {
         {/* A folding row wears the band; its sticky cell paints the SAME
             colour, opaque, or the first column would break the band while
             the months scroll beneath it. */}
-        <tr className="border-t border-gray-100 dark:border-gray-700/60 bg-gray-50 dark:bg-gray-700">
-          <td className="sticky left-0 bg-gray-50 dark:bg-gray-700 py-2 pr-4">
+        <tr className={`border-t border-gray-100 dark:border-gray-700/60 ${DEPTH_LEVEL_1}`}>
+          <td className={`sticky left-0 ${DEPTH_LEVEL_1} py-2 pr-4`}>
             <button
               type="button"
               onClick={() => toggleSection(side)}
@@ -621,8 +622,8 @@ function ForecastStatement(): React.JSX.Element {
           const groupOpen = !closedGroups.has(groupKey);
           return (
             <React.Fragment key={entry.key}>
-              <tr className="border-t border-gray-50 dark:border-gray-700/50 bg-gray-50 dark:bg-gray-700">
-                <td className="sticky left-0 bg-gray-50 dark:bg-gray-700 py-1.5 pl-4 pr-4">
+              <tr className={`border-t border-gray-50 dark:border-gray-700/50 ${DEPTH_LEVEL_2}`}>
+                <td className={`sticky left-0 ${DEPTH_LEVEL_2_STICKY} py-1.5 pl-4 pr-4`}>
                   <button
                     type="button"
                     onClick={() => toggleGroup(groupKey)}

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -29,7 +29,8 @@ import { WholePoundsScope, WholePoundsToggle } from '../contexts/WholePoundsCont
 import ToggleSwitch from '../components/ui/ToggleSwitch';
 import { buildPortfolioSummary, buildPortfolioHistory } from '../utils/portfolioSummary';
 import { useHistoricalAccounts } from '../hooks/useHistoricalAccounts';
-import { computePortfolioPerformance, scopeValueAt } from '../utils/portfolioPerformance';
+import { computePortfolioPerformance, scopeValueAt, scopeOpeningFlows } from '../utils/portfolioPerformance';
+import { dayOf } from '../utils/plWindow';
 import { buildTopLevelIdByAccountId, groupByTopLevelId } from '../utils/accountNesting';
 import { getDateLocale } from '../utils/dateFormatter';
 import { preferences } from '../services/preferencesService';
@@ -512,10 +513,7 @@ function InvestmentsView() {
     [openAccounts]
   );
 
-  const netPortfolioValue = useMemo(
-    () => toDecimal(summary.value).minus(securedAgainstPortfolio.total),
-    [summary.value, securedAgainstPortfolio.total]
-  );
+
 
   // The window the chart covers. 'ALL' is unbounded at both ends, which the
   // history walk reads as "first transaction until today".
@@ -534,11 +532,32 @@ function InvestmentsView() {
     return { from: new Date(now.getFullYear(), now.getMonth() - months, now.getDate()), to: now };
   }, [selectedPeriod, customStart, customEnd]);
 
-  // Real history: what the pair was worth on each date, never a projection of
-  // today's figure backwards.
+  /**
+   * THE SCOPE — the whole portfolio, or one pair (owner, 20 Aug: "we need
+   * to have a similar page viewable for individual investment accounts, so
+   * I can see how a singular portfolio is performing"). One selector; the
+   * tiles, the return band, the chart and every drill follow it.
+   */
+  const [performanceScope, setPerformanceScope] = useState<string>('all');
+  const pairGroups = useMemo(() => {
+    const topLevelIdByAccountId = buildTopLevelIdByAccountId(historicalAccounts);
+    return {
+      topLevelIdByAccountId,
+      membersByTopLevelId: groupByTopLevelId(historicalAccounts, topLevelIdByAccountId),
+    };
+  }, [historicalAccounts]);
+  const scopeMembers = useMemo(
+    () => performanceScope === 'all'
+      ? summary.memberAccounts
+      : (pairGroups.membersByTopLevelId.get(performanceScope) ?? summary.memberAccounts),
+    [performanceScope, summary.memberAccounts, pairGroups]
+  );
+
+  // Real history: what the SCOPE was worth on each date, never a projection
+  // of today's figure backwards.
   const performanceData = useMemo(
-    () => buildPortfolioHistory(summary.memberAccounts, transactions, historyRange),
-    [summary.memberAccounts, transactions, historyRange]
+    () => buildPortfolioHistory(scopeMembers, transactions, historyRange),
+    [scopeMembers, transactions, historyRange]
   );
 
   /**
@@ -550,25 +569,13 @@ function InvestmentsView() {
    */
   const performance = useMemo(
     () => computePortfolioPerformance({
-      memberAccounts: summary.memberAccounts,
+      memberAccounts: scopeMembers,
       transactions,
       transactionSplits,
       categories,
       range: historyRange,
     }),
-    [summary.memberAccounts, transactions, transactionSplits, categories, historyRange]
-  );
-
-  /** All time, for the Return % tile — the whole ledger, both measures. */
-  const allTimePerformance = useMemo(
-    () => computePortfolioPerformance({
-      memberAccounts: summary.memberAccounts,
-      transactions,
-      transactionSplits,
-      categories,
-      range: { from: null, to: null },
-    }),
-    [summary.memberAccounts, transactions, transactionSplits, categories]
+    [scopeMembers, transactions, transactionSplits, categories, historyRange]
   );
 
   /**
@@ -579,14 +586,13 @@ function InvestmentsView() {
   const [drillDate, setDrillDate] = useState<Date | null>(null);
   const drillRows = useMemo(() => {
     if (!drillDate) return null;
-    const topLevelIdByAccountId = buildTopLevelIdByAccountId(historicalAccounts);
-    const membersByTopLevelId = groupByTopLevelId(historicalAccounts, topLevelIdByAccountId);
     const rows = historicalAccounts
-      .filter(a => a.type === 'investment' && topLevelIdByAccountId.get(a.id) === a.id)
+      .filter(a => a.type === 'investment' && pairGroups.topLevelIdByAccountId.get(a.id) === a.id)
+      .filter(a => performanceScope === 'all' || a.id === performanceScope)
       .map(root => ({
         accountId: root.id,
         name: root.name,
-        value: scopeValueAt(membersByTopLevelId.get(root.id) ?? [root], transactions, drillDate),
+        value: scopeValueAt(pairGroups.membersByTopLevelId.get(root.id) ?? [root], transactions, drillDate),
       }))
       .filter(row => !row.value.isZero())
       .sort((a, b) => b.value.minus(a.value).toNumber());
@@ -594,7 +600,42 @@ function InvestmentsView() {
       rows,
       total: rows.reduce((sum, row) => sum.plus(row.value), toDecimal(0)),
     };
-  }, [drillDate, historicalAccounts, transactions]);
+  }, [drillDate, historicalAccounts, pairGroups, performanceScope, transactions]);
+
+  /**
+   * Per-pair windowed performance, for the tile drills: the same maths as
+   * the headline, one pair at a time, so the breakdown's lines SUM to the
+   * tile (pair-to-pair transfers appear on both sides and net away).
+   */
+  const perPairPerformance = useMemo(() => {
+    const byRoot = new Map<string, ReturnType<typeof computePortfolioPerformance>>();
+    for (const line of summary.lines) {
+      if (performanceScope !== 'all' && line.accountId !== performanceScope) continue;
+      byRoot.set(line.accountId, computePortfolioPerformance({
+        memberAccounts: pairGroups.membersByTopLevelId.get(line.accountId) ?? [],
+        transactions,
+        transactionSplits,
+        categories,
+        range: historyRange,
+      }));
+    }
+    return byRoot;
+  }, [summary.lines, performanceScope, pairGroups, transactions, transactionSplits, categories, historyRange]);
+
+  const netPortfolioValue = useMemo(
+    () => toDecimal(performance.endValue).minus(securedAgainstPortfolio.total),
+    [performance.endValue, securedAgainstPortfolio.total]
+  );
+
+  /** A window-filter for drill rows, from the same range the figures use. */
+  const inWindow = useMemo(() => {
+    const from = historyRange.from ? dayOf(historyRange.from) : null;
+    const to = dayOf(historyRange.to ?? new Date());
+    return (date: Date | string): boolean => {
+      const day = dayOf(date);
+      return (from === null || day >= from) && day <= to;
+    };
+  }, [historyRange]);
 
   /** Which measure leads — the user's choice, remembered (GIPS shows both). */
   const [performanceMeasure, setPerformanceMeasure] = useState<'mwr' | 'twr'>(
@@ -717,7 +758,7 @@ function InvestmentsView() {
     () => allocationData.reduce((sum, slice) => sum + slice.value, 0),
     [allocationData]
   );
-  const isGain = summary.totalReturn.greaterThanOrEqualTo(0);
+  const isGain = performance.gain.greaterThanOrEqualTo(0);
   // The shared ramp. The array that stood here claimed to be "consistent
   // colors" while being the only one of the app's palettes to differ from its
   // twin — positions seven and eight had drifted to a cyan and a lime.
@@ -893,6 +934,27 @@ function InvestmentsView() {
       {/* Tab Content */}
       {activeTab === 'overview' && (
         <div className="grid gap-6">
+        {/* THE FOUR TILES READ OVER THE CHART'S WINDOW AND SCOPE (owner,
+            20 Aug: "the 4 boxes with figures in them should represent
+            whatever period you pick for the chart below"), through the same
+            maths as the return band — one definition, so the tiles and the
+            band can never disagree again (they did: the old tiles counted
+            transfers only, all time, and openings as return). */}
+        {summary.lines.length > 1 && (
+          <div className="flex justify-end -mb-2">
+            <select
+              value={performanceScope}
+              onChange={(e) => { setPerformanceScope(e.target.value); setDrillLineId(null); }}
+              aria-label="Which portfolio the figures cover"
+              className="text-sm border border-line dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-2 py-1.5"
+            >
+              <option value="all">All portfolios</option>
+              {summary.lines.map(line => (
+                <option key={line.accountId} value={line.accountId}>{line.name}</option>
+              ))}
+            </select>
+          </div>
+        )}
         {/* Summary Cards */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
         <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
@@ -911,9 +973,17 @@ function InvestmentsView() {
                 {formatCurrency(
                   showNetPosition && securedAgainstPortfolio.names.length > 0
                     ? netPortfolioValue
-                    : summary.value
+                    : performance.endValue
                 )}
               </p>
+              {/* A value from a window that ends in the past says WHEN it is
+                  from — a figure wearing today's label for last tax year's
+                  money would be the quiet lie this page exists to avoid. */}
+              {historyRange.to && dayOf(historyRange.to) !== dayOf(new Date()) && (
+                <p className="text-dense text-gray-500 dark:text-gray-400 mt-0.5">
+                  on {historyRange.to.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}
+                </p>
+              )}
               {/* The control appears ONLY when something is actually secured
                   against this portfolio. A gross/net switch with nothing to
                   net off is a question about a distinction that does not exist
@@ -976,10 +1046,10 @@ function InvestmentsView() {
         >
           <p className="text-body text-gray-500 dark:text-gray-400">Net Contributions</p>
           <p className="text-page font-bold text-blue-700 dark:text-blue-400">
-            {formatCurrency(summary.netContributions)}
+            {formatCurrency(performance.netFlows)}
           </p>
           <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">
-            Transferred in, less transferred out — click for each account's share
+            Put in less taken out over this period — click for each account's share
           </p>
         </button>
 
@@ -995,7 +1065,7 @@ function InvestmentsView() {
             <div>
               <p className="text-body text-gray-500 dark:text-gray-400">Total Return</p>
               <p className={`text-page font-bold ${isGain ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-                {isGain ? '+' : ''}{formatCurrency(summary.totalReturn)}
+                {isGain ? '+' : ''}{formatCurrency(performance.gain)}
               </p>
             </div>
             <TrendingUpIcon className={isGain ? 'text-green-500' : 'text-red-500'} size={24} />
@@ -1011,35 +1081,35 @@ function InvestmentsView() {
                   (measured on the owner's ledger: a small net under a large
                   gain). The money-weighted rate is the figure
                   a statement would print here. */}
-              {allTimePerformance.mwrAnnualised === null ? (
+              {performance.mwrAnnualised === null ? (
                 <>
                   <p className="text-page font-bold text-gray-500 dark:text-gray-400">—</p>
                   <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">
-                    Nothing has been invested yet, so there is no return to measure
+                    Nothing was invested in this window, so there is no return to measure
                   </p>
                 </>
               ) : (
                 <>
                   <p className={`text-page font-bold tabular-nums ${
-                    allTimePerformance.mwrAnnualised.isZero()
+                    performance.mwrAnnualised.isZero()
                       ? 'text-gray-900 dark:text-white'
-                      : allTimePerformance.mwrAnnualised.greaterThan(0)
+                      : performance.mwrAnnualised.greaterThan(0)
                         ? 'text-green-600 dark:text-green-400'
                         : 'text-red-600 dark:text-red-400'
                   }`}>
-                    {formatReturn(allTimePerformance.mwrAnnualised)}
+                    {formatReturn(performance.mwrAnnualised)}
                   </p>
                   <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">
-                    Money-weighted, annualised, since the start
+                    Money-weighted, annualised
                   </p>
                 </>
               )}
             </div>
             <TrendingDownIcon
               className={
-                allTimePerformance.mwrAnnualised === null
+                performance.mwrAnnualised === null
                   ? 'text-gray-400'
-                  : allTimePerformance.mwrAnnualised.greaterThanOrEqualTo(0) ? 'text-green-500' : 'text-red-500'
+                  : performance.mwrAnnualised.greaterThanOrEqualTo(0) ? 'text-green-500' : 'text-red-500'
               }
               size={24}
             />
@@ -1112,32 +1182,62 @@ function InvestmentsView() {
               if (openBreakdown === null) return null;
 
               if (drillLine === null) {
+                // WINDOWED, like the tiles they explain: each line is the
+                // pair's own performance over the chart's period, so the
+                // lines sum to the tile (pair-to-pair transfers appear on
+                // both sides and net away).
+                const scopedLines = portfolioLines.filter(
+                  line => performanceScope === 'all' || line.accountId === performanceScope
+                );
                 return (
                   <div className="space-y-1">
-                    {portfolioLines.map(line => (
-                      <button
-                        key={line.accountId}
-                        type="button"
-                        onClick={() => setDrillLineId(line.accountId)}
-                        className="block w-full text-left py-2 px-2 -mx-2 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 border-b border-gray-100 dark:border-gray-700/60 last:border-0"
-                      >
-                        <span className="flex justify-between gap-3">
-                          <span className="min-w-0 truncate text-body text-gray-700 dark:text-gray-300">{line.name}</span>
-                          <span className="tabular-nums shrink-0 text-body text-gray-900 dark:text-white">
-                            {formatCurrency(openBreakdown === 'contributions' ? line.netContributions : line.totalReturn)}
+                    {scopedLines.map(line => {
+                      const pairPerf = perPairPerformance.get(line.accountId);
+                      return (
+                        <button
+                          key={line.accountId}
+                          type="button"
+                          onClick={() => setDrillLineId(line.accountId)}
+                          className="block w-full text-left py-2 px-2 -mx-2 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 border-b border-gray-100 dark:border-gray-700/60 last:border-0"
+                        >
+                          <span className="flex justify-between gap-3">
+                            <span className="min-w-0 truncate text-body text-gray-700 dark:text-gray-300">{line.name}</span>
+                            <span className="tabular-nums shrink-0 text-body text-gray-900 dark:text-white">
+                              {pairPerf
+                                ? formatCurrency(openBreakdown === 'contributions' ? pairPerf.netFlows : pairPerf.gain)
+                                : '—'}
+                            </span>
                           </span>
-                        </span>
-                      </button>
-                    ))}
+                        </button>
+                      );
+                    })}
                     <p className="flex justify-between gap-3 pt-3 font-semibold text-body text-gray-900 dark:text-white">
                       <span>Total</span>
                       <span className="tabular-nums">
-                        {formatCurrency(openBreakdown === 'contributions' ? summary.netContributions : summary.totalReturn)}
+                        {formatCurrency(openBreakdown === 'contributions' ? performance.netFlows : performance.gain)}
                       </span>
                     </p>
                   </div>
                 );
               }
+
+              // The rows behind this pair's contributions, WINDOWED — the
+              // transfer legs inside the period plus any opening lump whose
+              // effective date falls in it, so the list sums to Put in less
+              // Taken out above.
+              const drillMembers = pairGroups.membersByTopLevelId.get(drillLine.accountId) ?? [];
+              const windowRows = [
+                ...drillLine.contributionRows.filter(row => inWindow(row.date)),
+                ...scopeOpeningFlows(drillMembers, transactions)
+                  .filter(o => inWindow(new Date(`${o.day}T00:00:00Z`)))
+                  .map(o => ({
+                    transactionId: `opening:${o.accountId}`,
+                    accountId: o.accountId,
+                    date: new Date(`${o.day}T00:00:00Z`),
+                    description: 'Opening balance',
+                    amount: o.amount,
+                  })),
+              ].sort((a, b) => b.date.getTime() - a.date.getTime());
 
               return (
                 <div>
@@ -1150,35 +1250,48 @@ function InvestmentsView() {
                   </button>
                   <h4 className="text-card font-semibold text-gray-900 dark:text-white mb-2">{drillLine.name}</h4>
 
-                  {/* The identity first, because it is what a RETURN is made
-                      of — a residual, not a list of rows. Contributions are
-                      the half that has transactions behind it, and they
-                      follow. */}
-                  <div className="mb-4 space-y-1">
-                    <p className="flex justify-between text-body text-gray-600 dark:text-gray-400">
-                      <span>Value today</span>
-                      <span className="tabular-nums">{formatCurrency(drillLine.value)}</span>
-                    </p>
-                    <p className="flex justify-between text-body text-gray-600 dark:text-gray-400">
-                      <span>Less net contributions</span>
-                      <span className="tabular-nums">{formatCurrency(drillLine.netContributions)}</span>
-                    </p>
-                    <p className="flex justify-between font-semibold text-body text-gray-900 dark:text-white border-t border-gray-200 dark:border-gray-700 pt-1">
-                      <span>Total return</span>
-                      <span className="tabular-nums">{formatCurrency(drillLine.totalReturn)}</span>
-                    </p>
-                  </div>
+                  {/* The identity first, WINDOWED like everything above it:
+                      the same five figures the return band explains, for this
+                      one pair over the chart's period. */}
+                  {(() => {
+                    const pairPerf = perPairPerformance.get(drillLine.accountId);
+                    if (!pairPerf) return null;
+                    return (
+                      <div className="mb-4 space-y-1">
+                        <p className="flex justify-between text-body text-gray-600 dark:text-gray-400">
+                          <span>Started at</span>
+                          <span className="tabular-nums">{formatCurrency(pairPerf.startValue)}</span>
+                        </p>
+                        <p className="flex justify-between text-body text-gray-600 dark:text-gray-400">
+                          <span>Put in</span>
+                          <span className="tabular-nums">{formatCurrency(pairPerf.moneyIn)}</span>
+                        </p>
+                        <p className="flex justify-between text-body text-gray-600 dark:text-gray-400">
+                          <span>Taken out</span>
+                          <span className="tabular-nums">{formatCurrency(pairPerf.moneyOut)}</span>
+                        </p>
+                        <p className="flex justify-between text-body text-gray-600 dark:text-gray-400">
+                          <span>Gain</span>
+                          <span className="tabular-nums">{formatCurrency(pairPerf.gain)}</span>
+                        </p>
+                        <p className="flex justify-between font-semibold text-body text-gray-900 dark:text-white border-t border-gray-200 dark:border-gray-700 pt-1">
+                          <span>Ended at</span>
+                          <span className="tabular-nums">{formatCurrency(pairPerf.endValue)}</span>
+                        </p>
+                      </div>
+                    );
+                  })()}
 
                   <p className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-1">
-                    The transfers behind the contributions
+                    The movements behind the contributions, this period
                   </p>
-                  {drillLine.contributionRows.length === 0 ? (
+                  {windowRows.length === 0 ? (
                     <p className="text-body text-gray-500 dark:text-gray-400 py-2">
                       No external transfers recorded — this account's whole value is return.
                     </p>
                   ) : (
                     <div className="space-y-1">
-                      {drillLine.contributionRows.map(row => {
+                      {windowRows.map(row => {
                         const rowAccount = accountsById.get(row.accountId);
                         return (
                           <p key={row.transactionId} className="flex justify-between gap-3 py-1 border-b border-gray-100 dark:border-gray-700/60 last:border-0">

--- a/src/pages/__tests__/Investments.test.tsx
+++ b/src/pages/__tests__/Investments.test.tsx
@@ -28,7 +28,10 @@ const account = (overrides: Partial<Account> & Pick<Account, 'id' | 'name' | 'ty
 });
 
 const txn = (overrides: Partial<Transaction> & Pick<Transaction, 'id' | 'accountId' | 'amount'>): Transaction => ({
-  date: new Date(2026, 2, 10),
+  // BEFORE the harness's pinned clock (browserShims sets 2025-01-20) and
+  // inside the default 12-month window — the tiles are WINDOWED now, and a
+  // fixture dated after the clock honestly reads as an empty window.
+  date: new Date(2024, 5, 10),
   description: 'Movement',
   category: '',
   type: 'transfer',
@@ -36,7 +39,9 @@ const txn = (overrides: Partial<Transaction> & Pick<Transaction, 'id' | 'account
 });
 
 const accounts: Account[] = [
-  account({ id: ISA, name: 'Fund ISA', type: 'investment', institution: 'Sample Brokers', openingBalance: 1000 }),
+  // The opening is DATED, before the default window: it reaches the tiles as
+  // starting value, never as a window flow — the owner's opening-balance rule.
+  account({ id: ISA, name: 'Fund ISA', type: 'investment', institution: 'Sample Brokers', openingBalance: 1000, openingBalanceDate: new Date(2023, 11, 1) }),
   account({ id: ISA_CASH, name: 'Fund ISA (Cash)', type: 'current', parentAccountId: ISA }),
   account({ id: EVERYDAY, name: 'Everyday Account', type: 'current', openingBalance: 5000 }),
 ];
@@ -52,9 +57,9 @@ const categories: Category[] = [
   { id: 'tofrom-everyday', name: 'To/From Everyday Account', type: 'both', level: 'detail', isTransferCategory: true, accountId: EVERYDAY },
 ];
 
-const renderInvestments = (overrides: { transactions?: Transaction[] } = {}) => {
+const renderInvestments = (overrides: { transactions?: Transaction[]; accounts?: Account[] } = {}) => {
   __setAppContextValue({
-    accounts,
+    accounts: overrides.accounts ?? accounts,
     transactions: overrides.transactions ?? transactions,
     transactionSplits: [],
     categories,
@@ -77,8 +82,9 @@ describe('Investments page — the pair is the portfolio', () => {
     renderInvestments();
 
     // £1,300 in the fund and £200 in its cash: the tile and the holding row
-    // both say £1,500.
-    expect(await screen.findAllByText('£1,500.00')).toHaveLength(2);
+    // both say £1,500 — and since the tiles went windowed, the return
+    // band's Ended at is the third voice of the same walk.
+    expect(await screen.findAllByText('£1,500.00')).toHaveLength(3);
 
     /*
      * The £1,300 IS shown now, and that is a ruling change, not a leak. This
@@ -131,24 +137,23 @@ describe('Investments page — contributions and return', () => {
     // £500 in from the current account. The £200 shuffled into the pair's own
     // cash side is not a contribution in either direction.
     expect(await screen.findByText('Net Contributions')).toBeInTheDocument();
-    expect(screen.getByText('£500.00')).toBeInTheDocument();
-    expect(screen.getByText('+£1,000.00')).toBeInTheDocument();
+    // The tile and the return band's Put in — same figure, same maths.
+    expect(screen.getAllByText('£500.00')).toHaveLength(2);
+    // OVERRULED with the windowed tiles: the old maths called £1,000 the
+    // "return" — but that was the OPENING BALANCE, capital mistaken for
+    // growth. Nothing in this fixture grew; the honest gain is zero.
+    expect(screen.queryByText('+£1,000.00')).not.toBeInTheDocument();
+    expect(screen.getAllByText('+£0.00').length).toBeGreaterThanOrEqual(1);
     // OVERRULED 20 Aug: the tile no longer prints gain-over-net-contributions
     // (+200.00% here) — that ratio turns absurd the moment withdrawals bring
-    // the net near zero. The pinned test clock (browserShims) sits BEFORE
-    // this fixture's rows, so here the tile honestly reports nothing
-    // measurable yet; the words-pin for the new measure runs on the
-    // backdated ledger in its own spec below.
+    // the net near zero. The words-pin for the new measure has its own spec.
     expect(screen.queryByText('+200.00%')).not.toBeInTheDocument();
   });
 
-  it('shows the all-time money-weighted rate, annualised — never gain-over-net-contributions', async () => {
-    // The same ledger, dated before the pinned clock, so the window is real.
-    renderInvestments({
-      transactions: transactions.map(t => ({ ...t, date: new Date(2024, 5, 10) })),
-    });
+  it('shows the money-weighted rate for the window, annualised — never gain-over-net-contributions', async () => {
+    renderInvestments();
 
-    expect(await screen.findByText('Money-weighted, annualised, since the start')).toBeInTheDocument();
+    expect(await screen.findByText('Money-weighted, annualised')).toBeInTheDocument();
     expect(screen.queryByText('+200.00%')).not.toBeInTheDocument();
   });
 
@@ -171,10 +176,15 @@ describe('Investments page — contributions and return', () => {
     expect(await screen.findByText(/no matching row in another account/)).toBeInTheDocument();
   });
 
-  it('refuses to state a return percentage when nothing was contributed', async () => {
-    renderInvestments({ transactions: [] });
+  it('refuses to state a return percentage when nothing was ever in the window', async () => {
+    // No rows AND no dated opening: an opening predating the window would be
+    // capital at work, and 0.00% — not a refusal — would be the honest tile.
+    renderInvestments({
+      transactions: [],
+      accounts: accounts.map(a => ({ ...a, openingBalance: 0, openingBalanceDate: undefined })),
+    });
 
-    expect(await screen.findByText('—')).toBeInTheDocument();
-    expect(screen.getByText('Nothing has been invested yet, so there is no return to measure')).toBeInTheDocument();
+    expect((await screen.findAllByText('—')).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Nothing was invested in this window, so there is no return to measure')).toBeInTheDocument();
   });
 });

--- a/src/styles/depthShading.ts
+++ b/src/styles/depthShading.ts
@@ -1,0 +1,23 @@
+/**
+ * THE DEPTH LADDER — one rule for every drill-down surface (owner, 20 Aug):
+ *
+ *   "across the board … the account group headings, there should be a shade
+ *    darker grey, then for the institution (level down), the grey we have,
+ *    and then the accounts, just plain white background. I think this ethos
+ *    should go through the app. Wherever there are 'drill downs', the lowest
+ *    is white, the next up is the grey you see, the next up is a darker
+ *    shade."
+ *
+ * So: LEVEL 1 (outermost heading) wears the darker grey, LEVEL 2 (the tier
+ * beneath) the lighter grey, and leaf rows the surface itself — no token,
+ * because absence of a band IS the third step. Light greys come from the
+ * house surface scale (tailwind.config.js); dark mode steps gray-700 →
+ * gray-700/50 → gray-800 to keep the same three-rung read.
+ *
+ * `DEPTH_LEVEL_2_STICKY` exists for sticky table cells, which must be OPAQUE
+ * (columns scroll beneath them): it is the literal blend of gray-700/50 over
+ * gray-800, so a sticky first column matches its translucent row exactly.
+ */
+export const DEPTH_LEVEL_1 = 'bg-surface-tertiary dark:bg-gray-700';
+export const DEPTH_LEVEL_2 = 'bg-surface-secondary dark:bg-gray-700/50';
+export const DEPTH_LEVEL_2_STICKY = 'bg-surface-secondary dark:bg-[#2b3544]';

--- a/src/utils/portfolioPerformance.ts
+++ b/src/utils/portfolioPerformance.ts
@@ -95,6 +95,30 @@ const DAYS_PER_YEAR = toDecimal('365.25');
 const dayTime = (day: string): number => Date.parse(`${day}T00:00:00Z`);
 
 /**
+ * The scope's opening-balance flows — each account's dated opening lump, the
+ * same resolution the performance walk counts as money in. Exposed so the
+ * contributions drill can LIST them beside the transfer rows: a breakdown
+ * that omitted the openings would not sum to the tile it explains.
+ */
+export function scopeOpeningFlows(
+  memberAccounts: readonly Account[],
+  transactions: readonly Transaction[]
+): Array<{ accountId: string; day: string; amount: DecimalInstance }> {
+  const memberIds = new Set(memberAccounts.map(a => a.id));
+  const memberTransactions = transactions.filter(t => memberIds.has(t.accountId));
+  const openingDates = resolveEffectiveOpeningDates([...memberAccounts], [...memberTransactions]);
+  const flows: Array<{ accountId: string; day: string; amount: DecimalInstance }> = [];
+  for (const account of memberAccounts) {
+    const opening = toDecimal(account.openingBalance ?? 0);
+    if (opening.isZero()) continue;
+    const effective = openingDates.get(account.id);
+    if (effective === undefined) continue; // time-zero seed — never a window flow
+    flows.push({ accountId: account.id, day: dayOf(effective), amount: opening });
+  }
+  return flows;
+}
+
+/**
  * The scope's value at the end of `date` — the same openings-plus-rows walk
  * the performance figures stand on, exposed for the chart's per-date drill
  * (owner, 20 Aug: "click on any month … a pop up window comes up with the


### PR DESCRIPTION
Three owner directions from 20–21 Aug, batched on his instruction ("don't PR that on its own, lets wait for a few bits to be done in one hit"):

## 1. The four tiles read the chart's window — and its scope

**"the 4 boxes with figures in them should represent whatever period you pick for the chart below"** — all four tiles now compute through the **same maths as the return band** (`computePortfolioPerformance` over `historyRange`), so tiles and band can never disagree again. They did: the old tiles counted transfers only, all time, and quietly booked **opening balances as return**. The test fixture proved it on the way through — what the old Total Return tile called a four-figure gain was the opening balance mistaken for growth; the honest windowed gain is zero, now pinned. A Portfolio Value from a window ending in the past states the date it is from.

## 2. One portfolio at a time

**"we need to have a similar page viewable for individual investment accounts"** — a scope selector (All portfolios / any single pair) drives the tiles, the return band, the chart, the chart's per-date drill and the tile breakdowns together. The breakdown modal's lines are each pair's **own windowed performance** (lines sum to the tile; pair-to-pair transfers net away), and its drill shows the five-figure identity — Started / Put in / Taken out / Gain / Ended — over window-filtered rows **including opening lumps**, which a transfer-only list would have omitted from its own total.

## 3. The depth ladder

**"wherever there are drill downs, the lowest is white, the next up is the grey you see, the next up is a darker shade — this ethos should go through the app"** — codified once in `src/styles/depthShading.ts` and applied to: the Accounts **type and institution bands** (open *and* closed — the two tiers wore the same grey), the closed band's headings, and the Forecast P&L's **sections vs group headings** in both layouts (the sticky table cell carries the documented opaque blend so the band survives horizontal scrolling). Closed rows also drop their institution sub-line when banded by institution, as the open list already did.

## Verified

69 specs across the touched suites (the fixture re-anchored before the harness's pinned clock; the opening-mistaken-for-return correction pinned), strict types, zero-warning lint — and all three pages exercised live in the browser: tiles ≡ band to the penny, the ladder reading on Accounts and the P&L.

🤖 Generated with [Claude Code](https://claude.com/claude-code)