### PR TITLE
The dashboard trio converts like the card it mirrors, the drill agrees with the card that opened it, and the portfolio chart joins the walk

### DIFF
--- a/src/components/AccountBreakdownModal.test.tsx
+++ b/src/components/AccountBreakdownModal.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AccountBreakdownModal, { type AccountBreakdownRow } from './AccountBreakdownModal';
+
+/**
+ * The drill behind the net-worth cards must AGREE with the card it opened
+ * from (currency audit, 22 Aug): the card converts a foreign account into the
+ * display currency, and this modal used to sum the same account's native
+ * units — a $200 row counted as £200 in the total under a card that said
+ * £100. A foreign row now carries `converted` and every total sums that,
+ * wearing ≈; the per-row figure stays the account's own currency.
+ *
+ * Every figure here is invented; the repo is public.
+ */
+describe('AccountBreakdownModal — totals agree with the converted card', () => {
+  const rows: AccountBreakdownRow[] = [
+    {
+      id: 'gbp-1',
+      name: 'Everyday',
+      accountType: 'current',
+      balance: 1000,
+      formatted: '£1,000.00',
+    },
+    {
+      id: 'usd-1',
+      name: 'Dollar Savings',
+      accountType: 'savings',
+      balance: 200,
+      converted: 100, // $200 at two-to-one — the page computed this
+      formatted: '$200.00',
+    },
+  ];
+
+  const renderModal = (view: 'net' | 'assets' | 'liabilities' = 'net') =>
+    render(
+      <AccountBreakdownModal
+        view={view}
+        onClose={vi.fn()}
+        rows={rows}
+        formatTotal={(v) => `£${v.toFixed(2)}`}
+        onOpenAccount={vi.fn()}
+      />
+    );
+
+  it('sums the converted value, marks the total ≈, and keeps the row native', () => {
+    renderModal();
+    // 1000 + 100, never 1000 + 200 — in the Assets band AND the net total,
+    // each wearing the ≈ that says a conversion is inside the figure. (The ≈
+    // and the figure are sibling text nodes, so the matcher reads the cell.)
+    const cellsSaying = (text: string) =>
+      screen.queryAllByText((_, el) => el?.tagName === 'TD' && el.textContent === text);
+    expect(cellsSaying('≈ £1100.00')).toHaveLength(2);
+    expect(cellsSaying('£1200.00')).toHaveLength(0);
+    expect(cellsSaying('≈ £1200.00')).toHaveLength(0);
+    // The row itself still speaks the account's own currency.
+    expect(screen.getByText('$200.00')).toBeInTheDocument();
+  });
+
+  it('shows a plain total when every row is already in the display currency', () => {
+    render(
+      <AccountBreakdownModal
+        view="net"
+        onClose={vi.fn()}
+        rows={[rows[0]]}
+        formatTotal={(v) => `£${v.toFixed(2)}`}
+        onOpenAccount={vi.fn()}
+      />
+    );
+    // Band total and net total, no ≈ anywhere.
+    expect(screen.getAllByText('£1000.00').length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText(/≈/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/AccountBreakdownModal.tsx
+++ b/src/components/AccountBreakdownModal.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Modal, ModalBody } from './common/Modal';
 import { ALL_ACCOUNT_SECTIONS, sectionTypeForAccount } from '../utils/accountSections';
+import { toDecimal } from '../utils/decimal';
 
 /**
  * The drill-in behind the Accounts page's Net Worth / Assets / Liabilities
@@ -10,6 +11,14 @@ import { ALL_ACCOUNT_SECTIONS, sectionTypeForAccount } from '../utils/accountSec
  * function the cards use, so the modal's totals cannot disagree with the
  * card that opened it. Assets are the accounts standing positive,
  * liabilities the ones standing negative — same split as the cards.
+ *
+ * Totals convert the way the card's do (currency audit, 22 Aug): a foreign
+ * row carries `converted` — its value in the display currency, computed by
+ * the PAGE from the same rates its card used — and every total sums that,
+ * wearing ≈ when one is in the figure. Before this, the drill summed native
+ * units behind a card that converted, so the two disagreed the moment a
+ * second currency was held — the header's own promise broken. The per-row
+ * figure stays the account's own currency, as everywhere.
  */
 
 export type AccountBreakdownView = 'net' | 'assets' | 'liabilities';
@@ -22,6 +31,14 @@ export interface AccountBreakdownRow {
   accountType: string;
   /** Signed balance, from the page's own computeAccountBalance. */
   balance: number;
+  /**
+   * The balance in the DISPLAY currency, when the account is held in another
+   * one — computed by the page from the same rates its summary card used.
+   * Absent for an account already in the display currency, and absent when
+   * no rate could be had (the total then counts the native figure, exactly
+   * as the card's own fallback does).
+   */
+  converted?: number;
   /** Formatted in the account's own currency by the page's formatter. */
   formatted: string;
 }
@@ -101,9 +118,15 @@ export default function AccountBreakdownModal({
     ];
   }, [view, grouped, rows, assets, liabilities, sortRows]);
 
-  const total = useMemo(() => {
+  // Decimal, not float `+` — and the display-currency value where one exists.
+  const sumOf = (list: readonly AccountBreakdownRow[]): number =>
+    list.reduce((sum, r) => sum.plus(toDecimal(r.converted ?? r.balance)), toDecimal(0)).toNumber();
+  const holdsForeignIn = (list: readonly AccountBreakdownRow[]): boolean =>
+    list.some(r => r.converted !== undefined);
+
+  const { total, totalHoldsForeign } = useMemo(() => {
     const included = view === 'assets' ? assets : view === 'liabilities' ? liabilities : rows;
-    return included.reduce((sum, r) => sum + r.balance, 0);
+    return { total: sumOf(included), totalHoldsForeign: holdsForeignIn(included) };
   }, [view, assets, liabilities, rows]);
 
   const arrow = (key: SortKey): string => (sortKey === key ? (sortDir === 1 ? ' ↑' : ' ↓') : '');
@@ -168,11 +191,11 @@ export default function AccountBreakdownModal({
                       </span>
                     </td>
                     <td className={`py-1.5 text-xs font-semibold text-right tabular-nums ${
-                      section.rows.reduce((s, r) => s + r.balance, 0) < 0
+                      sumOf(section.rows) < 0
                         ? 'text-red-600 dark:text-red-400'
                         : 'text-green-600 dark:text-green-400'
                     }`}>
-                      {formatTotal(section.rows.reduce((s, r) => s + r.balance, 0))}
+                      {holdsForeignIn(section.rows) ? '≈ ' : ''}{formatTotal(sumOf(section.rows))}
                     </td>
                   </tr>
                 )}
@@ -214,7 +237,7 @@ export default function AccountBreakdownModal({
               <td className={`pt-3 text-sm font-bold text-right tabular-nums ${
                 total < 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white'
               }`}>
-                {formatTotal(total)}
+                {totalHoldsForeign ? '≈ ' : ''}{formatTotal(total)}
               </td>
             </tr>
           </tfoot>

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -18,6 +18,8 @@ import {
 } from '../icons';
 import { useApp } from '../../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
+import { useConvertedNetWorth, type AccountBalanceEntry } from '../../hooks/useConvertedNetWorth';
+import { useNetWorthConversion } from '../../hooks/useNetWorthConversion';
 import { preserveDemoParam } from '../../utils/navigation';
 import EmptyState from '../EmptyState';
 import FilteredEmptyState from '../FilteredEmptyState';
@@ -270,6 +272,31 @@ export function ImprovedDashboard() {
     () => computeAccountBalances(accounts, transactions, serverBalances),
     [accounts, transactions, serverBalances]
   );
+
+  /**
+   * The SAME conversion the Accounts page's card runs (currency audit,
+   * 22 Aug): this trio renders the same NetWorthSummary component as that
+   * card, and until now was its un-fixed twin — native units summed as
+   * display units, so a dollar account counted as that many pounds. The
+   * single-currency majority keeps the exact arithmetic below; only a ledger
+   * that actually spans currencies converts, and says so.
+   */
+  const netWorthEntries = useMemo<AccountBalanceEntry[]>(
+    () => accounts.map(a => ({
+      balance: accountBalanceMap.get(a.id) ?? 0,
+      currency: a.currency || displayCurrency,
+    })),
+    [accounts, accountBalanceMap, displayCurrency]
+  );
+  const spansCurrencies = useMemo(
+    () => netWorthEntries.some(entry => entry.currency !== displayCurrency),
+    [netWorthEntries, displayCurrency]
+  );
+  const convertedNetWorth = useConvertedNetWorth(netWorthEntries, displayCurrency);
+  // Per-account factors for the breakdown modal's rows — same rates cache as
+  // the trio's conversion, so the drill cannot quote a different rate than
+  // the card it opens from. Null on a single-currency ledger.
+  const { conversion: rowConversion } = useNetWorthConversion(accounts);
 
   // Calculate key metrics — all money sums use Decimal arithmetic (float math
   // is banned on currency values; IEEE-754 drifts on long sums).
@@ -722,10 +749,13 @@ export function ImprovedDashboard() {
         aria-label="Net worth, assets and liabilities"
       >
         <NetWorthSummary
-          netWorth={formatCurrencyWithSymbol(metrics.netWorth)}
-          assets={formatCurrencyWithSymbol(metrics.totalAssets)}
-          liabilities={formatCurrencyWithSymbol(metrics.totalLiabilities)}
+          netWorth={formatCurrencyWithSymbol(spansCurrencies ? convertedNetWorth.netWorth : metrics.netWorth)}
+          assets={formatCurrencyWithSymbol(spansCurrencies ? convertedNetWorth.assets : metrics.totalAssets)}
+          liabilities={formatCurrencyWithSymbol(spansCurrencies ? convertedNetWorth.liabilities : metrics.totalLiabilities)}
           onSelect={figure => setBreakdownView(figure)}
+          provenance={spansCurrencies ? convertedNetWorth.provenance : null}
+          unconverted={spansCurrencies ? convertedNetWorth.unconverted : []}
+          displayCurrency={displayCurrency}
         />
       </section>
 
@@ -1514,18 +1544,26 @@ export function ImprovedDashboard() {
 
       {/* The SAME modal the Accounts page drills with, fed from the SAME
           balance map the three tiles sum — so its total and the tile cannot
-          disagree, which is the whole precondition for offering the click. */}
+          disagree, which is the whole precondition for offering the click.
+          Each row's figure is in the account's OWN currency (a $100 row used
+          to print as £100 here), and a foreign row carries its converted
+          value so the modal's totals agree with the converted trio above. */}
       <AccountBreakdownModal
         view={breakdownView}
         onClose={() => setBreakdownView(null)}
-        rows={accounts.map(a => ({
-          id: a.id,
-          name: a.name,
-          institution: a.institution,
-          accountType: a.type,
-          balance: accountBalanceMap.get(a.id) ?? 0,
-          formatted: formatCurrencyWithSymbol(accountBalanceMap.get(a.id) ?? 0),
-        }))}
+        rows={accounts.map(a => {
+          const balance = accountBalanceMap.get(a.id) ?? 0;
+          const factor = rowConversion?.factors.get(a.id);
+          return {
+            id: a.id,
+            name: a.name,
+            institution: a.institution,
+            accountType: a.type,
+            balance,
+            converted: factor ? toDecimal(balance).times(factor).toNumber() : undefined,
+            formatted: formatCurrencyWithSymbol(balance, a.currency),
+          };
+        })}
         formatTotal={(v) => formatCurrencyWithSymbol(v)}
         onOpenAccount={(accountId) => {
           setBreakdownView(null);

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -45,6 +45,7 @@ import {
   useConvertedNetWorth,
   type AccountBalanceEntry,
 } from '../hooks/useConvertedNetWorth';
+import { useNetWorthConversion } from '../hooks/useNetWorthConversion';
 import { useReconciliation } from '../hooks/useReconciliation';
 import { countAwaitingReviewByAccount } from '../utils/transactionReview';
 import { useAccountBankSync } from '@service';
@@ -663,6 +664,15 @@ function AccountsList() {
     displayCurrency,
     groupCurrencyEntries
   );
+
+  /**
+   * Per-ACCOUNT factors for the breakdown modal's rows (currency audit,
+   * 22 Aug): the card above converts its three figures, and the drill behind
+   * it summed native — the two disagreed the moment a second currency was
+   * held. Same module-level rates cache as the card's own conversion, so the
+   * factors cannot quote a different rate. Null on a single-currency ledger.
+   */
+  const { conversion: breakdownConversion } = useNetWorthConversion(openAccounts);
 
   // Each switch flips on its own: both on nests, both off flattens.
   const handleGroupingChange = (next: AccountGroupingOptions) => {
@@ -3172,14 +3182,19 @@ function AccountsList() {
             <AccountBreakdownModal
         view={breakdownView}
         onClose={() => setBreakdownView(null)}
-        rows={decimalAccounts.map(a => ({
-          id: a.id,
-          name: a.name,
-          institution: a.institution,
-          accountType: a.type,
-          balance: computeAccountBalance(a.id),
-          formatted: formatDisplayCurrency(computeAccountBalance(a.id), a.currency),
-        }))}
+        rows={decimalAccounts.map(a => {
+          const balance = computeAccountBalance(a.id);
+          const factor = breakdownConversion?.factors.get(a.id);
+          return {
+            id: a.id,
+            name: a.name,
+            institution: a.institution,
+            accountType: a.type,
+            balance,
+            converted: factor ? toDecimal(balance).times(factor).toNumber() : undefined,
+            formatted: formatDisplayCurrency(balance, a.currency),
+          };
+        })}
         formatTotal={(v) => formatDisplayCurrency(v)}
         // Through the same door as a click on an account's name, provenance and
         // all: coming back from a register opened here lands on that account's

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -29,6 +29,7 @@ import PageWrapper from '../components/PageWrapper';
 import { WholePoundsScope, WholePoundsToggle } from '../contexts/WholePoundsContext';
 import ToggleSwitch from '../components/ui/ToggleSwitch';
 import { buildPortfolioSummary, buildPortfolioHistory } from '../utils/portfolioSummary';
+import { useNetWorthConversion } from '../hooks/useNetWorthConversion';
 import { useHistoricalAccounts } from '../hooks/useHistoricalAccounts';
 import { formatCurrencyCompact } from '../utils/currency-decimal';
 import { computePortfolioPerformance, scopeValueAt, scopeOpeningFlows } from '../utils/portfolioPerformance';
@@ -556,10 +557,14 @@ function InvestmentsView() {
   );
 
   // Real history: what the SCOPE was worth on each date, never a projection
-  // of today's figure backwards.
+  // of today's figure backwards. The scope's members convert exactly as the
+  // net-worth surfaces do (currency audit, 22 Aug) — a dollar sleeve in a
+  // sterling pair used to join this chart as that many pounds. Null for the
+  // all-sterling scope, which keeps its arithmetic untouched.
+  const { conversion: scopeConversion } = useNetWorthConversion(scopeMembers);
   const performanceData = useMemo(
-    () => buildPortfolioHistory(scopeMembers, transactions, historyRange),
-    [scopeMembers, transactions, historyRange]
+    () => buildPortfolioHistory(scopeMembers, transactions, historyRange, new Date(), scopeConversion ?? undefined),
+    [scopeMembers, transactions, historyRange, scopeConversion]
   );
 
   /**

--- a/src/utils/portfolioSummary.test.ts
+++ b/src/utils/portfolioSummary.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildPortfolioSummary, buildPortfolioHistory } from './portfolioSummary';
+import { buildNetWorthConversion } from './netWorthSeries';
 import type { Account, Category, Transaction, TransactionSplit } from '../types';
 
 /**
@@ -363,5 +364,38 @@ describe('buildPortfolioHistory', () => {
 
   it('has nothing to draw when no account is paired into a portfolio', () => {
     expect(buildPortfolioHistory([], historyTransactions, { from: null, to: null })).toEqual([]);
+  });
+
+  it('converts a foreign member at the summing, exactly as the net-worth walk does', () => {
+    // Currency audit, 22 Aug: this was the ONE caller of buildNetWorthSnapshots
+    // that kept summing a dollar sleeve's native units as pounds after the walk
+    // learned to convert. Every figure here is invented; the repo is public.
+    const dollarSleeve = account({
+      id: ISA_CASH,
+      name: 'Fund ISA ($ Cash)',
+      type: 'current',
+      parentAccountId: ISA,
+      currency: 'USD',
+      openingBalance: 200,
+      openingBalanceDate: new Date(2026, 0, 5),
+    });
+    const members = [historyAccounts[0], dollarSleeve];
+    const conversion = buildNetWorthConversion(members, { GBP: 1, USD: 2 }, 'GBP');
+
+    // The last point, because a short window walks daily and its first point
+    // can predate the 5 January openings.
+    const converted = buildPortfolioHistory(
+      members, [], { from: new Date(2026, 0, 1), to: new Date(2026, 0, 31) },
+      new Date(2026, 5, 30), conversion
+    );
+    // $200 at two-to-one joins as £100 beside the sterling side's 1000.
+    expect(converted[converted.length - 1].value).toBe(1100);
+
+    // Omitted, the walk behaves exactly as it always has — native units.
+    const native = buildPortfolioHistory(
+      members, [], { from: new Date(2026, 0, 1), to: new Date(2026, 0, 31) },
+      new Date(2026, 5, 30)
+    );
+    expect(native[native.length - 1].value).toBe(1200);
   });
 });

--- a/src/utils/portfolioSummary.ts
+++ b/src/utils/portfolioSummary.ts
@@ -5,7 +5,7 @@ import { calculateTotalBalance } from './calculations-decimal';
 import { buildTopLevelIdByAccountId, groupByTopLevelId } from './accountNesting';
 import { buildCategoryKindLookup, classifyFlow } from './incomeExpense';
 import { expandSplitTransactions, type SplitExpandedTransaction } from './transactionSplits';
-import { buildNetWorthSnapshots } from './netWorthSeries';
+import { buildNetWorthSnapshots, type NetWorthConversion } from './netWorthSeries';
 import type { PeriodRange } from '../hooks/usePeriod';
 
 /**
@@ -343,13 +343,21 @@ export function buildPortfolioHistory(
   memberAccounts: readonly Account[],
   transactions: readonly Transaction[],
   range: PeriodRange,
-  now: Date = new Date()
+  now: Date = new Date(),
+  /**
+   * The same conversion the net-worth surfaces pass (currency audit, 22 Aug):
+   * this was the one caller of buildNetWorthSnapshots that kept summing a
+   * foreign member's native units as display units after the walk learned to
+   * convert. Omitted, the single-currency portfolio behaves exactly as before.
+   */
+  conversion?: NetWorthConversion
 ): PortfolioHistoryPoint[] {
   const memberIds = new Set(memberAccounts.map(a => a.id));
   return buildNetWorthSnapshots(
     [...memberAccounts],
     transactions.filter(t => memberIds.has(t.accountId)),
     range,
-    now
+    now,
+    conversion
   ).map(point => ({ label: point.label, value: point.netWorth, date: point.date }));
 }


### PR DESCRIPTION
The currency audit's **P1 findings** (22 Aug) — the three surfaces inside #382's blast radius, each carrying the exact defect the net-worth walk just shed. The wider programme (report gallery, Investments chain, exports, historical rates) awaits the owner's prioritisation.

## The dashboard trio

The dashboard's Net Worth / What you own / What you owe rendered the same `NetWorthSummary` component as the Accounts card — fed native sums, so a dollar account counted as that many pounds, with no provenance note. It now runs the **same `useConvertedNetWorth` wiring** as the Accounts card: gated on `spansCurrencies` (the single-currency majority keeps its exact arithmetic), converted figures plus the provenance note and unconverted list when a second currency is actually in play.

## The breakdown modal

The drill *behind* those cards — on both pages — summed native, in float `+`, contradicting the converted card that opened it the moment a second currency was held (its own header comment promised the opposite). A foreign row now carries `converted`, computed by the page from the same rates cache its card used; every total sums in Decimal and wears `≈`; the per-row figure stays the account's own currency. The dashboard's rows also printed a $ balance as £ — fixed in the same stroke. Two specs pin the agreeing total and the plain single-currency case.

## The portfolio chart

`buildPortfolioHistory` was the one caller of `buildNetWorthSnapshots` not passing the new `conversion` argument — the Investments performance chart kept summing a dollar sleeve's native units as pounds. The argument threads from the page via the shared hook; omitted, an all-sterling portfolio behaves exactly as before. A spec pins both paths.

Every figure in the tests is invented; the repo is public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)