### PR TITLE
fix(mobile): five phone reports — even drawer headings, the status bar's room, a drawer that opens over a warning, an honest failed load, and the tap that saved the form

### DIFF
--- a/src/components/DocumentManager.tsx
+++ b/src/components/DocumentManager.tsx
@@ -208,6 +208,7 @@ export default function DocumentManager({
           <div className="grid grid-cols-2 gap-2">
             {documents.slice(0, 4).map(doc => (
               <button
+                type="button"
                 key={doc.id}
                 onClick={() => {
                   setSelectedDocument(doc);
@@ -223,6 +224,7 @@ export default function DocumentManager({
             ))}
             {documents.length > 4 && (
               <button
+                type="button"
                 onClick={() => onDocumentSelect?.(documents[0])}
                 className="p-2 bg-gray-50 dark:bg-gray-700 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600 text-center text-sm text-gray-600 dark:text-gray-400"
               >
@@ -250,6 +252,7 @@ export default function DocumentManager({
           )}
         </div>
         <button
+          type="button"
           onClick={() => setShowUpload(true)}
           className="flex items-center gap-2 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-[#2d3a4d]"
         >
@@ -328,6 +331,7 @@ export default function DocumentManager({
                 <TagIcon size={12} />
                 {tag}
                 <button
+                  type="button"
                   onClick={() => setFilterTags(filterTags.filter(t => t !== tag))}
                   className="hover:text-red-600"
                 >
@@ -336,6 +340,7 @@ export default function DocumentManager({
               </span>
             ))}
             <button
+              type="button"
               onClick={() => setFilterTags([])}
               className="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
             >
@@ -365,6 +370,7 @@ export default function DocumentManager({
           </p>
           {documents.length === 0 && (
             <button
+              type="button"
               onClick={() => setShowUpload(true)}
               className="px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-[#2d3a4d]"
             >
@@ -455,6 +461,7 @@ export default function DocumentManager({
                 {/* Actions */}
                 <div className="flex items-center justify-between">
                   <button
+                    type="button"
                     onClick={() => {
                       setSelectedDocument(doc);
                       setShowViewer(true);
@@ -465,6 +472,7 @@ export default function DocumentManager({
                   </button>
                   <div className="flex items-center gap-2">
                     <button
+                      type="button"
                       onClick={() => downloadDocument(doc)}
                       className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
                       title="Download"
@@ -472,6 +480,7 @@ export default function DocumentManager({
                       <DownloadIcon size={16} />
                     </button>
                     <button
+                      type="button"
                       onClick={() => setEditingDocument(doc)}
                       className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
                       title="Edit"
@@ -479,6 +488,7 @@ export default function DocumentManager({
                       <EditIcon size={16} />
                     </button>
                     <button
+                      type="button"
                       onClick={() => handleDeleteDocument(doc.id)}
                       className="p-1 text-gray-400 hover:text-red-600"
                       title="Delete"
@@ -656,6 +666,7 @@ export default function DocumentManager({
           <ModalFooter>
             <div className="flex justify-between w-full">
               <button
+                type="button"
                 onClick={() => downloadDocument(selectedDocument)}
                 className="flex items-center gap-2 px-4 py-2 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white"
               >
@@ -663,6 +674,7 @@ export default function DocumentManager({
                 Download
               </button>
               <button
+                type="button"
                 onClick={() => {
                   setShowViewer(false);
                   setSelectedDocument(null);
@@ -725,12 +737,14 @@ export default function DocumentManager({
           
           <ModalFooter>
             <button
+              type="button"
               onClick={() => setEditingDocument(null)}
               className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white"
             >
               Cancel
             </button>
             <button
+              type="button"
               onClick={() => handleUpdateDocument(editingDocument, {
                 type: editingDocument.type,
                 notes: editingDocument.notes

--- a/src/components/DocumentUpload.tsx
+++ b/src/components/DocumentUpload.tsx
@@ -167,7 +167,14 @@ export default function DocumentUpload({
           onChange={handleFileSelection}
           className="hidden"
         />
+        {/* type="button", and on THIS one it is a fix with a story: rendered
+            inside the transaction editor's <form>, the untyped default is
+            type="submit", so tapping Attach saved the form and closed the
+            editor around it. See MarkdownEditor's toolbar for the same rule —
+            every control in a component that guests inside forms must say what
+            it is. */}
         <button
+          type="button"
           onClick={() => fileInputRef.current?.click()}
           className="flex items-center gap-2 px-3 py-1.5 text-sm bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600"
         >
@@ -208,6 +215,7 @@ export default function DocumentUpload({
             className="hidden"
           />
           <button
+            type="button"
             onClick={() => fileInputRef.current?.click()}
             className="flex items-center gap-2 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-[#2d3a4d]"
           >
@@ -215,6 +223,7 @@ export default function DocumentUpload({
             Select Files
           </button>
           <button
+            type="button"
             onClick={() => {
               // TODO: Implement camera capture for mobile
               alert('Camera capture coming soon!');
@@ -260,6 +269,7 @@ export default function DocumentUpload({
                   <TagIcon size={12} />
                   {tag}
                   <button
+                    type="button"
                     onClick={() => removeTag(tag)}
                     className="hover:text-red-600"
                   >
@@ -278,6 +288,7 @@ export default function DocumentUpload({
                 className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm"
               />
               <button
+                type="button"
                 onClick={addTag}
                 className="px-3 py-2 bg-gray-100 dark:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-500"
               >
@@ -353,6 +364,7 @@ export default function DocumentUpload({
                 )}
                 {!uploading && (
                   <button
+                    type="button"
                     onClick={() => removeFile(index)}
                     className="text-gray-400 hover:text-red-600"
                   >
@@ -400,6 +412,7 @@ export default function DocumentUpload({
       {/* Actions */}
       <div className="flex justify-between">
         <button
+          type="button"
           onClick={() => {
             setSelectedFiles([]);
             setUploadedDocs([]);
@@ -413,6 +426,7 @@ export default function DocumentUpload({
         <div className="flex gap-3">
           {onClose && (
             <button
+              type="button"
               onClick={onClose}
               className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white"
             >
@@ -420,6 +434,7 @@ export default function DocumentUpload({
             </button>
           )}
           <button
+            type="button"
             onClick={uploadFiles}
             disabled={selectedFiles.length === 0 || uploading}
             className="px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-[#2d3a4d] disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -589,9 +589,17 @@ export default function Layout(): React.JSX.Element {
           aria-modal="true"
           aria-labelledby="mobile-menu-title"
         >
-          <nav 
+          <nav
             id="mobile-menu"
             className="focus-ring-on-dark w-full max-w-sm h-full bg-[#1a2332] dark:bg-gray-800 shadow-2xl overflow-y-auto rounded-r-2xl"
+            // The drawer is `inset-0` so it starts at the WINDOW's top — which
+            // on an installed home-screen app is under the status bar (and an
+            // arriving notification banner), not below it. Both fixed headers
+            // already stand off by this constant; the drawer was the one piece
+            // of top chrome that didn't, so its "WealthTracker" title sat
+            // behind the clock. Padding, not `top`, because the panel's
+            // background should still reach the physical top of the screen.
+            style={{ paddingTop: TOP_CHROME_OFFSET }}
             onClick={e => e.stopPropagation()}
             role="navigation"
             aria-label="Mobile navigation menu"
@@ -632,11 +640,29 @@ export default function Layout(): React.JSX.Element {
                       appeared on the SECOND trip). The chevron is its own
                       button now: preventDefault stops the surrounding Link's
                       navigation, and the menu stays open showing the
-                      sub-pages, exactly as the other headings behave. */}
+                      sub-pages, exactly as the other headings behave.
+
+                      h-12 on ALL FOUR grouped headings, and the number is this
+                      row's, measured: the nested chevron button is held to the
+                      44px touch minimum (index.css), which after its -m-2
+                      stands a 28px flex item in the row — 48px with the
+                      py-2.5. The other headings had no inner button, so they
+                      sat at 40 (Settings) and 44 (Plan/Manage) beside this
+                      one's 48 (owner, 21 Aug: "make the 3 others the same as
+                      the accounts").
+
+                      An explicit HEIGHT, not min-h-[48px] — that was tried and
+                      measured at 44 on the two <button> rows, because the
+                      touch block's `button:not(.toggle-switch)` scores (0,1,1)
+                      against a utility's (0,1,0) and pins their min-height at
+                      44. The same trap as the `position` line in that block's
+                      own header comment. Used height = max(height, min-height)
+                      = max(48, 44), so h-12 lands 48 on <a> and <button> rows
+                      alike; md:h-auto hands the desktop back its own size. */}
                   <Link
                     to={isDemoModeRoutingEnabled ? '/accounts?demo=true' : '/accounts'}
                     onClick={toggleMobileMenu}
-                    className="w-full flex items-center gap-2 px-3 py-2.5 md:py-2 rounded-lg transition-colors min-h-[40px] md:min-h-[auto] bg-secondary text-white dark:text-gray-300 hover:bg-secondary dark:hover:bg-gray-800/50"
+                    className="w-full flex items-center gap-2 px-3 py-2.5 md:py-2 rounded-lg transition-colors h-12 md:h-auto bg-secondary text-white dark:text-gray-300 hover:bg-secondary dark:hover:bg-gray-800/50"
                   >
                     <WalletIcon size={18} />
                     <span className="flex-1 text-sm text-left">Accounts</span>
@@ -685,7 +711,7 @@ export default function Layout(): React.JSX.Element {
                     type="button"
                     onClick={() => setPlanExpanded(!planExpanded)}
                     aria-expanded={planExpanded}
-                    className="w-full flex items-center gap-2 px-3 py-2.5 md:py-2 rounded-lg transition-colors min-h-[40px] md:min-h-[auto] bg-secondary text-white dark:text-gray-300 hover:bg-secondary dark:hover:bg-gray-800/50"
+                    className="w-full flex items-center gap-2 px-3 py-2.5 md:py-2 rounded-lg transition-colors h-12 md:h-auto bg-secondary text-white dark:text-gray-300 hover:bg-secondary dark:hover:bg-gray-800/50"
                   >
                     <TargetIcon size={18} />
                     <span className="flex-1 text-sm text-left">Plan</span>
@@ -715,7 +741,7 @@ export default function Layout(): React.JSX.Element {
                     type="button"
                     onClick={() => setManageExpanded(!manageExpanded)}
                     aria-expanded={manageExpanded}
-                    className="w-full flex items-center gap-2 px-3 py-2.5 md:py-2 rounded-lg transition-colors min-h-[40px] md:min-h-[auto] bg-secondary text-white dark:text-gray-300 hover:bg-secondary dark:hover:bg-gray-800/50"
+                    className="w-full flex items-center gap-2 px-3 py-2.5 md:py-2 rounded-lg transition-colors h-12 md:h-auto bg-secondary text-white dark:text-gray-300 hover:bg-secondary dark:hover:bg-gray-800/50"
                   >
                     <SettingsIcon size={18} />
                     <span className="flex-1 text-sm text-left">Manage</span>
@@ -744,7 +770,7 @@ export default function Layout(): React.JSX.Element {
                   <Link
                     to={isDemoModeRoutingEnabled ? '/settings?demo=true' : '/settings'}
                     onClick={() => setSettingsExpanded(!settingsExpanded)}
-                    className="w-full flex items-center gap-2 px-3 py-2.5 md:py-2 rounded-lg transition-colors min-h-[40px] md:min-h-[auto] bg-secondary text-white dark:text-gray-300 hover:bg-secondary dark:hover:bg-gray-800/50"
+                    className="w-full flex items-center gap-2 px-3 py-2.5 md:py-2 rounded-lg transition-colors h-12 md:h-auto bg-secondary text-white dark:text-gray-300 hover:bg-secondary dark:hover:bg-gray-800/50"
                   >
                     <SettingsIcon size={18} />
                     <span className="flex-1 text-sm text-left">Settings</span>

--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -132,9 +132,17 @@ export default function MarkdownEditor({
       {/* Toolbar */}
       <div className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 px-3 py-2 border-b border-gray-300 dark:border-gray-600">
         <div className="flex items-center gap-1">
+          {/* type="button" on every control in here, and it is load-bearing:
+              this editor lives INSIDE other components' <form>s (the
+              transaction editor's Notes field), where an untyped <button>
+              defaults to type="submit". Tapping Bold then SAVED AND CLOSED the
+              whole form around it — on a phone it read as "the page froze and
+              kicked me back" (owner, 21 Aug), because the save's await is the
+              freeze and the modal closing is the kick. */}
           {formatButtons.map((button, index) => (
             <button
               key={index}
+              type="button"
               onClick={button.action}
               title={button.title}
               className="p-1.5 hover:bg-gray-200 dark:hover:bg-gray-700 rounded text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200"
@@ -147,6 +155,7 @@ export default function MarkdownEditor({
         {showPreview && (
           <div className="flex items-center gap-1">
             <button
+              type="button"
               onClick={() => setIsPreviewMode(false)}
               className={`p-1.5 rounded text-sm ${
                 !isPreviewMode 
@@ -157,6 +166,7 @@ export default function MarkdownEditor({
               <EditIcon size={14} />
             </button>
             <button
+              type="button"
               onClick={() => setIsPreviewMode(true)}
               className={`p-1.5 rounded text-sm ${
                 isPreviewMode 

--- a/src/components/__tests__/EditTransactionModal.test.tsx
+++ b/src/components/__tests__/EditTransactionModal.test.tsx
@@ -101,3 +101,60 @@ describe('EditTransactionModal — the amount wears the flow, not the field sign
     expect(amountInput().className).toContain('text-green-600');
   });
 });
+
+/**
+ * EVERY GUEST CONTROL DECLARES WHAT IT IS (owner, 21 Aug).
+ *
+ * An untyped <button> inside a <form> is type="submit". The Notes editor's
+ * toolbar and the attachments block are shared components that guest inside
+ * this form, and their untyped buttons made NINE extra submitters — so tapping
+ * Bold, or Attach, SAVED THE TRANSACTION AND CLOSED THE EDITOR. On a phone it
+ * presented as "the page freezes and then kicks me back to the register":
+ * the freeze was the save's await, the kick was the modal closing.
+ *
+ * The guard reads the rendered DOM rather than the source, so a NEW guest
+ * component with the same flaw fails it too. Submitting is reserved for the
+ * buttons that say Save.
+ */
+describe('EditTransactionModal — only the Save buttons may submit', () => {
+  const ACCOUNT: Account = {
+    id: 'acc-guard', name: 'Synthetic Current', type: 'current', balance: 0,
+    currency: 'GBP', lastUpdated: new Date('2026-01-01'), openingBalance: 0, isActive: true,
+  };
+  const ROW: Transaction = {
+    id: 'txn-guard-0', date: new Date(Date.UTC(2026, 0, 5)),
+    description: 'Synthetic row', amount: -12, type: 'expense',
+    category: '', accountId: ACCOUNT.id, cleared: false,
+  };
+
+  it('every submit-typed button in the form is a Save action', () => {
+    renderWithProviders(
+      <EditTransactionModal isOpen onClose={vi.fn()} transaction={ROW} />,
+      { initialState: { accounts: [ACCOUNT], transactions: [ROW] } }
+    );
+
+    const form = screen.getByRole('dialog').querySelector('form');
+    if (!form) throw new Error('the editor did not render its form');
+
+    const strays = Array.from(form.querySelectorAll('button'))
+      .filter((b): b is HTMLButtonElement => b instanceof HTMLButtonElement)
+      .filter(b => b.type === 'submit')
+      .filter(b => !/save/i.test(`${b.textContent ?? ''} ${b.title}`));
+
+    expect(
+      strays.map(b => b.title || b.getAttribute('aria-label') || b.textContent?.trim() || '(unnamed)')
+    ).toEqual([]);
+  });
+
+  it('tapping a Notes toolbar control edits the note — it does not close the editor', () => {
+    const onClose = vi.fn();
+    renderWithProviders(
+      <EditTransactionModal isOpen onClose={onClose} transaction={ROW} />,
+      { initialState: { accounts: [ACCOUNT], transactions: [ROW] } }
+    );
+
+    fireEvent.click(screen.getByTitle('Bold'));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -223,6 +223,14 @@ export interface AppContextType extends AppState {
   lastSyncTime: Date | null;
   syncError: string | null;
   /**
+   * The boot's transaction read failed and the list in state is its fallback
+   * (usually empty), NOT the ledger. Anything about to assert "there are no
+   * transactions" — an empty register, a zeroed report — must check this
+   * first and say "couldn't load" instead: presenting an unreadable ledger as
+   * an empty one tells a user their money is gone.
+   */
+  transactionsLoadFailed: boolean;
+  /**
    * What the store behind this app can do — the seam's own descriptor, surfaced
    * here so a component can read it without importing the seam.
    *
@@ -484,6 +492,20 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const [lastSyncTime, setLastSyncTime] = useState<Date | null>(null);
   const [syncError, setSyncError] = useState<string | null>(null);
   /**
+   * Did the boot's TRANSACTION read fail? — distinct from `syncError`, which
+   * only speaks when the accounts failed too and the whole app falls back.
+   *
+   * The seam's floor for a failed transaction read is "an empty register
+   * beside a working account list" (loadBoot never rejects), and that floor
+   * needs a flag or it is indistinguishable from a genuinely empty ledger:
+   * without one, a single timed-out page out of fifty booted the app into
+   * every register claiming "No transactions in this account yet" over
+   * accounts that are full. Consumers that would ASSERT emptiness (the
+   * register's empty state) must consult this and say "couldn't load" with a
+   * retry instead. Set once per boot from the stats the seam already reports.
+   */
+  const [transactionsLoadFailed, setTransactionsLoadFailed] = useState(false);
+  /**
    * What the store can do, asked ONCE PER BOOT and held in state.
    *
    * State rather than a call in the render body, because the answer changing is
@@ -668,6 +690,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         setAccounts(boot.accounts);
         setCategories(boot.categories);
         setTransactions(boot.transactions);
+        setTransactionsLoadFailed(boot.transactionStats.fullFetchReason === 'load failed');
         setTransactionSplitsState(boot.splits);
         setBudgets(boot.budgets);
         setGoals(boot.goals);
@@ -2339,6 +2362,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     isLoading,
     lastSyncTime,
     syncError,
+    transactionsLoadFailed,
     capabilities,
     refreshAccountsAndTransactions,
     refreshCategories,

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -372,7 +372,7 @@ export default function AccountTransactions() {
    */
   const backTo = readProvenance(location.state);
   const {
-    accounts, transactions, categories, isLoading,
+    accounts, transactions, categories, isLoading, transactionsLoadFailed,
     deleteTransaction, addTransaction, updateAccount, updateTransaction,
     // The dock's Txfr path writes BOTH legs: the row, then the one operation
     // that turns it into a linked pair. See commitQuickAdd.
@@ -3067,6 +3067,20 @@ export default function AccountTransactions() {
    * them back by name, and the one control that lets go.
    */
   const registerEmptyState = fullAccountTransactions.length === 0 ? (
+    transactionsLoadFailed ? (
+      // A THIRD case, and it outranks the other two: the boot's transaction
+      // read failed, so an empty list here is the FALLBACK, not the ledger.
+      // Asserting "no transactions yet" over a full account is the same lie
+      // the filtered empty state exists to prevent — "your money is gone" —
+      // told by a network failure instead of a filter. Consequence first,
+      // then the remedy; the remedy is a reload because the retry that can
+      // fix a failed boot is the boot.
+      <EmptyState
+        title="This account's transactions couldn't be loaded"
+        description="The last load didn't finish, so this register can't say what's in the account — nothing is missing from your ledger, it just couldn't be read this time. Trying again reloads the app."
+        action={{ label: 'Try again', onClick: () => window.location.reload() }}
+      />
+    ) : (
     <EmptyState
       title="No transactions in this account yet"
       description={`Its balance stays at ${formatRegisterMoney(computedAccountBalance)}, and this account adds nothing to your reports until something lands here. Nothing is estimated, so nothing appears until you add it.`}
@@ -3076,6 +3090,7 @@ export default function AccountTransactions() {
         onClick: () => navigate(preserveDemoParam('/enhanced-import', location.search))
       }}
     />
+    )
   ) : (
     <FilteredEmptyState
       hiddenCount={fullAccountTransactions.length}

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -313,7 +313,19 @@ function AccountsList() {
    * and a light that is always on is not a signal. The banded list behind it
    * already says the list is banded.
    */
-  const [showMoreControls, setShowMoreControls] = useState(false);
+  /**
+   * NULL UNTIL THE USER TOUCHES THE SWITCH — the default is decided by the
+   * page, not stored here. Folded away is the right default only while there
+   * is nothing behind the fold that demands attention; the moment there is (a
+   * broken feed, rows to review, accounts to reconcile), a drawer that opens
+   * shut is a drawer hiding an alarm, and the owner's report says what that
+   * costs: "unless the user does it manually, they could easily miss that
+   * there are things that need their attention" (21 Aug). So the resolved
+   * value lives below the three signals it reads, and this state records only
+   * an explicit choice — which then wins in both directions, because a person
+   * who folded the drawer over a live warning has seen the warning.
+   */
+  const [moreControlsChoice, setMoreControlsChoice] = useState<boolean | null>(null);
   const controlsId = useId();
   const groupPanelId = `${controlsId}-group`;
   const feedPanelId = `${controlsId}-feeds`;
@@ -781,6 +793,13 @@ function AccountsList() {
     ).length,
     [topLevelAccounts, nestedByParent, getUnreconciledCount]
   );
+
+  // The phone's "More" drawer opens ITSELF while anything behind it needs
+  // attention — the same three signals the buttons inside it wear amber for.
+  // Derived, not effect-set: the signals arrive as data loads, and a default
+  // written into state once at mount would be computed from an empty ledger.
+  const showMoreControls = moreControlsChoice
+    ?? (feedsNeedingAttention > 0 || reviewTotal > 0 || reconcileAccountCount > 0);
 
   /** Which job the page is focused on, or null for the ordinary list. */
   const [focusMode, setFocusMode] = useState<'review' | 'reconcile' | null>(null);
@@ -2727,7 +2746,7 @@ function AccountsList() {
               filter's own hidden label). */}
           <button
             type="button"
-            onClick={() => setShowMoreControls(prev => !prev)}
+            onClick={() => setMoreControlsChoice(!showMoreControls)}
             aria-expanded={showMoreControls}
             aria-controls={`${groupPanelId} ${feedPanelId}`}
             className="sm:hidden shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors"

--- a/src/pages/__tests__/AccountTransactions.registerChrome.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.registerChrome.test.tsx
@@ -229,6 +229,29 @@ describe('a register with nothing in it', () => {
   });
 });
 
+describe('a register the boot could not read is not an empty register', () => {
+  // The seam's floor for a failed transaction read is an empty list beside a
+  // working account list (loadBoot never rejects). Without this state the
+  // register asserted "No transactions in this account yet" over a FULL
+  // account every time one page of the boot download timed out — the same
+  // "your money is gone" lie the filtered empty state exists to prevent,
+  // told by the network instead of a filter.
+  it('says the load failed and offers a retry, not a beginning', async () => {
+    __setAppContextValue({ transactionsLoadFailed: true });
+    renderRegister([]);
+    await screen.findByRole('heading', { level: 1, name: 'Synthetic Chrome' });
+
+    const scope = within(grid());
+    expect(scope.getByRole('heading', { level: 3, name: "This account's transactions couldn't be loaded" })).toBeInTheDocument();
+    // The consequence, then the reassurance: the rows exist, they were not read.
+    expect(scope.getByText(/nothing is missing from your ledger/)).toBeInTheDocument();
+    expect(scope.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
+    // The two claims this state must NOT make: a beginning, or its remedies.
+    expect(scope.queryByRole('heading', { name: 'No transactions in this account yet' })).not.toBeInTheDocument();
+    expect(scope.queryByRole('button', { name: 'Add transaction' })).not.toBeInTheDocument();
+  });
+});
+
 describe('a register emptied by a filter is not an empty register', () => {
   const searchFor = (term: string): void => {
     fireEvent.click(screen.getByRole('button', { name: /Search & filters/ }));

--- a/src/pages/__tests__/Accounts.toReview.test.tsx
+++ b/src/pages/__tests__/Accounts.toReview.test.tsx
@@ -18,7 +18,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, within, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { PreferencesProvider } from '../../contexts/PreferencesContext';
 import { ToastProvider } from '../../contexts/ToastContext';
@@ -206,6 +206,56 @@ describe('Accounts list — the To Review column', () => {
     expect(clear?.className).not.toContain('text-blue-600');
     expect(clear?.className).toContain('text-gray-400');
     expect(clear?.className).toContain('font-normal');
+  });
+});
+
+describe('the phone’s More drawer opens itself over a live warning', () => {
+  // The drawer folds away Refresh feeds, the Bank connections button and the
+  // Review/Reconcile control. Folded is the right default only while none of
+  // them has anything to say — "unless the user does it manually, they could
+  // easily miss that there are things that need their attention" (owner,
+  // 21 Aug). aria-expanded is the state's own voice, so it is what is pinned.
+  const moreButton = (): HTMLElement =>
+    screen.getByRole('button', { name: /More controls/ });
+
+  it('defaults open while transactions are waiting for review', async () => {
+    __setAppContextValue({
+      accounts: [NATWEST],
+      transactions: [row('t1', NATWEST.id, { needsReview: true })],
+      isLoading: false,
+    });
+
+    renderAccounts();
+    await screen.findByRole('heading', { level: 3, name: 'Synthetic Natwest' });
+
+    expect(moreButton()).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('defaults folded when nothing needs attention', async () => {
+    __setAppContextValue({
+      accounts: [NATWEST],
+      transactions: [row('t1', NATWEST.id, { needsReview: false })],
+      isLoading: false,
+    });
+
+    renderAccounts();
+    await screen.findByRole('heading', { level: 3, name: 'Synthetic Natwest' });
+
+    expect(moreButton()).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('an explicit fold wins over the warning — the person has seen it', async () => {
+    __setAppContextValue({
+      accounts: [NATWEST],
+      transactions: [row('t1', NATWEST.id, { needsReview: true })],
+      isLoading: false,
+    });
+
+    renderAccounts();
+    await screen.findByRole('heading', { level: 3, name: 'Synthetic Natwest' });
+
+    fireEvent.click(moreButton());
+    expect(moreButton()).toHaveAttribute('aria-expanded', 'false');
   });
 });
 

--- a/src/services/__tests__/transactionService.test.ts
+++ b/src/services/__tests__/transactionService.test.ts
@@ -656,6 +656,38 @@ describe('TransactionService (deterministic fallback)', () => {
       expect(logger.error).toHaveBeenCalled();
     });
 
+    it('says `load failed` out loud when the full download itself fails', async () => {
+      // The full fetch used to route through getTransactions, whose catch
+      // swallows a failure into the localStorage fallback — on a big ledger,
+      // usually EMPTY. The boot then finished with 0 transactions and a reason
+      // ('no cache') that read as success, so every register asserted "No
+      // transactions in this account yet" over accounts that are full. The
+      // boot path now reports the failure in its stats; the app refuses to
+      // present the unreadable ledger as an empty one.
+      const alwaysFailing = {
+        from: vi.fn(() => {
+          const builder: Record<string, unknown> = {};
+          builder.select = vi.fn(() => builder);
+          builder.eq = vi.fn(() => builder);
+          builder.gte = vi.fn(() => builder);
+          builder.order = vi.fn(() => builder);
+          builder.range = vi.fn(() => builder);
+          builder.then = (resolve: (value: unknown) => unknown) =>
+            resolve({ data: null, count: null, error: { message: 'network down' } });
+          return builder;
+        })
+      };
+      const { cache, writes } = createCache(null);
+
+      const result = await build(alwaysFailing, cache).loadTransactionsForBoot('user-1');
+
+      expect(result.transactions).toEqual([]);
+      expect(result.stats).toEqual({ cached: 0, fetched: 0, total: 0, fullFetchReason: 'load failed' });
+      // No snapshot of a failure: the next boot must try the server again.
+      expect(writes).toHaveLength(0);
+      expect(logger.error).toHaveBeenCalled();
+    });
+
     it('asks for a window that reaches back before the high-water mark', async () => {
       // updated_at is stamped with the writing transaction's START time, so a
       // strict "newer than the mark" filter would miss a write that began

--- a/src/services/api/transactionService.ts
+++ b/src/services/api/transactionService.ts
@@ -669,39 +669,54 @@ class TransactionServiceImpl {
     }
 
     try {
-      // A full Money-era history of 50k+ rows is 50+ pages. Pages are fetched
-      // IN PARALLEL (count first, bounded concurrency); sequential paging made
-      // every app load a ~50-round-trip wait.
-      const count = await this.countTransactions(userId);
-
-      const pages = Math.ceil(count / PAGE_SIZE);
-      const results: Record<string, unknown>[][] = new Array<Record<string, unknown>[]>(pages);
-      let nextPage = 0;
-      const worker = async (): Promise<void> => {
-        for (;;) {
-          const i = nextPage++;
-          if (i >= pages) return;
-          results[i] = await this.fetchTransactionPage(userId, i * PAGE_SIZE);
-        }
-      };
-      await Promise.all(Array.from({ length: Math.min(PAGE_CONCURRENCY, pages) }, worker));
-
-      const rows = results.flat();
-      // Rows inserted between the count and the page fetches land past the
-      // last page — keep the old sequential tail walk for that (rare) case.
-      if (pages > 0 && (results[pages - 1]?.length ?? 0) === PAGE_SIZE) {
-        for (let from = pages * PAGE_SIZE; ; from += PAGE_SIZE) {
-          const tail = await this.fetchTransactionPage(userId, from);
-          rows.push(...tail);
-          if (tail.length < PAGE_SIZE) break;
-        }
-      }
-
-      return this.toTransactions(rows);
+      return await this.fetchAllTransactions(userId);
     } catch (error) {
       this.logger.error('TransactionService.getTransactions error:', error as Error);
       return this.readStoredTransactions();
     }
+  }
+
+  /**
+   * The full download, and it THROWS when it cannot deliver it.
+   *
+   * `getTransactions` swallows this into the stored fallback, which is the
+   * right floor for a mid-session refresh — but on a 50k-row ledger the
+   * localStorage fallback is usually EMPTY, so at boot that swallow turned
+   * "one page of fifty timed out" into "you have no transactions", with
+   * nothing anywhere saying a load had failed. The boot path calls this raw
+   * form instead and reports the failure in its stats, so the app can refuse
+   * to present an unreadable ledger as an empty one.
+   */
+  private async fetchAllTransactions(userId: string): Promise<Transaction[]> {
+    // A full Money-era history of 50k+ rows is 50+ pages. Pages are fetched
+    // IN PARALLEL (count first, bounded concurrency); sequential paging made
+    // every app load a ~50-round-trip wait.
+    const count = await this.countTransactions(userId);
+
+    const pages = Math.ceil(count / PAGE_SIZE);
+    const results: Record<string, unknown>[][] = new Array<Record<string, unknown>[]>(pages);
+    let nextPage = 0;
+    const worker = async (): Promise<void> => {
+      for (;;) {
+        const i = nextPage++;
+        if (i >= pages) return;
+        results[i] = await this.fetchTransactionPage(userId, i * PAGE_SIZE);
+      }
+    };
+    await Promise.all(Array.from({ length: Math.min(PAGE_CONCURRENCY, pages) }, worker));
+
+    const rows = results.flat();
+    // Rows inserted between the count and the page fetches land past the
+    // last page — keep the old sequential tail walk for that (rare) case.
+    if (pages > 0 && (results[pages - 1]?.length ?? 0) === PAGE_SIZE) {
+      for (let from = pages * PAGE_SIZE; ; from += PAGE_SIZE) {
+        const tail = await this.fetchTransactionPage(userId, from);
+        rows.push(...tail);
+        if (tail.length < PAGE_SIZE) break;
+      }
+    }
+
+    return this.toTransactions(rows);
   }
 
   /**
@@ -787,7 +802,23 @@ class TransactionServiceImpl {
       }
     }
 
-    const rows = await this.getTransactions(userId);
+    let rows: Transaction[];
+    try {
+      rows = await this.fetchAllTransactions(userId);
+    } catch (error) {
+      // The floor `getTransactions` keeps, with the failure SAID rather than
+      // swallowed: stored rows if there are any, and `load failed` in the
+      // stats either way. On a big ledger the stored fallback is usually
+      // empty, and an empty ledger the app cannot vouch for must not boot
+      // looking like a ledger with nothing in it — every register would offer
+      // "No transactions in this account yet" for accounts that are full.
+      this.logger.error('TransactionService boot full fetch failed:', error as Error);
+      const stored = await this.readStoredTransactions();
+      return {
+        transactions: stored,
+        stats: { cached: 0, fetched: 0, total: stored.length, fullFetchReason: 'load failed' }
+      };
+    }
     // Deliberately not awaited: the snapshot write is a structured clone of the
     // whole history and the app has everything it needs without it. A failure
     // is swallowed inside the cache — an unwritable cache costs speed, nothing

--- a/src/test/mocks/AppContextSupabase.ts
+++ b/src/test/mocks/AppContextSupabase.ts
@@ -77,6 +77,9 @@ const baseValue = {
   customReports: [],
   tags: [],
   isLoading: false,
+  // False here means "the boot delivered the ledger" — the healthy state every
+  // suite assumes. The register's couldn't-load state flips it on explicitly.
+  transactionsLoadFailed: false,
   capabilities: deviceCapabilities,
   resetLoadedData: asyncNoop,
   exportData: () => JSON.stringify({ accounts, transactions, budgets, goals, categories }),


### PR DESCRIPTION
Five owner reports from the phone (21 Aug), each diagnosed to its mechanism and pinned by a test or a measured comment.

## 1. The drawer's grouped headings sat at three different heights
Accounts measured 48px, Plan/Manage 44, Settings 40. The touch hit-area block's `button:not(.toggle-switch)` (specificity 0,1,1) beats a Tailwind min-h utility (0,1,0), so the two `<button>` rows were pinned at 44 while the `<a>` rows obeyed their `min-h-[40px]` — and Accounts' nested chevron button pushed its row to 48 naturally. All four now state `h-12` outright: used height = max(height, min-height) lands 48 on both element kinds. Measured 48/48/48/48 after the change.

## 2. "WealthTracker" behind the phone's clock
The drawer is `inset-0`, so its header started under the status bar on an installed home-screen app. It now stands off by `TOP_CHROME_OFFSET` — the same constant both fixed headers already use.

## 3. The "More" fold hid live warnings
Refresh feeds, Bank connections and the Review/Reconcile control folded away unconditionally. The default is now derived from the same three signals those controls wear amber for — a broken feed, rows to review, accounts to reconcile. Any of them live → the drawer opens itself; an explicit fold still wins (the person has seen the warning). State records only the user's choice, so the default is computed from the loaded ledger, not the empty one at mount. Three specs pin it.

## 4. "No transactions in this account yet" over a full account
The boot's full transaction download failure was swallowed into the (usually empty) localStorage fallback and reported as success, so one timed-out page out of fifty booted the app into every register asserting emptiness. The boot path now catches the raw fetch and says `load failed` in its stats; the context surfaces `transactionsLoadFailed`; and the register's empty state refuses to assert a beginning it cannot vouch for — it names the failed load and offers Try again. Service spec + register spec added.

## 5. "The page freezes and then kicks me back to the register"
Nine untyped `<button>`s inside the transaction editor's `<form>` — the Notes toolbar, its preview toggles, and the attachments block's Attach — were all `type="submit"`, so a stray tap SAVED THE TRANSACTION AND CLOSED THE EDITOR: the save's await was the freeze, the modal closing was the kick. Every guest control (MarkdownEditor ×8, DocumentManager ×14, DocumentUpload ×9) now declares `type="button"`, and a rendered-DOM guard pins that the form's only submitters are the Save buttons — proven non-vacuous by stripping one fix and watching it fail.

Every figure in the new tests is invented; the repo is public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)