### PR TITLE
design(aug22): the cash-only card reconciles to the portfolio in two section totals, and the page becomes Plan with tabs Actuals | Forecast

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -388,7 +388,13 @@ export default function Layout(): React.JSX.Element {
             <TopNavDropdown
               label="Plan"
               icon={TargetIcon}
-              homeTo="/budget"
+              // The group's namesake page (Claude Design 22 Aug §9,
+              // owner-approved): /forecast is now titled Plan — the actuals
+              // P&L with the scenario tool beside it — so the LABEL navigates
+              // there, exactly as the Accounts label navigates to Accounts.
+              // It is no longer a sub-item of itself; the chevron holds the
+              // group's other three pages.
+              homeTo="/forecast"
               items={[
                 { to: '/budget', icon: BarChart3Icon, label: 'Budget' },
                 { to: '/calendar', icon: CalendarIcon, label: 'Calendar' },
@@ -398,10 +404,6 @@ export default function Layout(): React.JSX.Element {
                 // says what the page is; the page's own heading keeps the
                 // question it answers — "What I'm committed to".
                 { to: '/recurring-payments', icon: ClockIcon, label: 'Recurring Payments' },
-                // The scenario tool's base — review twelve months of actuals,
-                // strike the one-offs, and only ever promote to Budget by an
-                // explicit, per-category act (docs/forecast-direction.md).
-                { to: '/forecast', icon: TrendingUpIcon, label: 'Forecast' },
               ]}
               activePaths={['/budget', '/calendar', '/recurring-payments', '/forecast']}
               openDropdown={openDropdown}
@@ -715,27 +717,43 @@ export default function Layout(): React.JSX.Element {
                     the desktop menu. This group used to be "deliberately
                     absent" as desk work; the owner overruled it (17 Aug), and
                     the Calendar now carries the due-next panel, which is
-                    exactly a thing to check from a phone. */}
+                    exactly a thing to check from a phone.
+
+                    THE NAME NAVIGATES, THE ARROW EXPANDS — the Accounts row's
+                    arrangement exactly, and for the same reason it exists
+                    there: since §9 (22 Aug) the group has a namesake page.
+                    /forecast is titled Plan now, so tapping Plan opens it and
+                    the chevron unfolds the group's other three pages. */}
                 <div>
-                  <button
-                    type="button"
-                    onClick={() => setPlanExpanded(!planExpanded)}
-                    aria-expanded={planExpanded}
+                  <Link
+                    to={isDemoModeRoutingEnabled ? '/forecast?demo=true' : '/forecast'}
+                    onClick={toggleMobileMenu}
                     className="w-full flex items-center gap-2 px-3 py-2.5 md:py-2 rounded-lg transition-colors h-12 md:h-auto bg-secondary text-white dark:text-gray-300 hover:bg-secondary dark:hover:bg-gray-800/50"
                   >
                     <TargetIcon size={18} />
                     <span className="flex-1 text-sm text-left">Plan</span>
-                    <ChevronRightIcon
-                      size={14}
-                      className={`text-gray-400 transition-transform duration-200 ${planExpanded ? 'rotate-90' : ''}`}
-                    />
-                  </button>
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        setPlanExpanded(!planExpanded);
+                      }}
+                      aria-expanded={planExpanded}
+                      aria-label={planExpanded ? 'Hide the Plan pages' : 'Show the Plan pages'}
+                      className="inline-flex items-center justify-end py-2 -my-2 pl-2 pr-3 -mr-3 rounded-lg"
+                    >
+                      <ChevronRightIcon
+                        size={14}
+                        className={`text-gray-400 transition-transform duration-200 ${planExpanded ? 'rotate-90' : ''}`}
+                      />
+                    </button>
+                  </Link>
                   {planExpanded && (
                     <div className="mt-1 space-y-1">
                       <SidebarLink to="/budget" icon={BarChart3Icon} label="Budget" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
                       <SidebarLink to="/calendar" icon={CalendarIcon} label="Calendar" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
                       <SidebarLink to="/recurring-payments" icon={ClockIcon} label="Recurring Payments" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
-                      <SidebarLink to="/forecast" icon={TrendingUpIcon} label="Forecast" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
                     </div>
                   )}
                 </div>

--- a/src/components/__tests__/Layout.test.tsx
+++ b/src/components/__tests__/Layout.test.tsx
@@ -212,8 +212,10 @@ describe('Layout — the Plan menu and split triggers', () => {
   it('groups the forward-looking pages under Plan, not as top-level items', () => {
     renderWithProviders(<Layout />);
 
-    // Plan's label navigates to Budget, its menu holds all three.
-    expect(navLink('Plan')).toHaveAttribute('href', '/budget');
+    // Plan's label navigates to its NAMESAKE page (§9, 22 Aug: /forecast is
+    // titled Plan — the actuals P&L with the scenario tool beside it), the
+    // same idiom as the Accounts label; its menu holds the other three.
+    expect(navLink('Plan')).toHaveAttribute('href', '/forecast');
     fireEvent.click(menuButton('Plan'));
     expect(navLink('Budget')).toHaveAttribute('href', '/budget');
     expect(navLink('Calendar')).toHaveAttribute('href', '/calendar');
@@ -223,14 +225,15 @@ describe('Layout — the Plan menu and split triggers', () => {
     expect(navLink('Recurring Payments')).toHaveAttribute('href', '/recurring-payments');
   });
 
-  it('orders Plan as Budget, Calendar, Recurring Payments, Forecast', () => {
+  it('orders Plan as Budget, Calendar, Recurring Payments — the Plan page itself is the label', () => {
     renderWithProviders(<Layout />);
 
+    // No 'Forecast' item: the page is not a sub-item of itself, exactly as
+    // there is no 'Accounts' item inside the Accounts menu.
     expect(openMenuItems('Plan')).toEqual([
       'Budget',
       'Calendar',
       'Recurring Payments',
-      'Forecast',
     ]);
   });
 

--- a/src/desktop/routes.ts
+++ b/src/desktop/routes.ts
@@ -192,7 +192,10 @@ export const DESKTOP_ROUTES = [
   // The forecast's BASE (docs/forecast-direction.md step 4): reads the open
   // ledger's rows; its exclusions are verdicts in the file's own
   // suggestion_dismissals — as local as the register it reviews.
-  { path: 'forecast', at: 'forecast', title: 'Forecast' },
+  // Titled Plan since §9 (22 Aug): the page is the actuals P&L and the
+  // scenario tool together, and the name matches the nav group. The PATH
+  // stays /forecast — a route is an address, and addresses don't move.
+  { path: 'forecast', at: 'forecast', title: 'Plan' },
   { path: 'reports', at: 'reports', title: 'Reports' },
   { path: 'reports/:reportId', at: 'reports/:reportId', title: 'Reports' },
   { path: 'custom-reports', at: 'custom-reports', title: 'Custom reports' },

--- a/src/pages/Forecast.tsx
+++ b/src/pages/Forecast.tsx
@@ -674,13 +674,19 @@ function ForecastStatement(): React.JSX.Element {
   ].filter((part): part is string => part !== null);
 
   return (
-    <PageWrapper title="Forecast">
+    /* PLAN, not Forecast (Claude Design 22 Aug §9, owner-approved): the page
+       is two things — a twelve-month actuals P&L and a projection from it —
+       and "Forecast" was both where you were and one of two tabs, with the
+       selected tab the one that ISN'T the page name. "Plan" covers both and
+       matches the nav group; the tabs say what each side holds. "Current"
+       also went — what that side shows is history, so it says Actuals. */
+    <PageWrapper title="Plan">
       <div className="max-w-[1400px] mx-auto space-y-6">
         <div className="flex flex-wrap items-center justify-between gap-3">
           {/* The tab, chosen the way the calendar chooses its view — a
-              segmented control (owner, 19 Aug: "Lets have two tabs for now.
-              Current and forecast"). */}
-          <div className="flex items-center rounded-lg bg-gray-100 dark:bg-gray-700 p-0.5" role="group" aria-label="Forecast view">
+              segmented control (owner, 19 Aug: "Lets have two tabs for now",
+              renamed 22 Aug with the page). */}
+          <div className="flex items-center rounded-lg bg-gray-100 dark:bg-gray-700 p-0.5" role="group" aria-label="Plan view">
             {(['current', 'forecast'] as const).map(option => (
               <button
                 key={option}
@@ -693,7 +699,7 @@ function ForecastStatement(): React.JSX.Element {
                     : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100'
                 }`}
               >
-                {option === 'current' ? 'Current' : 'Forecast'}
+                {option === 'current' ? 'Actuals' : 'Forecast'}
               </button>
             ))}
           </div>

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -751,6 +751,30 @@ function InvestmentsView() {
     [holdingAllocation.slices]
   );
 
+  /**
+   * The two-section split the cash-only card shows: the investment accounts'
+   * own value against the settlement sleeves, sharing out the portfolio
+   * (owner, 22 Aug). line.value is the pair and line.cash the nested part,
+   * so investments = Σvalue − Σcash and the two rows sum to summary.value by
+   * construction. Shares are of that same total, so they read 100% together.
+   */
+  const cashOnlySplit = useMemo(() => {
+    const total = summary.value;
+    const cash = summary.lines.reduce(
+      (sum, line) => line.cash.reduce((inner, entry) => inner.plus(entry.value), sum),
+      toDecimal(0)
+    );
+    const investments = total.minus(cash);
+    const shareOf = (part: DecimalInstance): string =>
+      total.greaterThan(0)
+        ? `${((part.toNumber() / total.toNumber()) * 100).toFixed(2)}%`
+        : '0.00%';
+    return [
+      { label: 'Investments', value: investments, share: shareOf(investments) },
+      { label: 'Cash', value: cash, share: shareOf(cash) },
+    ];
+  }, [summary]);
+
   const holdingSlicesTotal = useMemo(
     () => holdingSlices.reduce((sum, slice) => sum + slice.value, 0),
     [holdingSlices]
@@ -1861,13 +1885,42 @@ function InvestmentsView() {
                settlement sleeves can appear here — the rest of the
                portfolio's value lives on the ledger, undividable by security
                until holdings are added. */
-            <p className="text-body text-gray-500 dark:text-gray-400">
-              No securities are recorded in these accounts — the{' '}
-              {formatCurrency(holdingAllocation.total)} shown by this card is all
-              settlement cash. The rest of the portfolio&rsquo;s value lives on the
-              ledger without per-security holdings, so there is nothing to divide
-              up by security until holdings are added from an account&rsquo;s panel.
-            </p>
+            <div>
+              {/* THE TWO SECTION TOTALS, reconciling to the portfolio (owner,
+                  22 Aug: the cash-only sentence named a figure — the sleeves
+                  alone — that the reader could not square with the Portfolio
+                  Value above it. With no holdings recorded, the honest split
+                  is investment accounts against settlement cash: two totals
+                  and two shares that sum to the portfolio, said to be section
+                  totals rather than an allocation by holding). Same maths as
+                  the page: line.value is the pair, line.cash the nested part,
+                  so the two rows always add to the summary's own total. */}
+              <p className="text-body text-gray-500 dark:text-gray-400">
+                No individual securities are recorded in these accounts, so
+                these are the totals of the two sections rather than an
+                allocation by holding:
+              </p>
+              <div className="mt-3 space-y-2">
+                {cashOnlySplit.map(row => (
+                  <div key={row.label} className="flex items-center justify-between gap-3 text-body">
+                    <span className="text-gray-700 dark:text-gray-300">{row.label}</span>
+                    <div className="flex items-center gap-3 shrink-0">
+                      <span className="text-gray-500 dark:text-gray-400 tabular-nums">
+                        {formatCurrency(row.value)}
+                      </span>
+                      <span className="text-gray-900 dark:text-white font-medium tabular-nums w-16 text-right">
+                        {row.share}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <p className="mt-3 text-dense text-gray-500 dark:text-gray-400">
+                Together they are the portfolio&rsquo;s{' '}
+                {formatCurrency(summary.value)}. Holdings can be added from
+                an account&rsquo;s panel to divide the investment side by security.
+              </p>
+            </div>
           ) : (
             <div>
               {/* Ring ABOVE the legend, matching "Asset Allocation" directly

--- a/src/pages/__tests__/Investments.test.tsx
+++ b/src/pages/__tests__/Investments.test.tsx
@@ -96,9 +96,17 @@ describe('Investments page — the pair is the portfolio', () => {
      * completes it.
      */
     // The itemised line, not the page title: both say "Investments", so the
-    // label is read from the same paragraph as its figure.
-    const investedFigure = screen.getByText('£1,300.00');
-    expect(investedFigure.closest('p')?.textContent).toContain('Investments');
+    // label is read from the same container as its figure. TWO occurrences
+    // since 22 Aug — the itemised line, and the cash-only card's section
+    // row — and each must sit beside its own "Investments" label.
+    const investedFigures = screen.getAllByText('£1,300.00');
+    expect(investedFigures).toHaveLength(2);
+    investedFigures.forEach(figure => {
+      // The itemised line is a <p>; the section row is a justify-between div
+      // whose label sits in a sibling span — either way, the figure's own
+      // row must name what it is.
+      expect(figure.closest('p, [class*="justify-between"]')?.textContent).toContain('Investments');
+    });
   });
 
   it('shows the nested cash inside the holding, not as a holding of its own', async () => {
@@ -129,9 +137,17 @@ describe('Investments page — the pair is the portfolio', () => {
     // its own words. The count is still the point (nothing double-counted),
     // so it moves with the page rather than being loosened.
     expect(await screen.findAllByText('100.00%')).toHaveLength(2);
+    // REVISED 22 Aug (owner): the cash-only card shows the TWO SECTION
+    // totals — investments against settlement cash, sharing out the
+    // portfolio — rather than a sentence naming a figure the reader could
+    // not square with the Portfolio Value. £1,300 + £200 = £1,500 here, so
+    // the shares are 86.67% and 13.33%, summing to 100%.
     expect(
-      screen.getByText(/No securities are recorded in these accounts/)
+      screen.getByText(/No individual securities are recorded in these accounts/)
     ).toBeInTheDocument();
+    expect(screen.getByText('86.67%')).toBeInTheDocument();
+    expect(screen.getByText('13.33%')).toBeInTheDocument();
+    expect(screen.getByText(/Together they are the portfolio’s/)).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
Two owner rulings on the 22 August batch.

## 1. The cash-only card shows the two section totals

The §4 sentence named a figure — the settlement sleeves alone — that the reader could not square with the Portfolio Value above it. With no holdings recorded, the honest split is the one the owner asked for: **Investments** and **Cash**, each with its amount and share, summing to the portfolio — introduced as *"the totals of the two sections rather than an allocation by holding"* and closing with *"Together they are the portfolio's £T."*

Same maths as the page's own summary (`line.value` is the pair, `line.cash` the nested part), so the two rows add to `summary.value` by construction. Specs pin the copy, both percentages, and that each figure sits beside its own label.

## 2. §9, owner-approved: the page is Plan

The page is a twelve-month actuals P&L and a projection from it, and "Forecast" was both where you were and one of two tabs — with the selected tab the one that *isn't* the page name. Now: title **Plan**, tabs **Actuals | Forecast** ("Current" also went — what that side shows is history).

The nav follows the Accounts idiom: the **Plan** label navigates to its namesake page — desktop `homeTo`, and in the phone drawer the name navigates while the arrow expands — and the page is no longer a sub-item of itself (no 'Accounts' item lives inside the Accounts menu either). The **path stays `/forecast`**: a route is an address, and addresses don't move; the desktop route registry retitles without a route change.

Layout specs re-pinned (Plan label href, three-item menu), Investments specs re-pinned to the two-row split. Verified live: h1 "Plan", tabs correct, nav label lands on the page.

Every figure in the tests is invented; the repo is public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)