### PR TITLE
The drill's totals convert and say so, the closed page keeps the way back, and settings need no reopening

### DIFF
--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -27,6 +27,7 @@ import CardPeriodControl from './CardPeriodControl';
 import { WIDGET_CHART_HEIGHT } from './widgetChrome';
 import { useReportDrill } from './useReportDrill';
 import { useHistoricalAccounts } from '../../../hooks/useHistoricalAccounts';
+import { useNetWorthConversion } from '../../../hooks/useNetWorthConversion';
 
 /**
  * Compact, live versions of the Reports-hub reports for the Dashboard's
@@ -109,9 +110,22 @@ export function NetWorthWidget({ picker, pin }: {
    */
   const accounts = useHistoricalAccounts(openAccounts);
 
+  /**
+   * The SAME conversion the full report applies (ruling C: this card and the
+   * report may not disagree about the same money) — foreign-currency accounts
+   * convert at today's rates instead of counting native units as display
+   * units. The full provenance sentence lives on the report this card opens;
+   * the ≈ on the headline is this card's own honest mark.
+   */
+  const { conversion, displayCurrency } = useNetWorthConversion(accounts);
+  const holdsForeign = useMemo(
+    () => accounts.some(a => (a.currency || displayCurrency) !== displayCurrency),
+    [accounts, displayCurrency]
+  );
+
   const snapshots = useMemo(
-    () => buildNetWorthSnapshots(accounts, transactions, picker.range),
-    [accounts, transactions, picker.range]
+    () => buildNetWorthSnapshots(accounts, transactions, picker.range, new Date(), conversion ?? undefined),
+    [accounts, transactions, picker.range, conversion]
   );
   const latest = snapshots.length > 0 ? snapshots[snapshots.length - 1] : null;
 
@@ -124,7 +138,7 @@ export function NetWorthWidget({ picker, pin }: {
       subtitle={
         <>
           <span className="min-w-0 text-xl font-bold text-gray-900 dark:text-white truncate">
-            {latest ? formatCurrency(latest.netWorth) : '—'}
+            {latest ? `${holdsForeign ? '≈ ' : ''}${formatCurrency(latest.netWorth)}` : '—'}
           </span>
           {pin && <CardPeriodControl cardLabel={NET_WORTH_TITLE} picker={picker} pin={pin} />}
         </>

--- a/src/hooks/useNetWorthConversion.ts
+++ b/src/hooks/useNetWorthConversion.ts
@@ -1,0 +1,60 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { Account } from '../types';
+import { buildNetWorthConversion, type NetWorthConversion } from '../utils/netWorthSeries';
+import { getExchangeRatesWithProvenance, type RatesProvenance } from '../utils/currency-decimal';
+import { useCurrencyDecimal } from './useCurrencyDecimal';
+
+/**
+ * The net-worth series' currency conversion, for every surface that draws it
+ * (Claude Design, 22 Aug §1 — and the finding underneath: the walk summed
+ * native units as display units, so a dollar balance counted as that many
+ * pounds while the dashboard's summary converted properly).
+ *
+ * ONE hook, because two surfaces draw the same series — the report and the
+ * dashboard card — and ruling C is precisely that they may not disagree about
+ * the same money. Each computes its factors from the same rates cache every
+ * other conversion in the app uses.
+ *
+ * `conversion` is null while every account is already in the display currency
+ * — the single-currency majority pays nothing and sees no note. Until rates
+ * arrive (or if they never do) the foreign currencies are reported as
+ * UNCONVERTED rather than guessed: ConvertedTotalNote's serious state, said
+ * out loud.
+ */
+export function useNetWorthConversion(accounts: readonly Account[]): {
+  conversion: NetWorthConversion | null;
+  provenance: RatesProvenance | null;
+  displayCurrency: string;
+} {
+  const { displayCurrency } = useCurrencyDecimal();
+  const [ratesState, setRatesState] = useState<{ rates: Record<string, number>; provenance: RatesProvenance } | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    void (async () => {
+      try {
+        const { rates, provenance } = await getExchangeRatesWithProvenance();
+        if (live) setRatesState({ rates, provenance });
+      } catch {
+        // No rates at all: the walk stays native and the caller's note
+        // reports every foreign currency as unconverted. Nothing to throw
+        // at the user.
+      }
+    })();
+    return () => { live = false; };
+  }, []);
+
+  const conversion = useMemo((): NetWorthConversion | null => {
+    const foreign = accounts.filter(a => (a.currency || displayCurrency) !== displayCurrency);
+    if (foreign.length === 0) return null;
+    if (!ratesState) {
+      return {
+        factors: new Map(),
+        unconverted: [...new Set(foreign.map(a => a.currency))].sort(),
+      };
+    }
+    return buildNetWorthConversion(accounts, ratesState.rates, displayCurrency);
+  }, [accounts, ratesState, displayCurrency]);
+
+  return { conversion, provenance: ratesState?.provenance ?? null, displayCurrency };
+}

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -727,6 +727,10 @@ export default function AccountTransactions() {
    */
   const [showAddTransaction, setShowAddTransaction] = useState(false);
   const [showAccountSettings, setShowAccountSettings] = useState(false);
+  // The CLOSED page's settings dialog (owner, 22 Aug): regrouping or renaming
+  // a closed account must not cost a reopen–edit–close round trip. Its own
+  // flag, because the closed branch returns before the register's modal.
+  const [showClosedSettings, setShowClosedSettings] = useState(false);
   const [deleteConfirmTransaction, setDeleteConfirmTransaction] = useState<Transaction | null>(null);
   const [selectedTransactionId, setSelectedTransactionId] = useState<string | null>(null);
   /**
@@ -2991,13 +2995,14 @@ export default function AccountTransactions() {
     // hasn't got is an open register (the same rule as the Accounts page,
     // where a closed account offers Reopen rather than a way in).
     if (closedLookup.account) {
+      const closedAccount = closedLookup.account;
       return (
         <div className="flex flex-col h-full">
-          {/* No back-arrow chrome above the card: the two actions below ARE the
-              page, and a second "Back to Accounts" would only duplicate one. */}
+          {/* No back-arrow chrome above the card: the actions below ARE the
+              page, and a second back button would only duplicate one. */}
           <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6 max-w-2xl">
             <h1 className="text-xl font-bold text-gray-900 dark:text-white">
-              {closedLookup.account.name}
+              {closedAccount.name}
             </h1>
             <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
               This account is closed, and closed accounts don&rsquo;t have an open register.
@@ -3014,17 +3019,64 @@ export default function AccountTransactions() {
               >
                 {reopening ? 'Re-opening…' : 'Re-open and view'}
               </button>
+              {/* Settings WITHOUT reopening (owner, 22 Aug: "if I want to
+                  change in what group that account sits without re-opening I
+                  can go in to its settings") — the same no-round-trip rule
+                  the Accounts page's closed rows already follow. */}
               <button
                 type="button"
-                onClick={() => navigate(preserveDemoParam('/accounts', location.search))}
+                onClick={() => setShowClosedSettings(true)}
+                disabled={reopening}
+                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+              >
+                <SettingsIcon size={16} />
+                Account Settings
+              </button>
+              {/* THE WAY BACK IS WHERE THE READER CAME FROM (owner, 22 Aug):
+                  reached from the net-worth report's drill, "Back to
+                  Accounts" dumped him on the Accounts page mid-analysis. The
+                  same provenance the open register's back button honours is
+                  honoured here — the report's own path reopens the drill on
+                  the date he was reading. */}
+              <button
+                type="button"
+                onClick={() => (backTo
+                  ? navigate(backTo.path, { state: returnState(backTo) })
+                  : navigate(preserveDemoParam('/accounts', location.search)))}
                 disabled={reopening}
                 className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
               >
                 <ArrowLeftIcon size={16} />
-                Back to Accounts
+                {backTo ? backTo.label : 'Back to Accounts'}
               </button>
             </div>
           </div>
+          <AccountSettingsModal
+            isOpen={showClosedSettings}
+            onClose={() => setShowClosedSettings(false)}
+            account={closedAccount}
+            // The open accounts, which is what the pairing field pairs with —
+            // the Accounts page's own rule for its closed rows.
+            accounts={accounts}
+            hasTransactions={accountHasHistory(transactions, closedAccount.id)}
+            onSave={async (accountId, updates) => {
+              await updateAccount(accountId, updates);
+              if (updates.isActive === true) {
+                // Reopened from settings: the re-pull flips accountIsOpen and
+                // this page becomes the register on its own.
+                await refreshAccountsAndTransactions();
+              } else {
+                // Still closed: the lookup's copy is what this page renders,
+                // so refetch it and show the saved facts rather than the old
+                // ones — the same read the lookup itself makes.
+                const list = await dataPort.listClosedAccounts();
+                setClosedLookup({ status: 'done', account: list.find(a => a.id === accountId) ?? null });
+              }
+              if (updates.isActive !== undefined || updates.name !== undefined) {
+                await refreshCategories();
+              }
+            }}
+          />
         </div>
       );
     }

--- a/src/pages/NetWorthReport.tsx
+++ b/src/pages/NetWorthReport.tsx
@@ -20,6 +20,10 @@ import { toDecimal } from '../utils/decimal';
 import { formatDecimal } from '../utils/decimal-format';
 import { preserveDemoParam } from '../utils/navigation';
 import { buildNetWorthSnapshots, netWorthAxisTicks, netWorthPointToken, netWorthValueAxis } from '../utils/netWorthSeries';
+import { buildReportDrillPath } from '../utils/reportDrillLink';
+import { withProvenance } from '../utils/navigationProvenance';
+import ConvertedTotalNote from '../components/ConvertedTotalNote';
+import { useNetWorthConversion } from '../hooks/useNetWorthConversion';
 import { useArrivalAction } from '../hooks/useArrivalFocus';
 import { resolveEffectiveOpeningDates } from '../utils/openingDates';
 import { TrendingUpIcon, ChevronRightIcon } from '../components/icons';
@@ -120,7 +124,7 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
    * separately-computed figure, so it moves with them.
    */
   const accounts = useHistoricalAccounts(openAccounts);
-  const { formatCurrency } = useCurrencyDecimal();
+  const { formatCurrency, displayCurrency } = useCurrencyDecimal();
   // Watches the dark class rather than reading it once — the theme scheduler
   // can flip the ground under a mounted chart. The series does the same, and
   // for the same measured reason: the light navies are 1.08:1 on a dark card.
@@ -155,9 +159,16 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
     [transactions]
   );
 
+  /**
+   * The currency conversion for this series — the ONE hook the dashboard's
+   * net-worth card also calls, so the two surfaces cannot disagree about the
+   * same money (ruling C). See useNetWorthConversion for the whole account.
+   */
+  const { conversion, provenance: ratesProvenance } = useNetWorthConversion(accounts);
+
   const snapshots = useMemo(
-    () => buildNetWorthSnapshots(accounts, sortedTransactions, picker.range),
-    [accounts, sortedTransactions, picker.range]
+    () => buildNetWorthSnapshots(accounts, sortedTransactions, picker.range, new Date(), conversion ?? undefined),
+    [accounts, sortedTransactions, picker.range, conversion]
   );
 
   /**
@@ -316,15 +327,51 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
         return {
           section,
           entries,
-          subtotal: entries.reduce((sum, e) => sum.plus(e.balance), toDecimal(0)),
+          // CONVERTED into the display currency where a factor exists (Claude
+          // Design, 22 Aug §1): the rows print their own currency, but a band
+          // total mixing dollars into a pounds figure unit-for-unit was a
+          // number nobody quoted. Wears ≈ and the sheet's provenance line
+          // when any conversion (or unconverted residue) is in it.
+          subtotal: entries.reduce((sum, e) => {
+            const factor = conversion?.factors.get(e.account.id);
+            return sum.plus(factor ? e.balance.times(factor) : e.balance);
+          }, toDecimal(0)),
+          holdsForeign: entries.some(e => (e.account.currency || displayCurrency) !== displayCurrency),
         };
       });
-  }, [drillBalances, drillSort]);
+  }, [drillBalances, drillSort, conversion, displayCurrency]);
 
   const drillAll = useMemo(
     () => drillGroups.flatMap(group => group.entries),
     [drillGroups]
   );
+
+  /** Any foreign money in the drilled day at all — gates the ≈ and its line. */
+  const drillHoldsForeign = useMemo(
+    () => drillBalances.some(e => (e.account.currency || displayCurrency) !== displayCurrency),
+    [drillBalances, displayCurrency]
+  );
+
+  /**
+   * Open an account's register FROM the drill, with the way back stated
+   * (owner, 22 Aug): the register's back button — and the closed-account
+   * page's — reads this provenance and returns HERE, to this report with the
+   * drill reopened on the same date, via the same focus token the Dashboard's
+   * card already lands on. Without it, "Back to Accounts" dumped the reader
+   * on the Accounts page mid-analysis.
+   */
+  const openRegisterFromDrill = useCallback((accountId: string): void => {
+    const state = drillDate
+      ? withProvenance({
+          path: buildReportDrillPath('net-worth-over-time', {
+            focus: netWorthPointToken(drillDate),
+            currentSearch: location.search,
+          }),
+          label: 'Back to report',
+        })
+      : undefined;
+    navigate(preserveDemoParam(`/accounts/${accountId}`, location.search), { state });
+  }, [drillDate, navigate, location.search]);
 
   return (
     <div className="max-w-[1400px] mx-auto">
@@ -362,6 +409,17 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
             {change.greaterThanOrEqualTo(0) ? '+' : ''}{formatCurrency(change.toNumber())}
           </span>.
         </p>
+        {/* The SAME provenance note the summary card carries everywhere else
+            (ruling C reaching this surface, Claude Design 22 Aug §1) — only
+            when a conversion is actually in the figures. Rendered nothing for
+            the single-currency majority, per the data-health rule. */}
+        {conversion && (
+          <ConvertedTotalNote
+            provenance={conversion.factors.size > 0 ? ratesProvenance : null}
+            unconverted={conversion.unconverted}
+            displayCurrency={displayCurrency}
+          />
+        )}
       </div>
 
       {/* Opening-date caveat — shown right above the chart it qualifies, and
@@ -661,11 +719,11 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
                     <button
                       key={account.id}
                       type="button"
-                      onClick={() => navigate(preserveDemoParam(`/accounts/${account.id}`, location.search))}
+                      onClick={() => openRegisterFromDrill(account.id)}
                       className="w-full flex items-center gap-3 py-2.5 text-left hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors rounded-lg px-2 -mx-2"
                       title="Open this account's register"
                     >
-                      <span className="flex-1 min-w-0 truncate text-sm text-gray-800 dark:text-gray-200">{account.name}</span>
+                      <span className="flex-1 min-w-0 text-sm text-gray-800 dark:text-gray-200 break-words line-clamp-2">{account.name}</span>
                       <span className={`text-sm font-semibold tabular-nums ${
                         balance.greaterThanOrEqualTo(0) ? 'text-gray-900 dark:text-white' : 'text-red-600 dark:text-red-400'
                       }`}>
@@ -688,7 +746,9 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
                         <span className={`text-sm font-semibold tabular-nums ${
                           group.subtotal.greaterThanOrEqualTo(0) ? 'text-gray-900 dark:text-white' : 'text-red-600 dark:text-red-400'
                         }`}>
-                          {formatCurrency(group.subtotal.toNumber())}
+                          {/* ≈ when the band holds converted money — the mark
+                              the summary cards already use for the same fact. */}
+                          {group.holdsForeign ? '≈ ' : ''}{formatCurrency(group.subtotal.toNumber())}
                         </span>
                       </div>
                       {drillView === 'grouped' && (
@@ -697,11 +757,11 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
                             <button
                               key={account.id}
                               type="button"
-                              onClick={() => navigate(preserveDemoParam(`/accounts/${account.id}`, location.search))}
+                              onClick={() => openRegisterFromDrill(account.id)}
                               className="w-full flex items-center gap-3 py-2 text-left hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors rounded-lg px-2"
                               title="Open this account's register"
                             >
-                              <span className="flex-1 min-w-0 truncate text-sm text-gray-800 dark:text-gray-200">{account.name}</span>
+                              <span className="flex-1 min-w-0 text-sm text-gray-800 dark:text-gray-200 break-words line-clamp-2">{account.name}</span>
                               <span className={`text-sm font-semibold tabular-nums ${
                                 balance.greaterThanOrEqualTo(0) ? 'text-gray-900 dark:text-white' : 'text-red-600 dark:text-red-400'
                               }`}>
@@ -720,11 +780,30 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
               <div className="flex items-center justify-between pt-3 mt-1 border-t border-gray-200 dark:border-gray-700">
                 <span className="text-sm font-semibold text-gray-900 dark:text-white">Net worth</span>
                 <span className="text-sm font-bold tabular-nums text-gray-900 dark:text-white">
+                  {drillHoldsForeign ? '≈ ' : ''}
                   {formatCurrency(
-                    drillBalances.reduce((sum, e) => sum.plus(e.balance), toDecimal(0)).toNumber()
+                    drillBalances.reduce((sum, e) => {
+                      const factor = conversion?.factors.get(e.account.id);
+                      return sum.plus(factor ? e.balance.times(factor) : e.balance);
+                    }, toDecimal(0)).toNumber()
                   )}
                 </span>
               </div>
+              {/* THE RATE BASIS, SAID (Claude Design, 22 Aug §1): a historic
+                  drill converts at SOME date's rate, and which one is a real
+                  decision the reader cannot infer. The app holds no
+                  historical rate table, so the answer is today's — defensible
+                  only if stated. Rendered nothing when nothing converted. */}
+              {drillHoldsForeign && (
+                <p className="pt-2 text-dense text-gray-500 dark:text-gray-400">
+                  ≈ marks totals holding another currency, converted at{' '}
+                  {ratesProvenance
+                    ? <>today&rsquo;s rates (as of {ratesProvenance.asOf.toLocaleTimeString(getDateLocale(), { hour: '2-digit', minute: '2-digit' })})</>
+                    : 'no available rate — those amounts are counted unconverted'}
+                  {' '}applied to that day&rsquo;s balances. Each account&rsquo;s own
+                  figure is shown in its own currency.
+                </p>
+              )}
             </div>
           )}
         </ModalBody>

--- a/src/pages/__tests__/AccountTransactions.registerChrome.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.registerChrome.test.tsx
@@ -306,3 +306,72 @@ describe('a register emptied by a filter is not an empty register', () => {
     expect(screen.queryByRole('heading', { name: 'No transactions match these filters' })).not.toBeInTheDocument();
   });
 });
+
+/**
+ * THE CLOSED PAGE KEEPS THE WAY BACK, AND OFFERS SETTINGS WITHOUT REOPENING
+ * (owner, 22 Aug): reached from the net-worth report's drill, "Back to
+ * Accounts" dumped him on the Accounts page mid-analysis — the same
+ * provenance the open register's back button honours is honoured here. And
+ * regrouping a closed account must not cost a reopen–edit–close round trip,
+ * the rule the Accounts page's closed rows already follow.
+ */
+describe('a closed account reached from a report', () => {
+  const CLOSED: Account = {
+    id: 'acc-shut', name: 'Synthetic Shuttered', type: 'savings', balance: 0,
+    currency: 'GBP', lastUpdated: new Date('2026-01-01'), openingBalance: 0, isActive: false,
+  };
+
+  it('offers Account Settings, and the way back is where the reader came from', async () => {
+    __setAppContextValue({ accounts: [], transactions: [], categories: [], isLoading: false });
+    vi.spyOn(DataService, 'listClosedAccounts').mockResolvedValue([CLOSED]);
+
+    render(
+      <MemoryRouter initialEntries={[{
+        pathname: `/accounts/${CLOSED.id}`,
+        state: { from: { path: '/reports/net-worth-over-time?focus=2014-07-31', label: 'Back to report' } },
+      }]}>
+        <PreferencesProvider>
+          <ToastProvider>
+            <NotificationProvider>
+              <Routes>
+                <Route path="/reports/net-worth-over-time" element={<div>Report page</div>} />
+                <Route path="/accounts/:accountId" element={<AccountTransactions />} />
+              </Routes>
+            </NotificationProvider>
+          </ToastProvider>
+        </PreferencesProvider>
+      </MemoryRouter>
+    );
+
+    await screen.findByRole('heading', { level: 1, name: 'Synthetic Shuttered' });
+    expect(screen.getByRole('button', { name: 'Account Settings' })).toBeInTheDocument();
+    // The provenance label, not the hardcoded fallback…
+    const back = screen.getByRole('button', { name: 'Back to report' });
+    expect(screen.queryByRole('button', { name: 'Back to Accounts' })).not.toBeInTheDocument();
+    // …and it genuinely goes there.
+    fireEvent.click(back);
+    expect(await screen.findByText('Report page')).toBeInTheDocument();
+  });
+
+  it('falls back to Back to Accounts on a direct arrival', async () => {
+    __setAppContextValue({ accounts: [], transactions: [], categories: [], isLoading: false });
+    vi.spyOn(DataService, 'listClosedAccounts').mockResolvedValue([CLOSED]);
+
+    render(
+      <MemoryRouter initialEntries={[`/accounts/${CLOSED.id}`]}>
+        <PreferencesProvider>
+          <ToastProvider>
+            <NotificationProvider>
+              <Routes>
+                <Route path="/accounts/:accountId" element={<AccountTransactions />} />
+              </Routes>
+            </NotificationProvider>
+          </ToastProvider>
+        </PreferencesProvider>
+      </MemoryRouter>
+    );
+
+    await screen.findByRole('heading', { level: 1, name: 'Synthetic Shuttered' });
+    expect(screen.getByRole('button', { name: 'Back to Accounts' })).toBeInTheDocument();
+  });
+});

--- a/src/utils/netWorthSeries.test.ts
+++ b/src/utils/netWorthSeries.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildNetWorthSnapshots, netWorthAxisTicks, netWorthValueAxis } from './netWorthSeries';
+import { buildNetWorthSnapshots, buildNetWorthConversion, netWorthAxisTicks, netWorthValueAxis } from './netWorthSeries';
 import type { Account, Transaction } from '../types';
 import type { PeriodRange } from '../hooks/usePeriod';
 
@@ -185,5 +185,44 @@ describe('netWorthValueAxis — the floor belongs to the data, not the tick step
   it('an empty or all-zero series stays sane', () => {
     expect(netWorthValueAxis([])).toEqual({ domain: [0, 1], ticks: [0, 1] });
     expect(netWorthValueAxis([0, 0])).toEqual({ domain: [0, 1], ticks: [0, 1] });
+  });
+});
+
+/**
+ * FOREIGN MONEY JOINS THE SUM CONVERTED, NOT UNIT-FOR-UNIT (Claude Design,
+ * 22 Aug §1 — and the finding underneath it: the walk summed a dollar
+ * account's native units as pounds, while the dashboard's summary converted.
+ * The two could disagree by the whole unconverted delta).
+ *
+ * The rate table is the app's own shape: units of each currency per one GBP,
+ * so a factor from USD into GBP is rates.GBP / rates.USD. Every figure here
+ * is invented; the repo is public.
+ */
+describe('buildNetWorthSnapshots — currency conversion at the summing', () => {
+  const book = [
+    account({ id: 'gbp-1', name: 'Sterling Current', openingBalance: 1000, openingBalanceDate: D(2026, 1, 1) }),
+    account({ id: 'usd-1', name: 'Dollar Current', currency: 'USD', openingBalance: 200, openingBalanceDate: D(2026, 1, 1) }),
+  ];
+
+  it('applies each account\'s factor at the sum, leaving native walks native', () => {
+    const conversion = buildNetWorthConversion(book, { GBP: 1, USD: 2 }, 'GBP');
+    // Two dollars to the pound: the $200 opening joins the total as £100.
+    const snaps = buildNetWorthSnapshots(book, [], RANGE, new Date(2026, 2, 28), conversion);
+    expect(on(snaps, 14)?.netWorth).toBe(1100);
+    expect(conversion.unconverted).toEqual([]);
+  });
+
+  it('without a conversion the old native-unit behaviour is unchanged', () => {
+    const snaps = buildNetWorthSnapshots(book, [], RANGE, new Date(2026, 2, 28));
+    expect(on(snaps, 14)?.netWorth).toBe(1200);
+  });
+
+  it('a currency with no rate is counted native and REPORTED, never guessed', () => {
+    const conversion = buildNetWorthConversion(book, { GBP: 1 }, 'GBP');
+    expect(conversion.unconverted).toEqual(['USD']);
+    expect(conversion.factors.size).toBe(0);
+    const snaps = buildNetWorthSnapshots(book, [], RANGE, new Date(2026, 2, 28), conversion);
+    // Native fallback: the figure carries the residue the caller must say.
+    expect(on(snaps, 14)?.netWorth).toBe(1200);
   });
 });

--- a/src/utils/netWorthSeries.ts
+++ b/src/utils/netWorthSeries.ts
@@ -1,8 +1,54 @@
 import type { Account, Transaction } from '../types';
-import { toDecimal } from './decimal';
+import { toDecimal, type DecimalInstance } from './decimal';
 import { resolveEffectiveOpeningDates } from './openingDates';
 import type { PeriodRange } from '../hooks/usePeriod';
 import { getDateLocale } from '../utils/dateFormatter';
+
+/**
+ * How foreign-currency accounts join a net-worth sum (Claude Design, 22 Aug
+ * §1 — and the finding underneath it: the walk was summing every account's
+ * NATIVE units as display-currency units, so a dollar account's balance
+ * counted as that many pounds. The dashboard's summary converts; this series
+ * did not, and the two could disagree by the whole unconverted delta).
+ *
+ * `factors` multiplies an account's native balance into the display currency
+ * at TODAY'S rates — which is a real decision for a historic series, and the
+ * caller's provenance line must say it: yesterday's balance at today's rate,
+ * because the app holds no historical rate table. An account with no factor
+ * (its currency has no rate) counts UNCONVERTED, exactly as the summary's
+ * ConvertedTotalNote already reports that state — wrong by however much it
+ * was worth, and said out loud rather than guessed at parity.
+ */
+export interface NetWorthConversion {
+  /** Multiplier into the display currency, per account id. Absent = native. */
+  factors: Map<string, DecimalInstance>;
+  /** Currency codes with no rate: their amounts counted unconverted. */
+  unconverted: string[];
+}
+
+/** Build the per-account factors from a units-per-GBP rate table. */
+export function buildNetWorthConversion(
+  accounts: readonly Pick<Account, 'id' | 'currency'>[],
+  rates: Record<string, number>,
+  displayCurrency: string
+): NetWorthConversion {
+  const factors = new Map<string, DecimalInstance>();
+  const unconverted = new Set<string>();
+  const displayRate = rates[displayCurrency];
+  for (const account of accounts) {
+    const currency = account.currency || displayCurrency;
+    if (currency === displayCurrency) continue;
+    const accountRate = rates[currency];
+    if (!accountRate || !displayRate) {
+      unconverted.add(currency);
+      continue;
+    }
+    // The table is units per GBP, so A→B is rates[B]/rates[A]; GBP is only
+    // the pivot — the same arithmetic useFxQuote documents.
+    factors.set(account.id, toDecimal(displayRate).dividedBy(toDecimal(accountRate)));
+  }
+  return { factors, unconverted: [...unconverted].sort() };
+}
 
 export interface NetWorthSnapshot {
   date: Date;
@@ -49,7 +95,8 @@ export function buildNetWorthSnapshots(
   accounts: Account[],
   transactions: Transaction[],
   range: PeriodRange,
-  now: Date = new Date()
+  now: Date = new Date(),
+  conversion?: NetWorthConversion
 ): NetWorthSnapshot[] {
   if (accounts.length === 0) return [];
 
@@ -120,7 +167,13 @@ export function buildNetWorthSnapshots(
     }
     let assets = toDecimal(0);
     let liabilities = toDecimal(0);
-    for (const b of balances.values()) {
+    for (const [accountId, native] of balances.entries()) {
+      // Into the display currency where a factor exists; native (and reported
+      // by the caller as unconverted) where it does not. Balances stay native
+      // through the walk — the transactions are native — and convert only at
+      // the summing, so one rate refresh never has to replay the history.
+      const factor = conversion?.factors.get(accountId);
+      const b = factor ? native.times(factor) : native;
       if (b.greaterThan(0)) assets = assets.plus(b);
       else liabilities = liabilities.plus(b.abs());
     }


### PR DESCRIPTION
Owner asks (22 Aug) + Claude Design's second 22-Aug handover §1–§2. The remaining sections (§3–§7) follow in a second PR.

## The owner's two asks — the closed page reached from the report

- **Account Settings without reopening.** A closed account's page offered only "Re-open and view" — changing its group cost a reopen–edit–close round trip. The page now carries an **Account Settings** button opening the same modal the Accounts page uses. Saving a regroup refreshes the closed lookup; saving a reopen refreshes accounts and transactions so the register appears in place.
- **"Back to report", not "Back to Accounts".** The drill's account buttons now write navigation provenance: arriving at a register (open or closed) from the report shows **Back to report**, and following it returns to the report **with the drill reopened on the same date** via the focus token the dashboard card already lands on. A direct arrival still falls back to Back to Accounts. Two specs pin both ways.

## Design §1 — and the finding underneath it

The series never converted at all: the walk summed each account's **native units as display units**, so a dollar balance counted as that many pounds, while the dashboard summary converted properly. Now:

- `buildNetWorthConversion` computes per-account factors from the app's one rates cache; a currency with no rate stays **native and reported**, never guessed at parity.
- One hook — `useNetWorthConversion` — feeds **both** surfaces that draw the series (report + dashboard card), so they cannot disagree (ruling C).
- The report carries the summary's own `ConvertedTotalNote`; drill band totals wear `≈` when they hold foreign money; and the sheet states the rate basis in words: **today's rates applied to that day's balances** (the app holds no historical rate table — defensible, and now stated, exactly as the handover asked).
- Three walk specs pin factor application, missing-rate reporting, and the no-conversion path.

## Design §2 — six of thirteen rows unidentifiable

Drill row names wrap to two lines (`line-clamp-2`) instead of truncating — the two-line option, costing vertical space and reading instantly.

Every figure in the tests is invented; the repo is public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)