### PR TITLE
hygiene(sheets): every button in the bottom-sheet chrome declares its type

### DIFF
--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -222,6 +222,7 @@ export function BottomSheet({
             </h2>
             {showCloseButton && (
               <button
+                type="button"
                 onClick={onClose}
                 className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
                 aria-label="Close"
@@ -266,6 +267,7 @@ export function BottomSheetItem({
 }) {
   return (
     <button
+      type="button"
       onClick={onClick}
       disabled={disabled}
       className={`w-full flex items-center gap-3 px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-left ${
@@ -341,6 +343,7 @@ export function ActionSheet({
       
       <div className="border-t border-gray-200 dark:border-gray-700 p-2">
         <button
+          type="button"
           onClick={onClose}
           className="w-full justify-center py-3 font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
         >

--- a/src/components/MobileBottomSheet.tsx
+++ b/src/components/MobileBottomSheet.tsx
@@ -170,7 +170,15 @@ export function MobileBottomSheet({
             <h2 id="bottom-sheet-title" className="text-lg font-semibold text-gray-900 dark:text-white">
               {title}
             </h2>
+            {/* type="button" as a stated fact, not a live fix: today the
+                hosted <form> sits in the children BELOW this header, so the
+                untyped default was inert — but it still REPORTED type=submit,
+                and one restructure (a caller wrapping the sheet in its form)
+                away from being the transaction editor's stray-submitter bug
+                (#375) on this surface too. Chrome in a component that hosts
+                forms declares what it is; a spec pins it. */}
             <button
+              type="button"
               onClick={onClose}
               className="relative z-10 p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
               aria-label="Close bottom sheet"

--- a/src/components/ResponsiveModal.test.tsx
+++ b/src/components/ResponsiveModal.test.tsx
@@ -160,3 +160,33 @@ describe('ResponsiveModal', () => {
     expect(listenerCount()).toBe(0);
   });
 });
+
+/**
+ * THE SHEET'S OWN CHROME DECLARES WHAT IT IS (22 Aug, found while capturing
+ * the FX dialog). The close button carried no type and so REPORTED
+ * type="submit" — inert today, because the hosted form sits in the children
+ * below the header, but one caller restructure away from the transaction
+ * editor's stray-submitter bug (#375) landing on this surface. The spec pins
+ * the declared type and that closing never submits a hosted form.
+ */
+describe('the sheet close button is not a submitter', () => {
+  it('closes without submitting a hosted form', () => {
+    installMatchMedia(true);
+    const onClose = vi.fn();
+    const onSubmit = vi.fn((e: React.FormEvent) => e.preventDefault());
+
+    render(
+      <ResponsiveModal isOpen onClose={onClose} title="Add Transaction">
+        <form onSubmit={onSubmit}>
+          <input aria-label="Amount" />
+        </form>
+      </ResponsiveModal>
+    );
+
+    const close = screen.getByRole('button', { name: 'Close bottom sheet' });
+    expect((close as HTMLButtonElement).type).toBe('button');
+    close.click();
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Found while producing the FX-dialog captures for Claude Design (22 Aug): the bottom sheet's close button — and three more in `BottomSheet`'s chrome — carried no `type`, so each REPORTED `type="submit"`.

Inert today, and the commit says so honestly: the hosted `<form>` sits in the sheet's children below the header, so none of these was a live submitter. But each is one caller restructure (wrapping the sheet in its form) away from the transaction editor's stray-submitter bug (#375) landing on this surface — a Close that saves the transaction being abandoned.

All four declare `type="button"` now, per the #375 rule — chrome in a component that hosts forms says what it is — and a spec pins both the declared type and that closing never submits a hosted form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)