### PR TITLE
design(aug22): arrows agree with their figures via ONE rule, Budget's empty page is an empty state, and a cash-only ring becomes a sentence

### DIFF
--- a/src/components/TrendArrow.tsx
+++ b/src/components/TrendArrow.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { TrendingUpIcon, TrendingDownIcon } from './icons';
+
+/**
+ * The direction beside a figure — and the ONE component that decides when a
+ * direction may render at all.
+ *
+ * The rule it holds (Claude Design, 16 Aug, restated 22 Aug when it turned out
+ * to have been copied rather than shared): a zero has no direction, so at zero
+ * — or with nothing to measure — NOTHING renders. It took four surfaces
+ * re-deriving this by hand (the dashboard pair got it right, Budget's copies
+ * didn't, Investments' Return % wore a hard-coded down arrow beside a positive
+ * figure) before the rule got a home. New cards call this; they do not write
+ * their own conditional.
+ *
+ * Two kinds of direction, one prop apart:
+ *  - omit `direction` and the arrow follows the SIGN of the figure it sits
+ *    with — up and green for a gain, down and red for a loss. An arrow that
+ *    disagrees with its own figure's sign is answering a question the card
+ *    doesn't ask.
+ *  - pass `direction` for a FLOW arrow (income up, expenses down), where the
+ *    glyph names which way money moves and only the zero rule applies. These
+ *    exist because the owner asked for them by name on the dashboard pair.
+ */
+
+/** The one shape of Decimal this component needs to read a sign from. */
+interface SignReadable {
+  isZero(): boolean;
+  greaterThan(n: number): boolean;
+}
+
+interface TrendArrowProps {
+  /** The figure the arrow sits with. null, undefined or zero renders nothing. */
+  value: number | SignReadable | null | undefined;
+  /** Fixed flow direction. Omitted, the arrow follows the value's sign. */
+  direction?: 'up' | 'down';
+  size?: number;
+  className?: string;
+}
+
+const isZeroValue = (value: number | SignReadable): boolean =>
+  typeof value === 'number' ? value === 0 : value.isZero();
+
+const isPositive = (value: number | SignReadable): boolean =>
+  typeof value === 'number' ? value > 0 : value.greaterThan(0);
+
+export default function TrendArrow({
+  value,
+  direction,
+  size = 24,
+  className = '',
+}: TrendArrowProps): React.JSX.Element | null {
+  if (value === null || value === undefined || isZeroValue(value)) return null;
+
+  const up = direction ? direction === 'up' : isPositive(value);
+  const Icon = up ? TrendingUpIcon : TrendingDownIcon;
+  const colour = up ? 'text-green-500' : 'text-red-500';
+
+  return (
+    <Icon
+      size={size}
+      className={`${colour} flex-shrink-0 ${className}`.trim()}
+      aria-hidden="true"
+    />
+  );
+}

--- a/src/components/__tests__/TrendArrow.test.tsx
+++ b/src/components/__tests__/TrendArrow.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import TrendArrow from '../TrendArrow';
+import { toDecimal } from '../../utils/decimal';
+
+/**
+ * The one home of "no direction at zero" (Claude Design, 16 Aug; made shared
+ * 22 Aug after the fourth hand-rolled copy got it wrong). Every card that
+ * wants an arrow beside a figure calls this; these specs are the rule's own
+ * words, independent of any page.
+ */
+describe('TrendArrow — a zero has no direction', () => {
+  const svgOf = (ui: React.ReactElement): SVGElement | null =>
+    render(ui).container.querySelector('svg');
+
+  it('renders nothing at zero, for numbers and Decimals alike', () => {
+    expect(svgOf(<TrendArrow value={0} />)).toBeNull();
+    expect(svgOf(<TrendArrow value={toDecimal(0)} />)).toBeNull();
+  });
+
+  it('renders nothing when there is nothing to measure', () => {
+    expect(svgOf(<TrendArrow value={null} />)).toBeNull();
+    expect(svgOf(<TrendArrow value={undefined} />)).toBeNull();
+  });
+
+  it('follows the sign of the figure it sits with', () => {
+    // A positive figure may never wear a falling arrow — the finding that
+    // made this component (Return % at +18.25% with a down glyph).
+    expect(svgOf(<TrendArrow value={18.25} />)?.getAttribute('class')).toContain('text-green-500');
+    expect(svgOf(<TrendArrow value={toDecimal(-5)} />)?.getAttribute('class')).toContain('text-red-500');
+  });
+
+  it('a flow arrow keeps its stated direction but still yields to the zero rule', () => {
+    // Expenses point down even though spending is a positive figure…
+    expect(svgOf(<TrendArrow value={100} direction="down" />)?.getAttribute('class')).toContain('text-red-500');
+    // …and at zero the flow claim disappears with everything else.
+    expect(svgOf(<TrendArrow value={0} direction="down" />)).toBeNull();
+  });
+});

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -7,8 +7,6 @@ import { useNavigate, useLocation } from 'react-router-dom';
 // state layer's preamble away.
 import { useIdentityKey } from '@identity';
 import {
-  TrendingUpIcon,
-  TrendingDownIcon,
   AlertCircleIcon,
   ChevronRightIcon,
   WalletIcon,
@@ -23,6 +21,7 @@ import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import { preserveDemoParam } from '../../utils/navigation';
 import EmptyState from '../EmptyState';
 import FilteredEmptyState from '../FilteredEmptyState';
+import TrendArrow from '../TrendArrow';
 import { TableSkeleton, type TableSkeletonColumn } from '../loading/TableSkeleton';
 import { useDelayedFlag } from '../../hooks/useDelayedFlag';
 import EditTransactionModal from '../EditTransactionModal';
@@ -824,9 +823,11 @@ export function ImprovedDashboard() {
                 : 'text-green-600 dark:text-green-400'
             }`}>
               {formatCurrencyWithSymbol(performance.income)}
-              {performance.income !== 0 && (
-                <TrendingUpIcon size={20} className="text-green-500 flex-shrink-0" aria-hidden="true" />
-              )}
+              {/* Through the SHARED zero rule now. This pair got "no direction
+                  at zero" right first (16 Aug) — and then Budget's cards were
+                  found re-deriving it wrong, the fourth copy in one pass. The
+                  rule lives in TrendArrow; this is the reference call site. */}
+              <TrendArrow value={performance.income} direction="up" size={20} />
             </p>
           </button>
 
@@ -842,9 +843,7 @@ export function ImprovedDashboard() {
                 : 'text-red-600 dark:text-red-400'
             }`}>
               {formatCurrencyWithSymbol(performance.expenses)}
-              {performance.expenses !== 0 && (
-                <TrendingDownIcon size={20} className="text-red-500 flex-shrink-0" aria-hidden="true" />
-              )}
+              <TrendArrow value={performance.expenses} direction="down" size={20} />
             </p>
           </button>
         </div>

--- a/src/pages/Budget.tsx
+++ b/src/pages/Budget.tsx
@@ -1,9 +1,12 @@
 import { useState, useMemo, useEffect, useCallback } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { preserveDemoParam } from '../utils/navigation';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { useNotifications } from '../contexts/NotificationContext';
 import { useToast } from '../contexts/ToastContext';
-import { TrendingUpIcon, TrendingDownIcon, BanknoteIcon, RepeatIcon, PiggyBankIcon, ArrowRightIcon, BellIcon, CalculatorIcon } from '../components/icons';
+import { BanknoteIcon, RepeatIcon, PiggyBankIcon, ArrowRightIcon, BellIcon, CalculatorIcon } from '../components/icons';
+import TrendArrow from '../components/TrendArrow';
 import { EditIcon, DeleteIcon } from '../components/icons';
 import { IconButton } from '../components/icons/IconButton';
 import BudgetModal from '../components/BudgetModal';
@@ -17,6 +20,7 @@ import { getEffectiveBudgetAmount } from '../utils/budgetAmounts';
 import PageWrapper from '../components/PageWrapper';
 import { WholePoundsScope, WholePoundsToggle } from '../contexts/WholePoundsContext';
 import PageTip from '../components/PageTip';
+import EmptyState from '../components/EmptyState';
 import { calculateBudgetPercentage } from '../utils/calculations-decimal';
 import {
   buildCategoryChildIndex,
@@ -42,6 +46,8 @@ export default function Budget() {
 }
 
 function BudgetView() {
+  const navigate = useNavigate();
+  const location = useLocation();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingBudget, setEditingBudget] = useState<Budget | null>(null);
   const [activeTab, setActiveTab] = useState<'traditional' | 'envelope' | 'templates' | 'rollover' | 'alerts' | 'zero-based'>('traditional');
@@ -244,7 +250,7 @@ function BudgetView() {
   };
 
   // Calculate totals with memoization
-  const { totalBudgeted, totalSpent, totalRemaining, totalRemainingValue } = useMemo(() => {
+  const { totalBudgeted, totalSpent, totalSpentValue, totalRemaining, totalRemainingValue } = useMemo(() => {
     const active = budgetsWithSpent.filter(b => b && b.isActive !== false);
     // Summed from exactly what the cards show — the effective amount (plan plus
     // carry) and the same spend — so the header can never contradict them.
@@ -255,6 +261,7 @@ function BudgetView() {
     return {
       totalBudgeted: formatCurrency(budgeted),
       totalSpent: formatCurrency(spent),
+      totalSpentValue: spent.toNumber(),
       totalRemaining: formatCurrency(remaining),
       totalRemainingValue: remaining.toNumber()
     };
@@ -368,7 +375,13 @@ function BudgetView() {
       {/* Tab Content */}
       {activeTab === 'traditional' && (
         <div className="grid gap-6">
-        {/* Summary Cards */}
+        {/* Summary Cards — HIDDEN WHILE THERE ARE NO BUDGETS (Claude Design,
+            22 Aug §3). Three £0.00 cards above "no budgets yet" are furniture
+            for data that isn't there — the same finding as the column strip
+            over an empty table, and the empty state below should be the first
+            thing the page says. Skeletons still show while loading, because a
+            loading page doesn't yet know it is empty. */}
+        {(isLoading || budgets.length > 0) && (
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
           <div className="flex items-center justify-between">
@@ -391,7 +404,12 @@ function BudgetView() {
                 {isLoading ? <SkeletonText className="w-32 h-8" /> : totalSpent}
               </p>
             </div>
-            <TrendingDownIcon className="text-red-500" size={24} />
+            {/* Through the shared rule, not a copy of it: this was an
+                unconditional red falling arrow, so £0.00 spent wore a claim
+                of money going out — the dashboard's 16 Aug zero-arrow fix
+                landing on one surface and not its sibling (Claude Design,
+                22 Aug §2). Flow direction: spending points down. */}
+            <TrendArrow value={totalSpentValue} direction="down" size={24} />
           </div>
         </div>
 
@@ -399,16 +417,22 @@ function BudgetView() {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-gray-600 dark:text-gray-400 text-body">Total Remaining</p>
+              {/* Neutral at zero: £0.00 remaining in green "reads as good news
+                  on a page where nothing has been set up" (§2). */}
               <p className={`text-page font-bold ${
-                totalRemainingValue >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+                totalRemainingValue === 0
+                  ? 'text-gray-900 dark:text-white'
+                  : totalRemainingValue > 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
               }`}>
                 {isLoading ? <SkeletonText className="w-32 h-8" /> : totalRemaining}
               </p>
             </div>
-            <TrendingUpIcon className={totalRemainingValue >= 0 ? 'text-green-500' : 'text-red-500'} size={24} />
+            {/* Sign-driven: headroom points up, overspend points down. */}
+            <TrendArrow value={totalRemainingValue} size={24} />
           </div>
         </div>
         </div>
+        )}
 
         {/* Budgets List */}
         <div className="pt-4">
@@ -530,17 +554,26 @@ function BudgetView() {
         ))}
           </div>
 
-          {budgets.length === 0 && (
-          <div className="text-center py-12 bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
-            <p className="text-gray-500 dark:text-gray-400 mb-4">No budgets set up yet</p>
-            <button
-              onClick={() => setIsModalOpen(true)}
-              className="text-primary hover:underline"
-            >
-              Create your first budget
-            </button>
-          </div>
-        )}
+          {/* The house empty-state pattern (Claude Design, 22 Aug §3): what is
+              absent, what follows from it, and remedies as REAL CONTROLS —
+              this was centred text with "Create your first budget" rendered as
+              a plain link, predating batch 7. The second way in goes to the
+              Forecast's twelve-month category P&L, which is precisely the
+              reading a first budget wants (turning it INTO budgets stays an
+              explicit act on that page, per the promotion rule). */}
+          {budgets.length === 0 && !isLoading && (
+            <div className="md:col-span-2">
+              <EmptyState
+                title="No budgets yet"
+                description="Budgets are what turn your categories into a plan — until there's one here, nothing on this page has anything to measure against."
+                action={{ label: 'Create a budget', onClick: () => setIsModalOpen(true) }}
+                secondaryAction={{
+                  label: 'See last year’s spending',
+                  onClick: () => navigate(preserveDemoParam('/forecast', location.search)),
+                }}
+              />
+            </div>
+          )}
         </div>
         </div>
       )}

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -4,7 +4,8 @@ import { preserveDemoParam } from '../utils/navigation';
 import { Modal, ModalBody } from '../components/common/Modal';
 import { formatDate } from '../utils/dateFormatter';
 import { useApp } from '../contexts/AppContextSupabase';
-import { TrendingUpIcon, TrendingDownIcon, BarChart3Icon, AlertCircleIcon, LineChartIcon, EyeIcon } from '../components/icons';
+import { BarChart3Icon, AlertCircleIcon, LineChartIcon, EyeIcon } from '../components/icons';
+import TrendArrow from '../components/TrendArrow';
 import InvestmentMarketView from '../components/InvestmentMarketView';
 import PortfolioManager, { type HoldingFormValues, type PurchaseDetails } from '../components/PortfolioManager';
 import { allInAverageCost } from '../services/investments/purchaseMath';
@@ -1046,7 +1047,13 @@ function InvestmentsView() {
           }`}
         >
           <p className="text-body text-gray-500 dark:text-gray-400">Net Contributions</p>
-          <p className="text-page font-bold text-blue-700 dark:text-blue-400">
+          {/* NEUTRAL, not link blue (Claude Design, 22 Aug §6): the tile IS
+              clickable, but the affordance is the button's own hover border —
+              permanently recolouring the number claimed link-ness in the one
+              place colour already means something else. Amounts wear semantic
+              colours or none; a negative net contribution keeps its
+              parentheses from the house formatter. */}
+          <p className="text-page font-bold text-gray-900 dark:text-white">
             {formatCurrency(performance.netFlows)}
           </p>
           <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">
@@ -1065,11 +1072,22 @@ function InvestmentsView() {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-body text-gray-500 dark:text-gray-400">Total Return</p>
-              <p className={`text-page font-bold ${isGain ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-                {isGain ? '+' : ''}{formatCurrency(performance.gain)}
+              {/* NEUTRAL AT ZERO, like every figure in this app: a £0.00 gain
+                  is not good news or bad, and green would claim one. */}
+              <p className={`text-page font-bold ${
+                performance.gain.isZero()
+                  ? 'text-gray-900 dark:text-white'
+                  : isGain ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+              }`}>
+                {isGain && !performance.gain.isZero() ? '+' : ''}{formatCurrency(performance.gain)}
               </p>
             </div>
-            <TrendingUpIcon className={isGain ? 'text-green-500' : 'text-red-500'} size={24} />
+            {/* The arrow follows the SIGN of the figure it sits with, through
+                the one component that owns that rule — this was a hard-coded
+                up glyph, so a losing window would have shown a red arrow
+                pointing UP (Claude Design, 22 Aug §1, the mirror of the
+                Return % card beside it). */}
+            <TrendArrow value={performance.gain} size={24} />
           </div>
         </button>
 
@@ -1106,14 +1124,14 @@ function InvestmentsView() {
                 </>
               )}
             </div>
-            <TrendingDownIcon
-              className={
-                performance.mwrAnnualised === null
-                  ? 'text-gray-400'
-                  : performance.mwrAnnualised.greaterThanOrEqualTo(0) ? 'text-green-500' : 'text-red-500'
-              }
-              size={24}
-            />
+            {/* This was a hard-coded DOWN glyph recoloured by sign — so a
+                +18.25% return wore a falling arrow, and the card disagreed
+                with Total Return beside it about the same twelve months
+                (Claude Design, 22 Aug §1: "a reader checks the arrow before
+                the sign, because that's what an arrow is for"). The shared
+                rule now decides: sign picks the direction, zero and
+                unmeasurable render no arrow at all. */}
+            <TrendArrow value={performance.mwrAnnualised} size={24} />
           </div>
         </div>
         </div>
@@ -1831,6 +1849,25 @@ function InvestmentsView() {
                 ? 'None of your holdings has a price yet, so there is nothing to size this by. Use “Update prices” on an account above.'
                 : 'No priced holdings and no settlement cash, so there is nothing to divide up yet.'}
             </p>
+          ) : holdingAllocation.securityCount === 0 ? (
+            /* ONE CATEGORY IS A SENTENCE, NOT A RING (Claude Design, 22 Aug
+               §4): a donut divides a whole into parts, and a closed one-colour
+               ring reading "Cash · 100.00%" does no work these words don't do
+               better. Checked against the ledger before styling anything, as
+               the handover asked: the owner's portfolio has investment
+               accounts and ZERO holdings rows, so "all cash" is the data's
+               honest answer, not a misread. The sentence also owns what the
+               ring never said: with no securities recorded, only the
+               settlement sleeves can appear here — the rest of the
+               portfolio's value lives on the ledger, undividable by security
+               until holdings are added. */
+            <p className="text-body text-gray-500 dark:text-gray-400">
+              No securities are recorded in these accounts — the{' '}
+              {formatCurrency(holdingAllocation.total)} shown by this card is all
+              settlement cash. The rest of the portfolio&rsquo;s value lives on the
+              ledger without per-security holdings, so there is nothing to divide
+              up by security until holdings are added from an account&rsquo;s panel.
+            </p>
           ) : (
             <div>
               {/* Ring ABOVE the legend, matching "Asset Allocation" directly
@@ -1904,13 +1941,21 @@ function InvestmentsView() {
         </div>
         </div>
 
-        {/* Investment Tips */}
+        {/* NEUTRAL BODY TEXT, not blue (Claude Design, 22 Aug §5): heading,
+            icon and all four bullets rendered in the link colour and none of
+            them was a link — the same offence as the 29 blue "All reconciled"
+            pills. Blue means link on this page; a reader will try to click a
+            paragraph wearing it, and the one clickable-looking phrase in here
+            ("Account Settings") genuinely isn't a destination — the pairing
+            lives in EACH account's own settings dialog, so the path stays
+            words. The content stays exactly as it was: it is the ethos in its
+            most literal form. */}
         <div className="bg-white dark:bg-gray-800 border border-line dark:border-gray-700 rounded-lg p-6">
           <div className="flex items-start gap-3">
-            <AlertCircleIcon className="text-blue-700 dark:text-blue-400 mt-1" size={20} />
+            <AlertCircleIcon className="text-gray-400 dark:text-gray-500 mt-1" size={20} />
             <div>
-              <h3 className="font-semibold text-blue-900 dark:text-blue-300 mb-2">How these figures are worked out</h3>
-              <ul className="text-body text-blue-800 dark:text-blue-200 space-y-1">
+              <h3 className="font-semibold text-gray-900 dark:text-white mb-2">How these figures are worked out</h3>
+              <ul className="text-body text-gray-600 dark:text-gray-400 space-y-1">
                 <li>• A line is worth the investment account plus any cash account paired with it — set the pairing in Account Settings → Part of investment account</li>
                 <li>• Money transferred in from elsewhere counts as a contribution; moving money between an investment account and its own cash does not</li>
                 <li>• Total Return is what the portfolio is worth today less what was put into it</li>

--- a/src/pages/__tests__/Budget.test.tsx
+++ b/src/pages/__tests__/Budget.test.tsx
@@ -254,3 +254,34 @@ describe('Budget page — a write the server refuses', () => {
     expect(deleteBudget).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * The empty page says what is absent and offers real ways in — and shows NO
+ * furniture for data that isn't there (Claude Design, 22 Aug §2/§3). Before
+ * this, three £0.00 summary cards stood over "no budgets set up yet", the
+ * £0.00 Remaining wore green, £0.00 Spent wore a red falling arrow, and
+ * "Create your first budget" was plain text where every other empty state
+ * offers a control.
+ */
+describe('Budget page — an empty page is an empty state, not zeroed furniture', () => {
+  it('hides the summary trio, drops the zero arrows, and offers both ways in', async () => {
+    __setAppContextValue({
+      accounts: ACCOUNTS,
+      categories: CATEGORIES,
+      budgets: [],
+      transactions: [],
+      transactionSplits: [],
+    });
+    renderBudget();
+
+    expect(await screen.findByRole('heading', { level: 3, name: 'No budgets yet' })).toBeInTheDocument();
+    // The consequence, then the remedies as real controls.
+    expect(screen.getByText(/nothing on this page has anything to measure against/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create a budget' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'See last year’s spending' })).toBeInTheDocument();
+    // No furniture: the three summary cards do not render over an empty page.
+    expect(screen.queryByText('Total Budgeted')).not.toBeInTheDocument();
+    expect(screen.queryByText('Total Spent')).not.toBeInTheDocument();
+    expect(screen.queryByText('Total Remaining')).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/__tests__/Investments.test.tsx
+++ b/src/pages/__tests__/Investments.test.tsx
@@ -121,12 +121,17 @@ describe('Investments page — the pair is the portfolio', () => {
   it('counts the whole portfolio once, at 100% allocation', async () => {
     renderInvestments();
 
-    // THREE since 15 August, not two: the fixture's single account is 100% of
-    // the account ring, 100% of its own row — and now 100% of the new
-    // "Allocation by holding" ring too, whose only slice is that account's
-    // cash. The count is the point of the test (nothing is double-counted), so
-    // it moves with the page rather than being loosened to "at least one".
-    expect(await screen.findAllByText('100.00%')).toHaveLength(3);
+    // TWO since 22 August, not three: the fixture holds no securities, and a
+    // cash-only "Allocation by holding" is now a SENTENCE rather than a
+    // one-slice ring (Claude Design §4 — "a donut divides a whole into parts;
+    // with one part there is nothing to divide"). The account ring and the
+    // account's own row keep their 100%; the sentence is asserted below in
+    // its own words. The count is still the point (nothing double-counted),
+    // so it moves with the page rather than being loosened.
+    expect(await screen.findAllByText('100.00%')).toHaveLength(2);
+    expect(
+      screen.getByText(/No securities are recorded in these accounts/)
+    ).toBeInTheDocument();
   });
 });
 
@@ -143,7 +148,13 @@ describe('Investments page — contributions and return', () => {
     // "return" — but that was the OPENING BALANCE, capital mistaken for
     // growth. Nothing in this fixture grew; the honest gain is zero.
     expect(screen.queryByText('+£1,000.00')).not.toBeInTheDocument();
-    expect(screen.getAllByText('+£0.00').length).toBeGreaterThanOrEqual(1);
+    // RE-PINNED 22 Aug (Claude Design §1/§2's zero rule reaching this tile):
+    // a zero gain is NEUTRAL — no plus sign, no green, no arrow. £0.00 is a
+    // fact, not good news.
+    expect(screen.queryByText('+£0.00')).not.toBeInTheDocument();
+    const returnTile = screen.getByText('Total Return').closest('button');
+    expect(returnTile).not.toBeNull();
+    expect(within(returnTile as HTMLElement).getByText('£0.00')).toBeInTheDocument();
     // OVERRULED 20 Aug: the tile no longer prints gain-over-net-contributions
     // (+200.00% here) — that ratio turns absurd the moment withdrawals bring
     // the net near zero. The words-pin for the new measure has its own spec.

--- a/src/utils/holdingAllocation.ts
+++ b/src/utils/holdingAllocation.ts
@@ -47,6 +47,14 @@ export interface HoldingAllocation {
   total: DecimalInstance;
   /** Positions with no price. Their value is unknown, so it is not in `total`. */
   unpricedCount: number;
+  /**
+   * How many of the slices are securities — i.e. everything except the one
+   * Cash entry. Zero means the "allocation" is all settlement cash, and a
+   * ring dividing one category into one part is a sentence's job (Claude
+   * Design, 22 Aug §4). The caller needs the fact, not the inference from
+   * slice labels.
+   */
+  securityCount: number;
 }
 
 /** The label for the one cash slice. Exported so the UI cannot misspell it. */
@@ -103,6 +111,7 @@ export function buildHoldingAllocation(
   return {
     slices,
     total: slices.reduce((sum, slice) => sum.plus(slice.value), toDecimal(0)),
-    unpricedCount
+    unpricedCount,
+    securityCount: bySymbol.size
   };
 }


### PR DESCRIPTION
Claude Design's 22 August handover, §1–§6 — their ordered top.

## §1 + §2 — one rule for every arrow, in one place

Investments' Return % wore a hard-coded DOWN glyph recoloured by sign (+18.25% under a falling arrow), Total Return mirrored it with a hard-coded UP glyph, and Budget's cards were the fourth surface found re-deriving the dashboard's 16 Aug zero-arrow rule by hand — £0.00 Spent under a red falling arrow, £0.00 Remaining in green under a rising one.

The rule now has one home, `components/TrendArrow`: **zero or unmeasurable renders nothing; otherwise the arrow follows the sign of the figure it sits with**, with an explicit `direction` for the dashboard's income/expense flow pair (which the owner asked for by name). Dashboard, Budget and Investments all call it; five component specs pin the rule itself, and the dashboard call site is marked as the reference.

Also neutral-at-zero landed where it was missing: a £0.00 gain and £0.00 remaining no longer wear green or a plus sign.

## §3 — Budget's empty page is an empty state

The three £0.00 summary cards no longer render over "no budgets yet" (furniture for data that isn't there — same finding as the column strip over an empty table). The centred-text state became the house EmptyState: the consequence, then remedies as real controls — **[Create a budget]** and **[See last year's spending]**, the second into the Forecast's twelve-month category P&L, which is precisely the reading a first budget wants. Turning that reading INTO budgets stays an explicit act, per the promotion rule.

## §4 — checked the data first, then made the ring a sentence

As the handover asked, the ledger was checked before styling anything: the owner's portfolio has investment accounts and **zero holdings rows**, so "100% cash" is the data's honest answer, not a chart misread. A cash-only allocation now renders as a sentence — a donut dividing one part into one part does no work — and the sentence owns what the ring never said: with no securities recorded, only the settlement sleeves can appear on this card; the rest of the portfolio's value lives on the ledger, undividable by security until holdings are added.

## §5 + §6 — the blue sweep

"How these figures are worked out" (heading, icon, all four bullets in link blue, none a link) is neutral body text now, content unchanged. Net Contributions' figure dropped its permanent link-blue — the tile's own hover border is the affordance, and amounts wear semantic colours or none.

Two Investments specs re-pinned to the new rulings; one Budget empty-state spec added; five TrendArrow specs.

§7–§11 follow in a second batch; §9 (renaming the page to Plan) and §12 (one budgeting methodology as the house way) are owner decisions and were raised, not assumed.

Every figure in the tests is invented; the repo is public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)