### PR TITLE
The FX caveat arrives before the decision, one dark selected-state, one subtitle, an earned legend, and Budget's tabs stand down

### DIFF
--- a/src/components/CrossCurrencyTransferDialog.test.tsx
+++ b/src/components/CrossCurrencyTransferDialog.test.tsx
@@ -151,6 +151,27 @@ describe('CrossCurrencyTransferDialog', () => {
     expect(conversion.rate.toString()).toBe('1.1');
   });
 
+  it('says the rate is approximate BEFORE the rate field, not after it', async () => {
+    // Claude Design, 22 Aug §4: the degraded sentence used to sit below the
+    // fields — a reader filled the rate and read the arriving amount, and only
+    // then met the line telling them the rate was approximate, after the
+    // decision it should inform. One slot above the fields now carries every
+    // state: source-and-timestamp when live, this sentence when not.
+    quoteFails();
+    render(
+      <CrossCurrencyTransferDialog
+        {...props}
+        destinationCurrency="XYZ"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    const notice = await screen.findByText(/No rate available offline/);
+    const position = notice.compareDocumentPosition(rateBox('XYZ'));
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it('cannot be confirmed on a half-typed box', async () => {
     quoteResponds({ GBP: 1, USD: 1.25 });
     render(<CrossCurrencyTransferDialog {...props} onConfirm={vi.fn()} onCancel={vi.fn()} />);

--- a/src/components/CrossCurrencyTransferDialog.tsx
+++ b/src/components/CrossCurrencyTransferDialog.tsx
@@ -245,7 +245,40 @@ export default function CrossCurrencyTransferDialog({
           recorded exactly as you enter them.
         </p>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-2">
+        {/* Provenance, in the sentence the design pass asks for: who quoted it
+            and when. Neutral grey — a rate that is merely old is not a warning,
+            and an amber here would spend the one the yellow thread owns.
+            ABOVE the fields, at body size (Claude Design 22 Aug §4): a reader
+            meets what qualifies the rate BEFORE filling the rate field, not
+            after the decision it should inform. One slot for all three states —
+            source and timestamp when live, the degraded sentence when not — so
+            the absence of provenance occupies the space provenance would have. */}
+        <p className="text-body text-gray-500 dark:text-gray-400 mb-4 min-h-[20px]">
+          {quote.status === 'loading' && 'Fetching a rate…'}
+          {/* THE SOURCE AND THE TIME, and not the rate a second time (Claude
+              Design §9.2). The field directly below this already prints the
+              rate in an input the reader can edit; repeating it here in full
+              spent a line saying something already on screen, and pushed the
+              two things this line ALONE can carry — who quoted it and when —
+              to the end where they read as an afterthought. */}
+          {quote.status === 'ready' && quote.source === 'api' && (
+            /* The ethos said once, where it is being enforced (Design, 17 Aug
+               §6): this dialog already records more about a converted figure
+               than most apps show — say that it does. */
+            <>{quote.provider}, {quotedAt}. Every converted figure records the
+            rate it used and when.</>
+          )}
+          {quote.status === 'ready' && quote.source === 'fallback' && (
+            <>No live rate right now, so this one is approximate — check it against your
+            statement before confirming.</>
+          )}
+          {quote.status === 'unavailable' && (
+            <>No rate available offline. Enter the rate or the amount that arrived — either
+            one fills in the other.</>
+          )}
+        </p>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-5">
           <div>
             <label
               htmlFor="cross-currency-rate"
@@ -297,34 +330,6 @@ export default function CrossCurrencyTransferDialog({
             </div>
           </div>
         </div>
-
-        {/* Provenance, in the sentence the design pass asks for: who quoted it
-            and when. Neutral grey — a rate that is merely old is not a warning,
-            and an amber here would spend the one the yellow thread owns. */}
-        <p className="text-dense text-gray-500 dark:text-gray-400 mb-5 min-h-[16px]">
-          {quote.status === 'loading' && 'Fetching a rate…'}
-          {/* THE SOURCE AND THE TIME, and not the rate a second time (Claude
-              Design §9.2). The field directly above this already prints the
-              rate in an input the reader can edit; repeating it here in full
-              spent a line saying something already on screen, and pushed the
-              two things this line ALONE can carry — who quoted it and when —
-              to the end where they read as an afterthought. */}
-          {quote.status === 'ready' && quote.source === 'api' && (
-            /* The ethos said once, where it is being enforced (Design, 17 Aug
-               §6): this dialog already records more about a converted figure
-               than most apps show — say that it does. */
-            <>{quote.provider}, {quotedAt}. Every converted figure records the
-            rate it used and when.</>
-          )}
-          {quote.status === 'ready' && quote.source === 'fallback' && (
-            <>No live rate right now, so this one is approximate — check it against your
-            statement before confirming.</>
-          )}
-          {quote.status === 'unavailable' && (
-            <>No rate available offline. Enter the rate or the amount that arrived — either
-            one fills in the other.</>
-          )}
-        </p>
 
         <div className="flex flex-wrap gap-3 justify-end items-center">
           <button

--- a/src/pages/Budget.tsx
+++ b/src/pages/Budget.tsx
@@ -280,19 +280,30 @@ function BudgetView() {
     }
   }, [budgets, transactions, categories, transactionSplits, foreignAccountIds, checkEnhancedBudgetAlerts]);
 
+  // The six methodology tabs are furniture for content that doesn't exist
+  // until a budget does (Claude Design 22 Aug §7) — the summary trio already
+  // stands down over the empty page, and the tab strip answers to the same
+  // rule. While the tabs are away the page shows the traditional view, which
+  // is where the empty state and its remedies live.
+  const tabsEarned = isLoading || budgets.length > 0;
+  const view = tabsEarned ? activeTab : 'traditional';
+
   return (
-    <PageWrapper 
+    <PageWrapper
       title="Budget"
       rightContent={
         <button
           onClick={() => setIsModalOpen(true)}
           className="inline-flex items-center gap-2 px-4 py-2 bg-[#1a2332] text-white text-body font-medium rounded-lg hover:bg-[#2d3a4d] transition-colors shadow-sm"
-          title="Add Budget"
+          title="Create a budget"
         >
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
             <path d="M12 5v14M5 12h14" />
           </svg>
-          Add Budget
+          {/* The empty state's words (Claude Design 22 Aug §7): two labels for
+              one action — "+ Add Budget" here, "+ Create a budget" there —
+              were two primaries in two cases on one page. */}
+          Create a budget
         </button>
       }
     >
@@ -300,7 +311,9 @@ function BudgetView() {
       <div className="flex justify-end mb-2">
         <WholePoundsToggle />
       </div>
-      {/* Navigation Tabs */}
+      {/* Navigation Tabs — only once there is a budget for them to slice
+          (Claude Design 22 Aug §7). */}
+      {tabsEarned && (
       <div className="flex space-x-1 bg-gray-100 dark:bg-gray-700 p-1 rounded-lg mb-6">
         <button
           onClick={() => setActiveTab('traditional')}
@@ -371,9 +384,10 @@ function BudgetView() {
           Zero-Based
         </button>
       </div>
+      )}
 
       {/* Tab Content */}
-      {activeTab === 'traditional' && (
+      {view === 'traditional' && (
         <div className="grid gap-6">
         {/* Summary Cards — HIDDEN WHILE THERE ARE NO BUDGETS (Claude Design,
             22 Aug §3). Three £0.00 cards above "no budgets yet" are furniture
@@ -579,27 +593,27 @@ function BudgetView() {
       )}
 
       {/* Envelope Budgeting Tab */}
-      {activeTab === 'envelope' && (
+      {view === 'envelope' && (
         <EnvelopeBudgeting />
       )}
 
       {/* Templates Tab */}
-      {activeTab === 'templates' && (
+      {view === 'templates' && (
         <RecurringBudgetTemplates />
       )}
 
       {/* Rollover Tab */}
-      {activeTab === 'rollover' && (
+      {view === 'rollover' && (
         <BudgetRollover />
       )}
 
       {/* Alerts Tab */}
-      {activeTab === 'alerts' && (
+      {view === 'alerts' && (
         <SpendingAlerts />
       )}
 
       {/* Zero-Based Budgeting Tab */}
-      {activeTab === 'zero-based' && (
+      {view === 'zero-based' && (
         <ZeroBasedBudgeting />
       )}
 

--- a/src/pages/NetWorthReport.tsx
+++ b/src/pages/NetWorthReport.tsx
@@ -402,13 +402,16 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
           assets={latest ? formatCurrency(latest.assets) : '—'}
           liabilities={latest ? formatCurrency(latest.liabilities) : '—'}
         />
-        <p className="text-body text-gray-600 dark:text-gray-400">
-          {latest ? <>As at <span className="font-medium text-gray-900 dark:text-gray-100">{latest.label}</span>. </> : null}
-          Change over the period{' '}
-          <span className={change.greaterThanOrEqualTo(0) ? 'font-medium text-green-600 dark:text-green-400' : 'font-medium text-red-600 dark:text-red-400'}>
-            {change.greaterThanOrEqualTo(0) ? '+' : ''}{formatCurrency(change.toNumber())}
-          </span>.
-        </p>
+        {/* The date alone. The change figure lived here too, and again as the
+            band's CHANGE tile two hundred pixels down — the same money said
+            twice (Claude Design 22 Aug §5). The band keeps it: it stands with
+            Started/Ended and the period %, which is where a change figure can
+            actually be read against something. */}
+        {latest && (
+          <p className="text-body text-gray-600 dark:text-gray-400">
+            As at <span className="font-medium text-gray-900 dark:text-gray-100">{latest.label}</span>.
+          </p>
+        )}
         {/* The SAME provenance note the summary card carries everywhere else
             (ruling C reaching this surface, Claude Design 22 Aug §1) — only
             when a conversion is actually in the figures. Rendered nothing for
@@ -466,7 +469,12 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
               title={showDetail ? 'Hide the assets and liabilities series' : 'Also show assets and liabilities'}
               className={`px-3 py-1 text-sm font-medium rounded-lg border transition-colors ${
                 showDetail
-                  ? 'border-[#1a2332] dark:border-blue-500 bg-[#1a2332] dark:bg-blue-600 text-white'
+                  /* The selected fill is the slate the period picker's ruling
+                     blessed (`dark:bg-[#2d3a4d]`), because this button stands
+                     in the SAME row as that picker — a stock dark:bg-blue-600
+                     here was a second selected-state identity six pixels from
+                     the first, on one ground only (Claude Design 22 Aug §3). */
+                  ? 'border-[#1a2332] dark:border-[#2d3a4d] bg-[#1a2332] dark:bg-[#2d3a4d] text-white'
                   : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
               }`}
             >
@@ -480,7 +488,7 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
                   onClick={() => handleChartType(type)}
                   className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
                     chartType === type
-                      ? 'bg-[#1a2332] dark:bg-blue-600 text-white'
+                      ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white'
                       : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
                   }`}
                 >
@@ -490,9 +498,19 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
             </div>
           </div>
         </div>
-        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
-          Computed from your full transaction history. Click any point to see every account's balance on that date.
-        </p>
+        {/* The card's subtitle used to restate the page header's ("computed
+            from your full history… click any point") two hundred pixels apart
+            (Claude Design 22 Aug §5). It now says the one thing the header
+            can't: what "growth" means on this card — the honesty line that
+            was below the band, in the slot a reader actually passes on the
+            way to the figures it qualifies. */}
+        {latest && earliest && snapshots.length > 1 && (
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+            Growth of everything you own less what you owe — money you saved counts
+            as growth here, unlike the portfolio&rsquo;s return figures, which strip
+            your payments in and out.
+          </p>
+        )}
         {/* ─ THE GROWTH BAND ─────────────────────────────────────────────────
             The Investments strip's shape, for the whole balance sheet, so the
             two rates can stand side by side — which is the owner's stated
@@ -551,11 +569,6 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
                 )}
               </div>
             </div>
-            <p className="mt-2 text-dense text-gray-500 dark:text-gray-400">
-              Growth of everything you own less what you owe — money you saved counts
-              as growth here, unlike the portfolio&rsquo;s return figures, which strip
-              your payments in and out.
-            </p>
           </div>
         )}
         {snapshots.length === 0 ? (
@@ -599,7 +612,11 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
                   formatter={(value: number | string) => formatCurrency(typeof value === 'number' ? value : Number(value))}
                   contentStyle={chartTooltipStyle} separator=": "
                 />
-                <Legend content={<DecompositionLegend />} />
+                {/* A legend distinguishes series; with one line there is
+                    nothing to distinguish and the card title already names it
+                    (Claude Design 22 Aug §6). Three series is when it earns
+                    its row. */}
+                {showDetail && <Legend content={<DecompositionLegend />} />}
                 {chartType === 'bar' ? (
                   // Money-style bar view: net worth as bars, assets/liabilities
                   // as context lines. Same data, same click-to-drill.
@@ -677,7 +694,7 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
                       aria-pressed={drillView === mode}
                       className={`px-2.5 py-1 text-sm font-medium rounded-md whitespace-nowrap transition-colors ${
                         drillView === mode
-                          ? 'bg-[#1a2332] dark:bg-blue-600 text-white'
+                          ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white'
                           : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
                       }`}
                     >

--- a/src/pages/__tests__/Budget.test.tsx
+++ b/src/pages/__tests__/Budget.test.tsx
@@ -275,13 +275,35 @@ describe('Budget page — an empty page is an empty state, not zeroed furniture'
     renderBudget();
 
     expect(await screen.findByRole('heading', { level: 3, name: 'No budgets yet' })).toBeInTheDocument();
-    // The consequence, then the remedies as real controls.
+    // The consequence, then the remedies as real controls. TWO controls carry
+    // the same words on purpose — the header button took the empty state's
+    // label (Claude Design 22 Aug §7: "+ Add Budget" and "+ Create a budget"
+    // were two primaries in two cases for one action).
     expect(screen.getByText(/nothing on this page has anything to measure against/)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Create a budget' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Create a budget' })).toHaveLength(2);
     expect(screen.getByRole('button', { name: 'See last year’s spending' })).toBeInTheDocument();
     // No furniture: the three summary cards do not render over an empty page.
     expect(screen.queryByText('Total Budgeted')).not.toBeInTheDocument();
     expect(screen.queryByText('Total Spent')).not.toBeInTheDocument();
     expect(screen.queryByText('Total Remaining')).not.toBeInTheDocument();
+    // Nor the six methodology tabs — a choice of budgeting philosophies is
+    // furniture until there is a budget to slice (Claude Design 22 Aug §7).
+    expect(screen.queryByRole('button', { name: 'Envelope' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Zero-Based' })).not.toBeInTheDocument();
+  });
+
+  it('brings the tabs back the moment a budget exists', async () => {
+    // Every figure here is invented; the repo is public.
+    __setAppContextValue({
+      accounts: ACCOUNTS,
+      categories: CATEGORIES,
+      budgets: [budget({ id: 'bud-groceries', categoryId: 'det-groceries', amount: 200 })],
+      transactions: [],
+      transactionSplits: [],
+    });
+    renderBudget();
+
+    expect(await screen.findByRole('button', { name: 'Envelope' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Zero-Based' })).toBeInTheDocument();
   });
 });

--- a/src/test/integration/BudgetWorkflowIntegration.test.tsx
+++ b/src/test/integration/BudgetWorkflowIntegration.test.tsx
@@ -56,8 +56,8 @@ describe('Budget Workflow Integration', () => {
         expect(screen.getByRole('heading', { level: 1, name: /budget/i })).toBeInTheDocument();
       });
 
-      // Click the Add Budget icon
-      const addBudgetIcon = screen.getByTitle('Add Budget');
+      // Click the Create a budget icon
+      const addBudgetIcon = screen.getByTitle('Create a budget');
       await user.click(addBudgetIcon);
 
       // Wait for modal to appear
@@ -212,8 +212,8 @@ describe('Budget Workflow Integration', () => {
         expect(screen.getByRole('heading', { level: 1, name: /budget/i })).toBeInTheDocument();
       });
 
-      // Click Add Budget icon
-      const addBudgetIcon = screen.getByTitle('Add Budget');
+      // Click Create a budget icon
+      const addBudgetIcon = screen.getByTitle('Create a budget');
       await user.click(addBudgetIcon);
 
       await waitFor(() => {


### PR DESCRIPTION
Claude Design's second 22-Aug handover, §3–§7 (§1–§2 shipped in #382).

## §3 `FIX` — one selected-state identity in dark mode

The net worth report's dark ground had the period picker's ruling-blessed slate (`dark:bg-[#2d3a4d]`) six pixels from a stock `dark:bg-blue-600` that appears nowhere in the token set — two identities for one control kind, on one ground only. All three of the report's control clusters (Assets & Liabilities toggle, Line/Bar segmented, the drill's view pills) now wear the slate.

**The grep Design asked for**: the stock blue stands in for the primary in **49 places across 20 files** (vs 15 uses of the slate). That census goes back to Design for a ruling before anyone sweeps it — it is a system decision, not a mechanical find-and-replace.

## §4 `QUIET` — the degraded FX notice moves above the rate field

It was the smallest text on the sheet and sat below the fields — read after the decision it should inform. One slot **above the rate field at body size** now carries every state: source-and-timestamp when live, the degraded sentence when not, so the absence of provenance occupies the space provenance would have. A spec pins the document order (notice precedes the rate input).

## §5 `QUIET` — one subtitle, one Change

The page header keeps the date alone (the change figure now lives only in the band's CHANGE tile, beside Started/Ended and the period %). The card's subtitle no longer restates the header — it says the one thing the header can't: the growth honesty-line that was below the band.

## §6 `QUIET` — the legend is earned

Rendered only when Assets & Liabilities is on and there are three series to distinguish.

## §7 `QUIET` — Budget's tabs stand down over the empty page

The six methodology tabs answer to the same rule as the summary trio: furniture for content that doesn't exist. While they are away the page shows the traditional view, where the empty state and its remedies live. And the header button took the empty state's label — "Create a budget" — ending the two-labels-two-cases split. Specs pin the tabs' absence, their return, and the two controls sharing one label.

Every figure in the tests is invented; the repo is public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)