### PR TITLE
The dark primary token exists, fifteen selected states join the slate, and Accounts pilots the inverted fill

### DIFF
--- a/src/components/AccountBreakdownModal.tsx
+++ b/src/components/AccountBreakdownModal.tsx
@@ -121,7 +121,7 @@ export default function AccountBreakdownModal({
           aria-pressed={grouped}
           className={`px-4 py-1.5 text-sm font-medium rounded-lg border transition-colors ${
             grouped
-              ? 'bg-[#1a2332] dark:bg-blue-600 border-[#1a2332] dark:border-blue-600 text-white'
+              ? 'bg-[#1a2332] dark:bg-[#2d3a4d] border-[#1a2332] dark:border-[#2d3a4d] text-white'
               : 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
           }`}
           title="Group accounts by type, the way the Accounts screen does"

--- a/src/components/ArchiveManager.tsx
+++ b/src/components/ArchiveManager.tsx
@@ -394,7 +394,7 @@ export default function ArchiveManager() {
                 onClick={() => setPreset(p.value)}
                 className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
                   preset === p.value
-                    ? 'bg-[#1a2332] dark:bg-blue-600 text-white'
+                    ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white'
                     : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'
                 }`}
               >

--- a/src/components/MonthlyIncomeExpenseMatrix.tsx
+++ b/src/components/MonthlyIncomeExpenseMatrix.tsx
@@ -236,7 +236,7 @@ export default function MonthlyIncomeExpenseMatrix({
           title={showDetail ? 'Show group subtotals only' : 'Show every category under each group'}
           className={`px-3 py-1 text-sm font-medium rounded-lg border transition-colors ${
             showDetail
-              ? 'border-[#1a2332] dark:border-blue-500 bg-[#1a2332] dark:bg-blue-600 text-white'
+              ? 'border-[#1a2332] dark:border-[#2d3a4d] bg-[#1a2332] dark:bg-[#2d3a4d] text-white'
               : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
           }`}
         >

--- a/src/design-system/__tests__/semantic-contrast.test.ts
+++ b/src/design-system/__tests__/semantic-contrast.test.ts
@@ -309,3 +309,59 @@ describe('NEXT_ACTION_YELLOW (the one "your next action is here" colour)', () =>
     }
   });
 });
+
+/**
+ * The primary-action pair, on BOTH grounds (Claude Design's canon ruling,
+ * 22 Aug 2026). The token was born because it had no dark counterpart and
+ * twenty files invented one — so the instrument reads both blocks of
+ * index.css and measures the pair each ground actually declares. Light is
+ * navy-on-white; dark INVERTS to near-white-with-navy-text, the ramp rule
+ * walking from whichever end contrasts with the ground.
+ */
+describe('primary action fill (dark-primary canon, 22 Aug 2026)', () => {
+  const tripleToHex = (triple: string): string =>
+    '#' + triple.trim().split(/\s+/)
+      .map(n => Number(n).toString(16).padStart(2, '0'))
+      .join('');
+
+  // :root declares the light pair; .dark redeclares the same names. The
+  // regexes anchor on order: the first declaration of each name is light,
+  // the second is dark — extract() throws if either moves.
+  const declarations = (name: string): [string, string] => {
+    const all = [...indexCss.matchAll(new RegExp(`${name}: ([0-9 ]+);`, 'g'))].map(m => m[1]);
+    if (all.length !== 2) {
+      throw new Error(`Expected ${name} declared once per ground, found ${all.length} — has a block moved?`);
+    }
+    return [tripleToHex(all[0]), tripleToHex(all[1])];
+  };
+
+  const [lightFill, darkFill] = declarations('--color-primary-action-rgb');
+  const [lightLabel, darkLabel] = declarations('--color-on-primary-action-rgb');
+  const [lightHover, darkHover] = declarations('--color-primary-action-hover-rgb');
+
+  it('keeps the label readable on the fill, resting and hovered, both grounds', () => {
+    expect(ratio(lightLabel, lightFill)).toBeGreaterThanOrEqual(AA_TEXT);
+    expect(ratio(lightLabel, lightHover)).toBeGreaterThanOrEqual(AA_TEXT);
+    expect(ratio(darkLabel, darkFill)).toBeGreaterThanOrEqual(AA_TEXT);
+    expect(ratio(darkLabel, darkHover)).toBeGreaterThanOrEqual(AA_TEXT);
+  });
+
+  it('keeps the fill discernible as a shape against the ground it sits on', () => {
+    for (const surface of SURFACES_LIGHT) {
+      expect(ratio(lightFill, surface)).toBeGreaterThanOrEqual(AA_GRAPHICS);
+    }
+    for (const surface of SURFACES_DARK) {
+      expect(ratio(darkFill, surface)).toBeGreaterThanOrEqual(AA_GRAPHICS);
+    }
+  });
+
+  it('inverts across the grounds rather than darkening in place', () => {
+    // The whole point of the ruling: the dark fill walks to the LIGHT end.
+    // A regression that "fixes" dark by picking another dark fill passes the
+    // contrast checks above only by luck; this pins the direction.
+    const luminance = (hex: string): number =>
+      ColorContrastChecker.getRelativeLuminance(ColorContrastChecker.hexToRgb(hex));
+    expect(luminance(lightFill)).toBeLessThan(0.2);
+    expect(luminance(darkFill)).toBeGreaterThan(0.7);
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -162,6 +162,31 @@ input[type="range"] {
      reason — `hover:bg-secondary/90` was one of the dead classes. */
   --color-secondary-rgb: 45 58 77;
   --color-secondary: rgb(var(--color-secondary-rgb));
+  /*
+   * THE PRIMARY ACTION FILL, WITH AN ANSWER ON BOTH GROUNDS (Claude Design's
+   * canon ruling, 22 Aug 2026). In light mode navy-900 does two jobs — brand
+   * and highest-contrast-thing-on-white — so one value served both the primary
+   * action and the selected state. On a dark ground it can do neither, and
+   * because no dark counterpart was stated, twenty files invented one and the
+   * nearest thing to hand was a stock blue (49 occurrences at the count).
+   *
+   * The rule is the chart ramp's: walk from whichever end contrasts with the
+   * ground. On white that end is dark (the navy); on a dark ground it is the
+   * light one — so the dark primary is a near-white fill with navy text, both
+   * already in this palette (#f1f3f7 is --color-light-accent, #e2e6ed is
+   * --color-light-border). No new hue: blue means link in this app.
+   *
+   * Selected states are NOT this token — a segment that marks a choice among
+   * siblings wears the slate (#2d3a4d, see PeriodPicker). This pair is for the
+   * button that invites the press.
+   *
+   * "A token with no counterpart on one ground is not a token, it is a
+   * light-mode value." — the ruling, worth keeping where the next token is
+   * written.
+   */
+  --color-primary-action-rgb: 26 35 50;
+  --color-on-primary-action-rgb: 255 255 255;
+  --color-primary-action-hover-rgb: 45 58 77;
   --color-tertiary: #d4a843;
   --color-light-bg: #f8f9fb;
   --color-light-card: #ffffff;
@@ -199,6 +224,12 @@ input[type="range"] {
   /* Light enough to read against gray-900 panels; still the navy family. */
   --focus-ring-color: #94a3b8;
   --color-border-focus: #94a3b8;
+  /* The primary action inverts on dark: near-white fill, navy label — the
+     ramp rule walking from the light end. Hover steps one token down the
+     same family (#e2e6ed, --color-light-border's value). */
+  --color-primary-action-rgb: 241 243 247;
+  --color-on-primary-action-rgb: 26 35 50;
+  --color-primary-action-hover-rgb: 226 230 237;
 }
 
 /* Numbers line up or they lie (DESIGN_PASS_2026-08, P5). Fixed-width digits

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -2383,7 +2383,17 @@ function AccountsList() {
       rightContent={
         <button
           onClick={() => setIsAddModalOpen(true)}
-          className="inline-flex items-center gap-2 px-4 py-2 bg-[#1a2332] text-white text-sm font-medium rounded-lg hover:bg-[#2d3a4d] transition-colors shadow-sm"
+          /* THE DARK-PRIMARY PILOT (Claude Design's canon ruling, 22 Aug 2026).
+             The raw navy had no dark: variant at all — a light-mode value that
+             all but vanished against the dark page. The token pair paints it
+             navy-on-white in light and INVERTED — near-white fill, navy label —
+             on dark: the ramp rule, walking from whichever end contrasts with
+             the ground. This page goes first because it holds a primary, a
+             secondary and a destructive together; the owner reads the captures
+             before the other nineteen files move. Chrome deliberately
+             unchanged — same radius, same type scale — so the only variable
+             in the capture is the colour. */
+          className="inline-flex items-center gap-2 px-4 py-2 bg-primary-action text-on-primary-action text-sm font-medium rounded-lg hover:bg-primary-action-hover transition-colors shadow-sm"
           title="Add Account"
         >
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
@@ -2598,7 +2608,7 @@ function AccountsList() {
               title="Band the list into account-type sections"
               className={`inline-flex items-center justify-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${
                 grouping.byType
-                  ? 'bg-[#1a2332] dark:bg-blue-600 border-[#1a2332] dark:border-blue-600 text-white'
+                  ? 'bg-[#1a2332] dark:bg-[#2d3a4d] border-[#1a2332] dark:border-[#2d3a4d] text-white'
                   : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
               }`}
             >
@@ -2616,7 +2626,7 @@ function AccountsList() {
               title="Band the list by institution"
               className={`inline-flex items-center justify-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${
                 grouping.byInstitution
-                  ? 'bg-[#1a2332] dark:bg-blue-600 border-[#1a2332] dark:border-blue-600 text-white'
+                  ? 'bg-[#1a2332] dark:bg-[#2d3a4d] border-[#1a2332] dark:border-[#2d3a4d] text-white'
                   : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
               }`}
             >

--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -593,7 +593,7 @@ export default function Reconciliation() {
                 title="Band the list into account-type sections"
                 className={`inline-flex items-center justify-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${
                   grouping.byType
-                    ? 'bg-[#1a2332] dark:bg-blue-600 border-[#1a2332] dark:border-blue-600 text-white'
+                    ? 'bg-[#1a2332] dark:bg-[#2d3a4d] border-[#1a2332] dark:border-[#2d3a4d] text-white'
                     : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
                 }`}
               >
@@ -611,7 +611,7 @@ export default function Reconciliation() {
                 title="Band the list by institution"
                 className={`inline-flex items-center justify-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${
                   grouping.byInstitution
-                    ? 'bg-[#1a2332] dark:bg-blue-600 border-[#1a2332] dark:border-blue-600 text-white'
+                    ? 'bg-[#1a2332] dark:bg-[#2d3a4d] border-[#1a2332] dark:border-[#2d3a4d] text-white'
                     : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
                 }`}
               >
@@ -631,13 +631,13 @@ export default function Reconciliation() {
             <div className="grid grid-flow-col auto-cols-fr flex-1 sm:flex-none sm:inline-flex rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-0.5">
               <button onClick={() => handleSortChange('default')}
                 className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
-                  sortMode === 'default' ? 'bg-[#1a2332] dark:bg-blue-600 text-white' : 'text-gray-600 dark:text-gray-400 hover:text-gray-900'
+                  sortMode === 'default' ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white' : 'text-gray-600 dark:text-gray-400 hover:text-gray-900'
                 }`}>
                 Default
               </button>
               <button onClick={() => handleSortChange('name')}
                 className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
-                  sortMode === 'name' ? 'bg-[#1a2332] dark:bg-blue-600 text-white' : 'text-gray-600 dark:text-gray-400 hover:text-gray-900'
+                  sortMode === 'name' ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white' : 'text-gray-600 dark:text-gray-400 hover:text-gray-900'
                 }`}>
                 Name A–Z
               </button>
@@ -649,7 +649,7 @@ export default function Reconciliation() {
                     : 'Sort by account value'}
                 className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
                   sortMode === 'balance-desc' || sortMode === 'balance-asc'
-                    ? 'bg-[#1a2332] dark:bg-blue-600 text-white'
+                    ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white'
                     : 'text-gray-600 dark:text-gray-400 hover:text-gray-900'
                 }`}>
                 Value {sortMode === 'balance-asc' ? '↑' : '↓'}
@@ -664,7 +664,7 @@ export default function Reconciliation() {
               title="Hide accounts that are fully reconciled with no balance difference"
               className={`w-full sm:w-auto px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors ${
                 onlyAttention
-                  ? 'bg-[#1a2332] dark:bg-blue-600 border-[#1a2332] dark:border-blue-600 text-white'
+                  ? 'bg-[#1a2332] dark:bg-[#2d3a4d] border-[#1a2332] dark:border-[#2d3a4d] text-white'
                   : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
               }`}
             >

--- a/src/pages/reports/IncomeSpendingOverTimeReport.tsx
+++ b/src/pages/reports/IncomeSpendingOverTimeReport.tsx
@@ -194,7 +194,7 @@ export default function IncomeSpendingOverTimeReport({ picker, focus }: ReportVi
                 aria-pressed={chartType === type}
                 className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
                   chartType === type
-                    ? 'bg-[#1a2332] dark:bg-blue-600 text-white'
+                    ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white'
                     : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
                 }`}
               >

--- a/src/pages/reports/PeriodComparisonReport.tsx
+++ b/src/pages/reports/PeriodComparisonReport.tsx
@@ -274,7 +274,7 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
                     unavailable
                       ? 'text-gray-400 dark:text-gray-600 cursor-not-allowed'
                       : effectiveBasis === value
-                        ? 'bg-[#1a2332] dark:bg-blue-600 text-white'
+                        ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white'
                         : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
                   }`}
                 >

--- a/src/pages/reports/SpendingByPayeeReport.tsx
+++ b/src/pages/reports/SpendingByPayeeReport.tsx
@@ -102,7 +102,7 @@ export default function SpendingByPayeeReport({ picker }: ReportViewProps): Reac
                 aria-pressed={side === value}
                 className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
                   side === value
-                    ? 'bg-[#1a2332] dark:bg-blue-600 text-white'
+                    ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white'
                     : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
                 }`}
               >

--- a/src/pages/settings/PayeeCleanup.tsx
+++ b/src/pages/settings/PayeeCleanup.tsx
@@ -763,7 +763,7 @@ export default function PayeeCleanup(): React.JSX.Element {
                     title={hint}
                     className={`px-2.5 py-1 text-xs font-medium rounded-md transition-colors ${
                       order === value
-                        ? 'bg-[#1a2332] dark:bg-blue-600 text-white'
+                        ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white'
                         : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
                     }`}
                   >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,6 +20,14 @@ export default {
         // fifty-four raw `var(--color-primary)` readers are untouched.
         primary: 'rgb(var(--color-primary-rgb, 26 35 50) / <alpha-value>)',
         secondary: 'rgb(var(--color-secondary-rgb, 45 58 77) / <alpha-value>)',
+        // The primary ACTION fill and its label, ground-aware (Claude Design's
+        // canon ruling, 22 Aug 2026): navy-on-white in light, inverted to
+        // near-white-with-navy-text on dark — the .dark block in index.css
+        // flips the triples, so ONE class pair paints a button correctly on
+        // both grounds. New primary buttons use these; never dark:bg-blue-*.
+        'primary-action': 'rgb(var(--color-primary-action-rgb, 26 35 50) / <alpha-value>)',
+        'on-primary-action': 'rgb(var(--color-on-primary-action-rgb, 255 255 255) / <alpha-value>)',
+        'primary-action-hover': 'rgb(var(--color-primary-action-hover-rgb, 45 58 77) / <alpha-value>)',
         // Gold is a FILL colour only (chips, marks, the yellow thread's box).
         // As text on white it measures 2.21:1 — that is what accent-text is
         // for. (DESIGN_PASS_2026-08 §2.1, instrumented 2026-08-12.)


### PR DESCRIPTION
Executes Claude Design's canon ruling (22 Aug) on the §3 census — the 49 stock blues were a **missing token** reproduced 49 times, not carelessness.

## The token, defined today (ruling §5)

`primary-action` / `on-primary-action` / `primary-action-hover` — CSS triples declared per ground in `index.css`, exposed through the Tailwind config. Light: navy fill, white label (unchanged look). Dark: **inverted** — near-white fill (`#f1f3f7`, already `--color-light-accent`) with a navy label — the ramp rule walking from whichever end contrasts with the ground. No new hue: blue means link in this app.

The contrast instrument now reads both declarations of each triple from source and measures: label-on-fill at rest and hover on both grounds (≥4.5:1), fill-as-shape against both grounds' surfaces (≥3:1), and — because a regression could pass contrast by darkening in place — **the inversion direction itself**, by relative luminance.

## Batch A — mechanical (ruling §4)

Fifteen selected-state fills across nine files leave `dark:bg-blue-600` for the slate the period picker's ruling blessed: Reconciliation's six pills, Accounts' two group-by pills, the payee / period-comparison / over-time report toggles, ArchiveManager, AccountBreakdownModal, MonthlyIncomeExpenseMatrix. Verified in the browser: every selected pill computes `rgb(45,58,77)`.

## Batch B pilot — one surface, for the owner to read

Accounts' **Add Account** — which had *no* dark variant at all, a light-mode value nearly invisible on the dark page — wears the token pair. Chrome deliberately unchanged (same radius, type scale, shadow) so the capture's only variable is colour. Verified live: dark computes `rgb(241,243,247)` fill / `rgb(26,35,50)` label; light computes exactly what it did before.

The other ~20 primary fills move only after the owner approves this page on both grounds. The remaining blues that fit neither ruling category (progress fills, ToggleSwitch's ON track, two tinted CTA washes) go back to Design as findings, per ruling §6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)