### PR TITLE
fix(mobile): the editor 'freeze and kick-back' was the app's own pull-to-refresh — and the Accounts chevron lands where its siblings land

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -675,7 +675,17 @@ export default function Layout(): React.JSX.Element {
                       }}
                       aria-expanded={accountsExpanded}
                       aria-label={accountsExpanded ? 'Hide the Accounts pages' : 'Show the Accounts pages'}
-                      className="p-2 -m-2 rounded-lg"
+                      // The icon must LAND where the other headings' bare
+                      // chevrons land: at the row's px-3 content edge. The
+                      // touch rule holds this button at 44px wide and the old
+                      // `p-2 -m-2` centred the icon in that box, which put it
+                      // 7px left of its three siblings (owner, 21 Aug). So the
+                      // icon is right-aligned inside the button instead:
+                      // -mr-3 walks the border box out to the ROW's edge and
+                      // pr-3 walks the icon back in by the same 12px — the
+                      // row's own padding, restated, not a tuned offset. The
+                      // vertical pair still cancels so the row stays 48px.
+                      className="inline-flex items-center justify-end py-2 -my-2 pl-2 pr-3 -mr-3 rounded-lg"
                     >
                       <ChevronRightIcon
                         size={14}

--- a/src/hooks/__tests__/usePullToRefresh.test.ts
+++ b/src/hooks/__tests__/usePullToRefresh.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePullToRefresh } from '../usePullToRefresh';
+
+/**
+ * THE PULL MUST NOT FIRE THROUGH AN OPEN DIALOG (owner, 21 Aug).
+ *
+ * The gesture's "am I at the top of the page?" guard reads `window.scrollY` —
+ * and the shared Modal pins the body (`position: fixed`, top -scrollY) while a
+ * dialog is open, which holds scrollY at 0 for the whole of it. So every touch
+ * inside the transaction editor was a pull candidate: scrolling UP at its
+ * bottom first had its scroll eaten by the hook's preventDefault ("the page
+ * freezes") and the release then reloaded the app out from under the editor
+ * ("refreshes the page and kicks me back to the register"). Reproduced in an
+ * installed app on a simulator — the WebContent process never died; this hook
+ * was the whole of the 'crash'.
+ *
+ * The events below are plain Events carrying a `touches` array, which is all
+ * the hook reads. `reload` is injected so a firing pull is observable without
+ * jsdom navigation.
+ */
+
+const touchEvent = (
+  type: 'touchstart' | 'touchmove' | 'touchend',
+  clientY?: number
+): Event => {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'touches', {
+    value: clientY === undefined ? [] : [{ clientY }],
+  });
+  return event;
+};
+
+/** A full pull gesture: down 400px from the top of the screen, then release. */
+const pullDown = (): void => {
+  act(() => {
+    window.dispatchEvent(touchEvent('touchstart', 100));
+  });
+  act(() => {
+    window.dispatchEvent(touchEvent('touchmove', 500));
+  });
+  act(() => {
+    window.dispatchEvent(touchEvent('touchend'));
+  });
+};
+
+describe('usePullToRefresh — an open dialog owns the screen', () => {
+  let matchMediaSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // The hook only arms in an installed app.
+    matchMediaSpy = vi.spyOn(window, 'matchMedia').mockImplementation(
+      (query: string) =>
+        ({
+          matches: query === '(display-mode: standalone)',
+          media: query,
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          addListener: () => {},
+          removeListener: () => {},
+          onchange: null,
+          dispatchEvent: () => false,
+        }) as unknown as MediaQueryList
+    );
+  });
+
+  afterEach(() => {
+    matchMediaSpy.mockRestore();
+    document.body.style.position = '';
+  });
+
+  it('a pull on an ordinary page reloads — the gesture the installed app exists for', () => {
+    const reload = vi.fn();
+    renderHook(() => usePullToRefresh(reload));
+
+    pullDown();
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('the same pull with the body scroll-locked does nothing — that is a dialog, not a page top', () => {
+    const reload = vi.fn();
+    document.body.style.position = 'fixed';
+    renderHook(() => usePullToRefresh(reload));
+
+    pullDown();
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('a scroll-locked drag keeps its default — the dialog scrolls instead of freezing', () => {
+    const reload = vi.fn();
+    document.body.style.position = 'fixed';
+    renderHook(() => usePullToRefresh(reload));
+
+    act(() => {
+      window.dispatchEvent(touchEvent('touchstart', 100));
+    });
+    const move = touchEvent('touchmove', 500);
+    act(() => {
+      window.dispatchEvent(move);
+    });
+
+    // The old behaviour: preventDefault on this event, which ATE the modal
+    // body's own scroll — the reported "freeze" before the reload.
+    expect(move.defaultPrevented).toBe(false);
+  });
+});

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -90,6 +90,22 @@ export function usePullToRefresh(reload: () => void = () => window.location.relo
         startY.current = null;
         return;
       }
+      // A SCROLL-LOCKED BODY IS NOT A PAGE AT ITS TOP. The shared Modal pins
+      // the body (`position: fixed`, top -scrollY) while a dialog is open, and
+      // scrollY reads 0 for the whole of that — not because the user is at the
+      // top of the page but because there is no scrollable page. Without this
+      // guard every touch inside an open dialog was a pull candidate: scrolling
+      // UP at the bottom of Edit Transaction first had its scroll eaten by the
+      // preventDefault below (reported as "the page freezes") and the release
+      // then reloaded the app out from under the editor ("refreshes the page
+      // and kicks me back to the register" — owner, 21 Aug, reproduced in the
+      // installed app on a simulator; the WebContent process never died, this
+      // listener was the whole of the 'crash'). While an overlay owns the
+      // screen there is nothing here to refresh.
+      if (document.body.style.position === 'fixed') {
+        startY.current = null;
+        return;
+      }
       startY.current = event.touches[0].clientY;
       engaged.current = false;
     };


### PR DESCRIPTION
Two phone reports (21 Aug), the first with a diagnosis that overturned the working theory.

## 1. The Edit Transaction "crash" was never a crash

Reproduced in an **installed home-screen app on an iOS simulator** (50k-row demo ledger): scroll the editor to its bottom, scroll back up → the page "freezes", then reloads back to the register — the owner's report, twice for twice. The WebContent process kept the same PID through every occurrence: nothing crashed, something **navigated**.

The navigator was `usePullToRefresh` (added 13 Aug so an installed app can escape a stale build). Its "at the top of the page" guard reads `window.scrollY` — and the shared Modal pins the body (`position: fixed`, `top: -scrollY`) while a dialog is open, holding `scrollY` at 0 throughout. So every touch inside the editor was a pull candidate: an upward scroll (finger moving down) first had its scroll eaten by the hook's `preventDefault` (**the freeze**), and the release fired `location.reload()` (**the refresh and kick-back**). Installed app + touch + open dialog only — which is why Safari tabs, desktop, Chromium and every jsdom suite stayed green while the owner hit it every time.

**Fix**: the pull stands down while the body is scroll-locked — a locked body is an overlay owning the screen, not a page at its top. Verified in the simulator: the exact gesture that reloaded the app twice-for-twice before the change survives it twice-for-twice after, including the strongest trigger (a full downward drag with the modal body at its top), and the modal scrolls instead of freezing. Pull-to-refresh on ordinary pages is untouched.

Three hook specs pin it (ordinary page still reloads; locked body does nothing; the drag keeps its default so the dialog scrolls) — proven non-vacuous by stripping the guard and watching two of them fail.

## 2. The drawer's Accounts chevron sat ~7px left of its siblings

The touch rule holds its hit-area button at 44px wide, and `p-2 -m-2` centred the 14px icon in that box. The icon is now right-aligned inside the button — `pr-3` walks it back in by exactly the row's own `px-3` — so it lands where the siblings' bare chevrons land. Measured: all four icons' right edges agree to the pixel.

Every figure in the tests is invented; the repo is public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)