### PR TITLE
design(aug22): the nesting reads as containment, the bucket says the fact, the coach-mark yields, and the Budget promise moves to the point of action

### DIFF
--- a/src/components/common/AccountSelector.test.tsx
+++ b/src/components/common/AccountSelector.test.tsx
@@ -4,7 +4,7 @@ import AccountSelector from './AccountSelector';
 
 /**
  * The account picker, pinned: the Accounts page's nested bands (type section →
- * institution sub-band → rows, "Other Accounts" last in both dimensions), the
+ * institution sub-band → rows, each dimension's catch-all last), the
  * type-to-filter the owner asked for, and the keyboard combobox contract it
  * shares with CategorySelector.
  */
@@ -86,7 +86,7 @@ describe('AccountSelector', () => {
         'Current Accounts',
         'American Express',
         'Natwest',
-        'Other Accounts',      // the unfiled sub-band inside Current Accounts
+        'No institution recorded', // the unfiled sub-band inside Current Accounts
         'Savings Accounts',
         'Natwest',
         'Credit Cards',

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -2288,7 +2288,16 @@ function AccountsList() {
                         onClick={() => toggleGroupCollapsed(subBandCollapseKeyFor(group.label, sub.label))}
                         aria-expanded={sub.isExpanded}
                         aria-controls={subRegionId}
-                        className={`w-full text-left flex items-center justify-between gap-2 mt-4 first:mt-0 border-t-2 first:border-t-0 border-b border-line dark:border-gray-700 ${DEPTH_LEVEL_2} hover:bg-surface-tertiary dark:hover:bg-gray-700 transition-colors duration-state px-4 sm:px-6 py-2`}
+                        /* INDENTED ONE STEP under its type band (Claude
+                           Design, 22 Aug §7): shade and size alone left the
+                           two headings reading as siblings with identical
+                           totals, not a type CONTAINING an institution. The
+                           indent is on the HEADING only — the rows beneath
+                           stay at the page's content edges, because they are
+                           measured against the shared column strip and an
+                           indented row would drift every figure off its
+                           column. */
+                        className={`w-full text-left flex items-center justify-between gap-2 mt-4 first:mt-0 border-t-2 first:border-t-0 border-b border-line dark:border-gray-700 ${DEPTH_LEVEL_2} hover:bg-surface-tertiary dark:hover:bg-gray-700 transition-colors duration-state pl-8 sm:pl-12 pr-4 sm:pr-6 py-2`}
                       >
                         <p className="flex items-center gap-2 min-w-0 text-body uppercase font-bold tracking-wide text-gray-900 dark:text-white truncate">
                           <ChevronRightIcon
@@ -3207,11 +3216,21 @@ function AccountsList() {
         }}
       />
 
-      <PageTip
-        id="accounts-intro"
-        title="Manage your accounts"
-        description="Add bank accounts, credit cards, savings, and investments. Click an account's name to open its transactions, or click the row to pick it out and walk the list with the arrow keys. Use the settings icon on each account to configure alerts and reconciliation."
-      />
+      {/* NOT over an empty page (Claude Design, 22 Aug §8): with no accounts
+          the empty state above is already the page's first sentence, and a
+          five-line dark panel floating over it was the heaviest thing on a
+          page with nothing on it — two pieces of guidance competing to be
+          read first. The copy is also cut to the two things the page cannot
+          say for itself; "add accounts" is what the header button and the
+          empty state both already teach. Same id: a shortening is a cosmetic
+          edit, and re-showing a tip nobody needs re-read is noise. */}
+      {!isLoading && openAccounts.length > 0 && (
+        <PageTip
+          id="accounts-intro"
+          title="Manage your accounts"
+          description="Click an account's name to open its transactions; the settings icon on each row configures alerts and reconciliation."
+        />
+      )}
     </PageWrapper>
   );}
   

--- a/src/pages/Forecast.tsx
+++ b/src/pages/Forecast.tsx
@@ -754,14 +754,17 @@ function ForecastStatement(): React.JSX.Element {
               <h2 className="text-label uppercase tracking-wider font-medium text-gray-500 dark:text-gray-400">
                 Your profit and loss
               </h2>
+              {/* TWO SHORT LINES, not four dense ones (Claude Design, 22 Aug
+                  §10): every sentence was worth keeping, which was the
+                  problem — good writing at a density that makes it skippable.
+                  The period statement and the exclusions stay here, where the
+                  numbers are; the Budget-relationship sentence moved to the
+                  Forecast tab, beside the place a scenario would actually be
+                  promoted — a reassurance at the point of action, not a
+                  disclaimer at the top of a page of history. */}
               <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">
                 {plWindow.label} — {windowSentence[windowKind]}. Category by
-                category, exactly as the register holds them.{' '}
-                <span className="text-gray-700 dark:text-gray-300">
-                  Nothing here writes to your Budget
-                </span>
-                {' '}— a scenario only ever becomes budgets by your explicit,
-                per-category say-so.
+                category, exactly as the register holds them.
               </p>
               <p className="text-dense text-gray-500 dark:text-gray-400 mt-2">
                 Transfers between your accounts are not income or spending and are
@@ -881,6 +884,14 @@ function ForecastStatement(): React.JSX.Element {
             <h2 className="text-card font-semibold text-theme-heading dark:text-white">The forecast</h2>
             <p className="text-body text-gray-500 dark:text-gray-400 mt-1">
               The scenario tool will live here — it is being designed.
+            </p>
+            {/* Moved here from the Actuals preamble (§10): this is where a
+                scenario would be written to Budget, so this is where the
+                promise belongs. When the promote control lands, the sentence
+                stands beside it. */}
+            <p className="text-dense text-gray-500 dark:text-gray-400 mt-2">
+              <span className="text-gray-700 dark:text-gray-300">Nothing here will write to your Budget</span>
+              {' '}— a scenario only ever becomes budgets by your explicit, per-category say-so.
             </p>
             {keptParts.length > 0 && (
               <p className="text-dense text-gray-700 dark:text-gray-300 mt-2">

--- a/src/pages/__tests__/Accounts.emptyStates.test.tsx
+++ b/src/pages/__tests__/Accounts.emptyStates.test.tsx
@@ -65,6 +65,17 @@ describe('an accounts list with nothing in it', () => {
     expect(emptyState).not.toBeNull();
     expect(within(emptyState as HTMLElement).getByRole('button', { name: 'Add Account' })).toBeInTheDocument();
   });
+
+  it('does not float the coach-mark over the empty state', async () => {
+    // Two pieces of guidance competing to be the page's first sentence
+    // (Claude Design, 22 Aug §8): the empty state IS the guidance on an empty
+    // page, so the page tip waits for a page with accounts on it.
+    __setAppContextValue({ accounts: [], transactions: [], categories: [], isLoading: false });
+    renderAccounts();
+
+    await screen.findByRole('heading', { level: 3, name: 'No accounts yet' });
+    expect(screen.queryByText('Manage your accounts')).not.toBeInTheDocument();
+  });
 });
 
 describe('an accounts list emptied by the search is not an empty accounts list', () => {

--- a/src/pages/__tests__/Accounts.test.tsx
+++ b/src/pages/__tests__/Accounts.test.tsx
@@ -534,9 +534,9 @@ describe('Accounts page — closed accounts ordering', () => {
     for (let i = 1; i < seq.length; i += 1) {
       expect(precedes(seq[i - 1], seq[i])).toBe(true);
     }
-    // The catch-all subheading for the account with no institution renders too
-    // (unique: no closed row carries "Other Accounts" as its institution).
-    expect(within(closedSection).getByText('Other Accounts')).toBeInTheDocument();
+    // The catch-all subheading says the FACT rather than posing as a bank
+    // called Other (Claude Design, 22 Aug §7).
+    expect(within(closedSection).getByText('No institution recorded')).toBeInTheDocument();
   });
 
   it('nests institution sub-bands in the archive when both toggles are on', async () => {
@@ -557,7 +557,7 @@ describe('Accounts page — closed accounts ordering', () => {
       within(closedSection).getAllByText('Aldermore')[0],
       within(closedSection).getByText('Beacon Savings'),
       within(closedSection).getByText('Credit Cards'),
-      within(closedSection).getByText('Other Accounts'),
+      within(closedSection).getByText('No institution recorded'),
       within(closedSection).getByText('Nimbus Card'),
     ];
     for (let i = 1; i < seq.length; i += 1) {

--- a/src/pages/__tests__/Forecast.test.tsx
+++ b/src/pages/__tests__/Forecast.test.tsx
@@ -158,8 +158,21 @@ describe('Forecast — the Current P&L', () => {
     expect(screen.getByText('+£17,800.00')).toBeInTheDocument();
     expect(screen.getByText('£1,483.33 a month')).toBeInTheDocument();
 
-    // The ruling, in words, on the page.
-    expect(screen.getByText(/Nothing here writes to your Budget/)).toBeInTheDocument();
+    // MOVED 22 Aug (Claude Design §10): the Budget-relationship promise left
+    // the Actuals preamble — a disclaimer at the top of a page of history —
+    // for the Forecast tab, beside the place a scenario would actually be
+    // promoted. The Actuals side must NOT carry it; the tab's own spec below
+    // asserts where it lives now.
+    expect(screen.queryByText(/writes to your Budget/)).not.toBeInTheDocument();
+  });
+
+  it('carries the Budget promise on the Forecast tab, at the point of action', () => {
+    renderForecast();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Forecast' }));
+
+    expect(screen.getByText(/Nothing here will write to your Budget/)).toBeInTheDocument();
+    expect(screen.getByText(/explicit, per-category say-so/)).toBeInTheDocument();
   });
 
   it('a section heading collapses to its total; a category expands to its rows', () => {

--- a/src/pages/__tests__/Reconciliation.grouping.test.tsx
+++ b/src/pages/__tests__/Reconciliation.grouping.test.tsx
@@ -122,7 +122,7 @@ describe('Reconciliation — grouping is two independent switches', () => {
       'Invented Bank, 1 account',
       'Rival Invented Bank, 1 account',
       'Invented Bank, 1 account',
-      'Other Accounts, 1 account',
+      'No institution recorded, 1 account',
     ]);
 
     // The rows really are inside their sub-bands, not siblings of them.
@@ -151,7 +151,7 @@ describe('Reconciliation — grouping is two independent switches', () => {
     expect(sections()).toEqual([
       'Invented Bank(2 accounts)',
       'Rival Invented Bank(1 account)',
-      'Other Accounts(1 account)',
+      'No institution recorded(1 account)',
     ]);
     expect(subBands()).toEqual([]);
   });
@@ -298,7 +298,7 @@ describe('Reconciliation — the switches are remembered, and are this page\'s o
     expect(sections()).toEqual([
       'Invented Bank(2 accounts)',
       'Rival Invented Bank(1 account)',
-      'Other Accounts(1 account)',
+      'No institution recorded(1 account)',
     ]);
   });
 });

--- a/src/utils/accountGrouping.test.ts
+++ b/src/utils/accountGrouping.test.ts
@@ -164,7 +164,7 @@ describe('groupAccountsForDisplay', () => {
 
     it('bands by institution alphabetically, unfiled accounts last', () => {
       const groups = groupsOf(groupAccountsForDisplay(book, options));
-      expect(groups.map(g => g.title)).toEqual(['ARGENT', 'Barclays', 'Calderbank', 'Other Accounts']);
+      expect(groups.map(g => g.title)).toEqual(['ARGENT', 'Barclays', 'Calderbank', 'No institution recorded']);
       expect(groups.every(g => g.kind === 'institution')).toBe(true);
     });
 
@@ -181,7 +181,7 @@ describe('groupAccountsForDisplay', () => {
 
     it('files absent AND blank institutions under the one catch-all', () => {
       const groups = groupsOf(groupAccountsForDisplay(book, options));
-      const other = groups.find(g => g.title === 'Other Accounts');
+      const other = groups.find(g => g.title === 'No institution recorded');
       // '   ' is not an institution called three spaces: it is nothing said.
       expect(namesIn(other?.accounts ?? [])).toEqual(['Loose Change', 'Blank Jar']);
     });
@@ -210,7 +210,7 @@ describe('groupAccountsForDisplay', () => {
           subs: [
             { title: 'Barclays', accounts: ['Barclays Current'] },
             { title: 'Calderbank', accounts: ['Calderbank Current'] },
-            { title: 'Other Accounts', accounts: ['Loose Change'] },
+            { title: 'No institution recorded', accounts: ['Loose Change'] },
           ],
         },
         {
@@ -221,7 +221,7 @@ describe('groupAccountsForDisplay', () => {
           title: 'Savings Accounts',
           subs: [
             { title: 'Calderbank', accounts: ['Calderbank Savings'] },
-            { title: 'Other Accounts', accounts: ['Blank Jar'] },
+            { title: 'No institution recorded', accounts: ['Blank Jar'] },
           ],
         },
         {
@@ -241,7 +241,7 @@ describe('groupAccountsForDisplay', () => {
       const groups = groupsOf(groupAccountsForDisplay(book, options));
       groups.forEach(group => {
         const subs = group.subGroups ?? [];
-        const catchAll = subs.findIndex(s => s.title === 'Other Accounts');
+        const catchAll = subs.findIndex(s => s.title === 'No institution recorded');
         if (catchAll !== -1) expect(catchAll).toBe(subs.length - 1);
       });
     });

--- a/src/utils/accountGrouping.ts
+++ b/src/utils/accountGrouping.ts
@@ -180,11 +180,14 @@ export const DEFAULT_ACCOUNT_GROUPING: AccountGroupingOptions = { byType: true, 
 export type AccountGroupKind = 'type' | 'institution';
 
 /**
- * Where an account with no institution files. Deliberately the same words as
- * the type catch-all: in both dimensions it means "nothing said where this
- * belongs", and it sorts last for the same reason.
+ * Where an account with no institution files. It USED to share the type
+ * catch-all's words, on the argument that both mean "nothing said where this
+ * belongs" — but as an institution heading, "Other Accounts" reads as the
+ * name of a bank, and a reader met a band apparently held at an institution
+ * called Other (Claude Design, 22 Aug §7: "if it's the no-institution bucket,
+ * say that"). So it says the fact. Still sorts last.
  */
-export const NO_INSTITUTION_TITLE = OTHER_SECTION_DEFINITION.title;
+export const NO_INSTITUTION_TITLE = 'No institution recorded';
 
 /** An institution band — a top-level band, or a sub-band inside a type section. */
 export interface AccountInstitutionGroup<T extends GroupableAccount> {


### PR DESCRIPTION
Claude Design's 22 August handover, batch 2 — §7, §8, §10, with §11 resolved by verification rather than code. (Batch 1, §1–§6, was #377.)

## §7 — a type containing an institution, legibly

With both Group-by switches on, the institution band inside a type band differed from its parent only in shade — two sibling bands with identical totals rather than containment. The sub-band heading now **indents one step** — heading only, because the rows beneath are measured against the shared column strip and an indented row would drift every figure off its column.

And the no-institution bucket stops posing as a bank called "Other Accounts": as an **institution** heading it now says the fact — **"No institution recorded"**. The type catch-all keeps its name; only the institution dimension changed. The shared module reaches further than the Accounts page — the pre-commit gate caught the Reconciliation page and the account picker still pinning the old words, and both are taught.

## §8 — the coach-mark yields to the empty state

The Accounts page tip was a five-line dark panel floating over a page whose empty state was already the guidance — two things competing to be the reader's first sentence. It no longer renders over an empty page (pinned by a spec), and its copy is cut to the two things the page cannot say for itself. Same tip id: a shortening is cosmetic, and re-showing a tip nobody needs re-read is noise.

## §10 — the Budget promise moves to the point of action

The Forecast preamble was four dense lines before any data. The period statement and the exclusions stay with the numbers (two short lines); the Budget-relationship promise — *"Nothing here will write to your Budget — a scenario only ever becomes budgets by your explicit, per-category say-so"* — moved to the **Forecast tab**, beside the place a scenario would actually be promoted. When the promote control lands, the sentence stands beside it. Specs assert both where it lives now and that the Actuals side no longer carries it.

## §11 — verified, not changed

The routing Design asked to eliminate first is already sound: both Investments rings draw through the `DashboardCharts` wrapper with the shared `useCategoricalRamp` — no lazy-barrel `Cell` path. The light five ARE the 17 Aug CIE-L*-respaced, instrument-pinned values (ΔL* ≈ 10.5, even). What the capture shows is that the interleave optimises **wedge** adjacency, so the three darkest steps land on legend **rows** 1/3/4 and read close at 12px swatch size — the measured cost of the one-hue ruling. Handed back to Design as a ruling question rather than hexes tuned against the standing instrument.

§9 (renaming the page to Plan, tabs Actuals | Forecast) and §12 (one budgeting methodology as the house way) are owner decisions — raised, not assumed.

Every figure in the tests is invented; the repo is public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)