### PR TITLE
polish(ui): £8m not £2000k, the closed band speaks with the open band's voice, and the arrow expands instead of leaving

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -626,20 +626,36 @@ export default function Layout(): React.JSX.Element {
                 
                 {/* Accounts with Sub-navigation (but no "All Accounts" redundancy) */}
                 <div>
+                  {/* THE ARROW EXPANDS, THE NAME NAVIGATES (owner, 21 Aug:
+                      tapping Accounts' arrow went to the page, closed the
+                      menu and flipped the flag — so the sub-pages only
+                      appeared on the SECOND trip). The chevron is its own
+                      button now: preventDefault stops the surrounding Link's
+                      navigation, and the menu stays open showing the
+                      sub-pages, exactly as the other headings behave. */}
                   <Link
                     to={isDemoModeRoutingEnabled ? '/accounts?demo=true' : '/accounts'}
-                    onClick={() => {
-                      setAccountsExpanded(!accountsExpanded);
-                      toggleMobileMenu();
-                    }}
+                    onClick={toggleMobileMenu}
                     className="w-full flex items-center gap-2 px-3 py-2.5 md:py-2 rounded-lg transition-colors min-h-[40px] md:min-h-[auto] bg-secondary text-white dark:text-gray-300 hover:bg-secondary dark:hover:bg-gray-800/50"
                   >
                     <WalletIcon size={18} />
                     <span className="flex-1 text-sm text-left">Accounts</span>
-                    <ChevronRightIcon 
-                      size={14} 
-                      className={`text-gray-400 transition-transform duration-200 ${accountsExpanded ? 'rotate-90' : ''}`} 
-                    />
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        setAccountsExpanded(!accountsExpanded);
+                      }}
+                      aria-expanded={accountsExpanded}
+                      aria-label={accountsExpanded ? 'Hide the Accounts pages' : 'Show the Accounts pages'}
+                      className="p-2 -m-2 rounded-lg"
+                    >
+                      <ChevronRightIcon
+                        size={14}
+                        className={`text-gray-400 transition-transform duration-200 ${accountsExpanded ? 'rotate-90' : ''}`}
+                      />
+                    </button>
                   </Link>
                   {/* THE SAME SHAPE AS THE DESKTOP ACCOUNTS MENU (owner,
                       17 Aug: "the drop-down headings … the same layout as the

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -2312,7 +2312,7 @@ function AccountsList() {
     return (
       <div key={account.id} className="flex items-center justify-between px-4 py-3">
         <div className="min-w-0">
-          <p className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
+          <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
             {account.name}
           </p>
           {/* Only when the list is NOT banded by institution — under an
@@ -2325,7 +2325,7 @@ function AccountsList() {
           )}
         </div>
         <div className="flex items-center gap-2 sm:gap-4">
-          <p className="text-sm tabular-nums text-gray-500 dark:text-gray-400">
+          <p className="text-sm tabular-nums text-gray-900 dark:text-white">
             {formatDisplayCurrency(account.balance, account.currency)}
           </p>
           <IconButton
@@ -3058,13 +3058,16 @@ function AccountsList() {
               ) : (
                 closedAccountBands.groups.map(group => (
                   <div key={`${group.kind}:${group.label}`}>
-                    <p className={`px-4 py-2 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400 ${DEPTH_LEVEL_1}`}>
+                    {/* The SAME voice as the open bands (owner, 21 Aug: "the
+                        closed accounts should look the same to read as the
+                        open accounts, in all aspects"). */}
+                    <p className={`px-4 sm:px-6 py-2.5 text-card uppercase font-bold tracking-wide text-gray-900 dark:text-white ${DEPTH_LEVEL_1}`}>
                       {group.title}
                     </p>
                     {group.subGroups ? (
                       group.subGroups.map(sub => (
                         <div key={sub.label}>
-                          <p className={`pl-8 pr-4 py-1.5 text-[11px] font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400 ${DEPTH_LEVEL_2}`}>
+                          <p className={`px-4 sm:px-6 py-2 text-body uppercase font-bold tracking-wide text-gray-900 dark:text-white ${DEPTH_LEVEL_2}`}>
                             {sub.title}
                           </p>
                           <div className="divide-y divide-gray-100 dark:divide-gray-700">

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -29,6 +29,7 @@ import { WholePoundsScope, WholePoundsToggle } from '../contexts/WholePoundsCont
 import ToggleSwitch from '../components/ui/ToggleSwitch';
 import { buildPortfolioSummary, buildPortfolioHistory } from '../utils/portfolioSummary';
 import { useHistoricalAccounts } from '../hooks/useHistoricalAccounts';
+import { formatCurrencyCompact } from '../utils/currency-decimal';
 import { computePortfolioPerformance, scopeValueAt, scopeOpeningFlows } from '../utils/portfolioPerformance';
 import { dayOf } from '../utils/plWindow';
 import { buildTopLevelIdByAccountId, groupByTopLevelId } from '../utils/accountNesting';
@@ -98,7 +99,7 @@ function InvestmentsView() {
     // far side is minted and linked by the same machinery every transfer uses.
     addTransaction, createTransferCounterpart,
   } = useApp();
-  const { formatCurrency } = useCurrencyDecimal();
+  const { formatCurrency, displayCurrency } = useCurrencyDecimal();
   /**
    * THE APP'S PERIOD VOCABULARY, spoken here too.
    *
@@ -1484,19 +1485,11 @@ function InvestmentsView() {
             >
               <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
               <XAxis dataKey="label" stroke="#9CA3AF" />
-              <YAxis 
-                stroke="#9CA3AF" 
-                tickFormatter={(value: number) => {
-                  const formatted = formatCurrency(value);
-                  if (value >= 1000) {
-                    const thousands = formatDecimal(
-                      toDecimal(value).dividedBy(1000),
-                      0
-                    );
-                    return `${formatted.charAt(0)}${thousands}k`;
-                  }
-                  return formatted;
-                }}
+              {/* £8m, not £2000k (owner, 21 Aug) — the house compact
+                  formatter, so the notation and the symbol are decided once. */}
+              <YAxis
+                stroke="#9CA3AF"
+                tickFormatter={(value: number) => formatCurrencyCompact(value, displayCurrency)}
               />
               <Tooltip
                 formatter={(value) => formatCurrency(toDecimal(Number(value)))}

--- a/src/utils/__tests__/currency-decimal.test.ts
+++ b/src/utils/__tests__/currency-decimal.test.ts
@@ -3,6 +3,7 @@ import { Decimal } from 'decimal.js';
 import {
   getCurrencySymbol,
   formatCurrency,
+  formatCurrencyCompact,
   getExchangeRates,
   supportedCurrencies,
   currencySymbols
@@ -567,5 +568,22 @@ describe('formatCurrency — whole pounds (per-page display choice, owner 19 Aug
   it('without the option, nothing changes', () => {
     expect(formatCurrency(24354.39)).toBe('£24,354.39');
     expect(formatCurrency(-42150.21)).toBe('(£42,150.21)');
+  });
+});
+
+describe('formatCurrencyCompact — axis notation (owner, 21 Aug: £8m, never £2000k)', () => {
+  it('millions in m, 1dp only when not whole', () => {
+    expect(formatCurrencyCompact(8_000_000)).toBe('£8m');
+    expect(formatCurrencyCompact(2_400_000)).toBe('£2.4m');
+  });
+
+  it('thousands in k, grouped, 1dp when whole-thousand rounding would collide', () => {
+    expect(formatCurrencyCompact(750_000)).toBe('£750k');
+    expect(formatCurrencyCompact(2_550)).toBe('£2.6k');
+  });
+
+  it('whole units below a thousand; negatives keep the minus (colourless axis notation)', () => {
+    expect(formatCurrencyCompact(850)).toBe('£850');
+    expect(formatCurrencyCompact(-2_400_000)).toBe('-£2.4m');
   });
 });

--- a/src/utils/currency-decimal.ts
+++ b/src/utils/currency-decimal.ts
@@ -181,6 +181,33 @@ export function formatCurrencyForSpeech(
   return showsMinus(decimal) ? `minus ${body}` : body;
 }
 
+/**
+ * Compact axis/summary notation: £8m, £2.4m, £750k, £2,000k — millions in m
+ * (1dp only when not whole), thousands in k with grouping, whole units below
+ * (owner, 21 Aug: '£2000k … doesn't look right'). The k tier keeps 1dp when
+ * whole-thousand rounding would print two neighbouring ticks identically.
+ * Negatives keep the minus: axis ticks are colourless compact notation, the
+ * one place the brackets rule deliberately does not reach.
+ */
+export function formatCurrencyCompact(
+  amount: DecimalInstance | number,
+  currency: string = 'GBP'
+): string {
+  const decimal = toDecimal(amount);
+  const abs = decimal.abs();
+  const sign = decimal.isNegative() ? '-' : '';
+  const symbol = getCurrencySymbol(currency);
+  if (abs.greaterThanOrEqualTo(1_000_000)) {
+    const millions = abs.dividedBy(1_000_000);
+    return `${sign}${symbol}${formatDecimal(millions, millions.isInteger() ? 0 : 1)}m`;
+  }
+  if (abs.greaterThanOrEqualTo(1_000)) {
+    const thousands = abs.dividedBy(1_000);
+    return `${sign}${symbol}${formatDecimal(thousands, thousands.isInteger() ? 0 : 1, { group: true })}k`;
+  }
+  return `${sign}${symbol}${formatDecimal(abs, 0, { group: true })}`;
+}
+
 // Format currency without fractional digits (floored values) for dashboard summaries
 export function formatCurrencyWhole(
   amount: DecimalInstance | number | string,


### PR DESCRIPTION
Three owner notes, 21 Aug:

## The axis — £8m, never £2000k

`formatCurrencyCompact` joins the house formatters: millions as **£8m** (1dp only when not whole), thousands as **£Xk** with proper grouping, whole units below, negatives keeping the minus (axis ticks are the one colourless compact notation the brackets rule deliberately does not reach). The k tier keeps 1dp when whole-thousand rounding would print two neighbouring ticks identically — measured "£3k, £3k" on the demo ledger before the rule. The Investments chart uses it with the **display currency**. Worth noting: the first draft interpolated a raw `£` and the money-format guard from the 19 Aug audit **rejected the commit** — the guard did exactly its job, and the formatter now lives where formatters live.

## The closed band — the open band's voice

**"the closed accounts should look the same to read as the open accounts, in all aspects"** — its type and institution headings now carry the open bands' own type (text-card/text-body, uppercase, bold, ink-dark) on the depth ladder's two greys, and the rows' names and balances read in the open rows' ink rather than archive-muted.

## The arrow — expands instead of leaving

The mobile drawer's Accounts row was one `<Link>` doing three jobs — navigate, close the drawer, flip the expand flag — so the sub-pages only ever appeared **on the second trip**. The chevron is its own button now: `preventDefault` stops the Link, the drawer stays open, the sub-pages appear, exactly as the other headings behave; the name still navigates. Verified in one tap at phone width (chevron found, URL unchanged, sub-pages visible, drawer open).

## Verified

51 formatter/guard specs (3 new for the compact notation), Layout + Accounts + Investments suites, strict types, zero-warning lint — axis ticks and the drawer exercised live in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)