### PR TITLE
Backdated rates by day — a 2017 balance at 2017's rate — and the aggregation census that keeps the audit true

### DIFF
--- a/src/components/HistoricRatesRestatementNotice.test.tsx
+++ b/src/components/HistoricRatesRestatementNotice.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import HistoricRatesRestatementNotice from './HistoricRatesRestatementNotice';
+import { preferences } from '../services/preferencesService';
+
+/**
+ * The one-time restatement statement (the ruling, 22 Aug §6.4): historic
+ * figures changed when per-day rates landed, and an app built on provability
+ * says so once — dismissibly, and never to a reader it does not concern.
+ */
+describe('HistoricRatesRestatementNotice', () => {
+  beforeEach(() => {
+    preferences.setItem('money_management_fx_history_restatement_dismissed', '');
+  });
+
+  it('says the recalculation happened, and that the ledger did not move', () => {
+    render(<HistoricRatesRestatementNotice visible={true} />);
+    expect(screen.getByText(/Historic figures have been recalculated/)).toBeInTheDocument();
+    // The sentence that matters most: valuation moved, agreement did not.
+    expect(screen.getByText(/Your recorded transactions are unchanged/)).toBeInTheDocument();
+  });
+
+  it('renders nothing for a surface it does not concern', () => {
+    const { container } = render(<HistoricRatesRestatementNotice visible={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('stays dismissed, as a preference rather than a tab', () => {
+    const { unmount } = render(<HistoricRatesRestatementNotice visible={true} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss this notice' }));
+    expect(screen.queryByText(/Historic figures/)).not.toBeInTheDocument();
+    unmount();
+    render(<HistoricRatesRestatementNotice visible={true} />);
+    expect(screen.queryByText(/Historic figures/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/HistoricRatesRestatementNotice.tsx
+++ b/src/components/HistoricRatesRestatementNotice.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { preferences } from '../services/preferencesService';
+import { XIcon } from './icons';
+
+/**
+ * The one-time restatement statement (the ruling, 22 Aug §6.4).
+ *
+ * When per-day reference rates arrived, figures readers had already seen
+ * CHANGED — a 2017 balance re-valued at 2017's rate is a different number
+ * from one valued at today's. Silently restating history is precisely what
+ * an app built on provability cannot do, so the affected surfaces say it
+ * once, dismissibly, with the sentence that matters most last: the ledger
+ * did not move, only the valuation did.
+ *
+ * Renders nothing for a single-currency ledger (nothing changed for them)
+ * and nothing once dismissed — the dismissal is a preference, so it follows
+ * the person, not the browser tab.
+ */
+
+const DISMISSAL_KEY = 'money_management_fx_history_restatement_dismissed';
+
+export default function HistoricRatesRestatementNotice({
+  visible,
+}: {
+  /** The surface's own gate: spans currencies AND the history is in force. */
+  visible: boolean;
+}): React.JSX.Element | null {
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    try {
+      return preferences.getItem(DISMISSAL_KEY) === 'true';
+    } catch {
+      return false;
+    }
+  });
+
+  if (!visible || dismissed) return null;
+
+  return (
+    <div className="mb-6 flex items-start gap-3 rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-5 py-4">
+      <div className="flex-1 text-sm text-gray-700 dark:text-gray-300">
+        <span className="font-semibold text-gray-900 dark:text-white">
+          Historic figures have been recalculated.
+        </span>{' '}
+        Balances in other currencies are now converted at the reference rate for each
+        date, rather than today&rsquo;s rate, so figures may differ from what you saw
+        previously. Your recorded transactions are unchanged.
+      </div>
+      <button
+        type="button"
+        onClick={() => {
+          setDismissed(true);
+          try {
+            preferences.setItem(DISMISSAL_KEY, 'true');
+          } catch {
+            // The notice still leaves this render; it may reappear next
+            // session, which errs on the side of saying it again.
+          }
+        }}
+        aria-label="Dismiss this notice"
+        className="shrink-0 rounded p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+      >
+        <XIcon size={16} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -113,19 +113,20 @@ export function NetWorthWidget({ picker, pin }: {
   /**
    * The SAME conversion the full report applies (ruling C: this card and the
    * report may not disagree about the same money) — foreign-currency accounts
-   * convert at today's rates instead of counting native units as display
-   * units. The full provenance sentence lives on the report this card opens;
-   * the ≈ on the headline is this card's own honest mark.
+   * convert at each day's ECB reference rate where the history is loaded,
+   * today's rates while degraded, EXACTLY as the report does with the same
+   * window. The full provenance sentence lives on the report this card
+   * opens; the ≈ on the headline is this card's own honest mark.
    */
-  const { conversion, displayCurrency } = useNetWorthConversion(accounts);
+  const { seriesConversion, displayCurrency } = useNetWorthConversion(accounts, { range: picker.range });
   const holdsForeign = useMemo(
     () => accounts.some(a => (a.currency || displayCurrency) !== displayCurrency),
     [accounts, displayCurrency]
   );
 
   const snapshots = useMemo(
-    () => buildNetWorthSnapshots(accounts, transactions, picker.range, new Date(), conversion ?? undefined),
-    [accounts, transactions, picker.range, conversion]
+    () => buildNetWorthSnapshots(accounts, transactions, picker.range, new Date(), seriesConversion ?? undefined),
+    [accounts, transactions, picker.range, seriesConversion]
   );
   const latest = snapshots.length > 0 ? snapshots[snapshots.length - 1] : null;
 

--- a/src/hooks/useNetWorthConversion.ts
+++ b/src/hooks/useNetWorthConversion.ts
@@ -1,7 +1,14 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { Account } from '../types';
-import { buildNetWorthConversion, type NetWorthConversion } from '../utils/netWorthSeries';
+import type { PeriodRange } from './usePeriod';
+import {
+  buildNetWorthConversion,
+  type NetWorthConversion,
+  type NetWorthConversionByDate,
+} from '../utils/netWorthSeries';
 import { getExchangeRatesWithProvenance, type RatesProvenance } from '../utils/currency-decimal';
+import { getHistoricalRates, fxDayKey, type HistoricalRates } from '../services/historicalRatesService';
+import { toDecimal, type DecimalInstance } from '../utils/decimal';
 import { useCurrencyDecimal } from './useCurrencyDecimal';
 
 /**
@@ -15,19 +22,54 @@ import { useCurrencyDecimal } from './useCurrencyDecimal';
  * the same money. Each computes its factors from the same rates cache every
  * other conversion in the app uses.
  *
+ * WITH `history` (the owner's backdated-rates ask, 22 Aug): the hook also
+ * loads the ECB's daily reference-rate history for the window and returns a
+ * dated conversion — each snapshot then converts at ITS OWN day's rate, a
+ * 2017 balance at 2017's rate, and "today's rates applied to that day's
+ * balances" retires as a caveat. When the history cannot be had (offline,
+ * first run with no cache) the hook degrades to exactly the pre-history
+ * behaviour — today's rates throughout, the old caveat still true — rather
+ * than degrade to silence. `historical` says which basis is in force, so the
+ * page states the right one.
+ *
  * `conversion` is null while every account is already in the display currency
  * — the single-currency majority pays nothing and sees no note. Until rates
  * arrive (or if they never do) the foreign currencies are reported as
  * UNCONVERTED rather than guessed: ConvertedTotalNote's serious state, said
  * out loud.
  */
-export function useNetWorthConversion(accounts: readonly Account[]): {
+export function useNetWorthConversion(
+  accounts: readonly Account[],
+  history?: { range: PeriodRange }
+): {
+  /** Today's-rates factors — for current balances and as the degraded basis. */
   conversion: NetWorthConversion | null;
+  /** What the series walk should take: dated when history is in force. */
+  seriesConversion: NetWorthConversion | NetWorthConversionByDate | null;
+  /** Per-date factors for a drill into one day; null while degraded. */
+  conversionAt: ((date: Date) => NetWorthConversion | null) | null;
+  /** True when per-date reference rates are in force for the series. */
+  historical: boolean;
   provenance: RatesProvenance | null;
   displayCurrency: string;
 } {
   const { displayCurrency } = useCurrencyDecimal();
   const [ratesState, setRatesState] = useState<{ rates: Record<string, number>; provenance: RatesProvenance } | null>(null);
+  const [historyState, setHistoryState] = useState<HistoricalRates | null>(null);
+
+  const foreignCurrencies = useMemo(
+    () => [...new Set(
+      accounts
+        .map(a => a.currency || displayCurrency)
+        .filter(c => c !== displayCurrency)
+    )].sort(),
+    [accounts, displayCurrency]
+  );
+  const wantsHistory = history !== undefined && foreignCurrencies.length > 0;
+  // Primitives, so the effect below re-runs on a real change of window and
+  // not on every render's fresh range object.
+  const historyFromKey = history?.range.from ? fxDayKey(history.range.from) : null;
+  const historyToKey = history?.range.to ? fxDayKey(history.range.to) : null;
 
   useEffect(() => {
     let live = true;
@@ -44,17 +86,87 @@ export function useNetWorthConversion(accounts: readonly Account[]): {
     return () => { live = false; };
   }, []);
 
+  useEffect(() => {
+    if (!wantsHistory) {
+      setHistoryState(null);
+      return;
+    }
+    let live = true;
+    void (async () => {
+      // A window with no stated start reaches for the whole series — the ECB
+      // epoch is the floor and the fetch is one small cached request. The
+      // currencies include the display one when it is not the GBP pivot,
+      // because every factor needs both legs' rates. Keys parse by triple,
+      // never by ISO string — an ISO string parses as UTC and moves a day
+      // boundary on any machine not on it.
+      const parseKey = (key: string): Date => {
+        const [y, m, d] = key.split('-').map(Number);
+        return new Date(y, m - 1, d);
+      };
+      const from = historyFromKey ? parseKey(historyFromKey) : new Date(1999, 0, 4);
+      const to = historyToKey ? parseKey(historyToKey) : new Date();
+      const wanted = displayCurrency === 'GBP'
+        ? foreignCurrencies
+        : [...new Set([...foreignCurrencies, displayCurrency])];
+      const result = await getHistoricalRates(wanted, from, to);
+      if (live) setHistoryState(result.provenance === null ? null : result);
+    })();
+    return () => { live = false; };
+    // foreignCurrencies is derived and array-fresh each render; its JOIN is
+    // the stable identity of what is actually wanted.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [wantsHistory, historyFromKey, historyToKey, displayCurrency, foreignCurrencies.join(',')]);
+
   const conversion = useMemo((): NetWorthConversion | null => {
-    const foreign = accounts.filter(a => (a.currency || displayCurrency) !== displayCurrency);
-    if (foreign.length === 0) return null;
+    if (foreignCurrencies.length === 0) return null;
     if (!ratesState) {
       return {
         factors: new Map(),
-        unconverted: [...new Set(foreign.map(a => a.currency))].sort(),
+        unconverted: foreignCurrencies,
       };
     }
     return buildNetWorthConversion(accounts, ratesState.rates, displayCurrency);
-  }, [accounts, ratesState, displayCurrency]);
+  }, [accounts, ratesState, displayCurrency, foreignCurrencies]);
 
-  return { conversion, provenance: ratesState?.provenance ?? null, displayCurrency };
+  const dated = useMemo((): {
+    byDate: NetWorthConversionByDate;
+    at: (date: Date) => NetWorthConversion | null;
+  } | null => {
+    if (!wantsHistory || historyState === null) return null;
+    const unavailable = new Set(historyState.unavailable);
+    // The display currency's own series missing means NO factor can be built:
+    // degrade to the live-rates basis rather than half-convert.
+    if (displayCurrency !== 'GBP' && unavailable.has(displayCurrency)) return null;
+    const unconverted = foreignCurrencies.filter(c => unavailable.has(c));
+    const byDay = new Map<string, NetWorthConversion>();
+    const at = (date: Date): NetWorthConversion | null => {
+      const key = fxDayKey(date);
+      const held = byDay.get(key);
+      if (held) return held;
+      const factors = new Map<string, DecimalInstance>();
+      const displayRate = historyState.rateOn(date, displayCurrency);
+      for (const account of accounts) {
+        const currency = account.currency || displayCurrency;
+        if (currency === displayCurrency) continue;
+        const accountRate = historyState.rateOn(date, currency);
+        if (accountRate === null || displayRate === null) continue;
+        // Units-per-GBP both sides, GBP the pivot: A→display is
+        // rate(display)/rate(A) — the app's one conversion arithmetic.
+        factors.set(account.id, toDecimal(displayRate).dividedBy(toDecimal(accountRate)));
+      }
+      const built: NetWorthConversion = { factors, unconverted };
+      byDay.set(key, built);
+      return built;
+    };
+    return { byDate: { at, unconverted }, at };
+  }, [wantsHistory, historyState, accounts, displayCurrency, foreignCurrencies]);
+
+  return {
+    conversion,
+    seriesConversion: dated?.byDate ?? conversion,
+    conversionAt: dated?.at ?? null,
+    historical: dated !== null,
+    provenance: ratesState?.provenance ?? null,
+    displayCurrency,
+  };
 }

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -30,6 +30,7 @@ import { WholePoundsScope, WholePoundsToggle } from '../contexts/WholePoundsCont
 import ToggleSwitch from '../components/ui/ToggleSwitch';
 import { buildPortfolioSummary, buildPortfolioHistory } from '../utils/portfolioSummary';
 import { useNetWorthConversion } from '../hooks/useNetWorthConversion';
+import HistoricRatesRestatementNotice from '../components/HistoricRatesRestatementNotice';
 import { useHistoricalAccounts } from '../hooks/useHistoricalAccounts';
 import { formatCurrencyCompact } from '../utils/currency-decimal';
 import { computePortfolioPerformance, scopeValueAt, scopeOpeningFlows } from '../utils/portfolioPerformance';
@@ -559,9 +560,13 @@ function InvestmentsView() {
   // Real history: what the SCOPE was worth on each date, never a projection
   // of today's figure backwards. The scope's members convert exactly as the
   // net-worth surfaces do (currency audit, 22 Aug) — a dollar sleeve in a
-  // sterling pair used to join this chart as that many pounds. Null for the
-  // all-sterling scope, which keeps its arithmetic untouched.
-  const { conversion: scopeConversion } = useNetWorthConversion(scopeMembers);
+  // sterling pair used to join this chart as that many pounds — and at each
+  // day's own reference rate where the history is loaded (the owner's
+  // backdated-rates ask), so a currency's movement stops masquerading as
+  // portfolio value. Null for the all-sterling scope, which keeps its
+  // arithmetic untouched.
+  const { seriesConversion: scopeConversion, historical: scopeHistorical } =
+    useNetWorthConversion(scopeMembers, { range: historyRange });
   const performanceData = useMemo(
     () => buildPortfolioHistory(scopeMembers, transactions, historyRange, new Date(), scopeConversion ?? undefined),
     [scopeMembers, transactions, historyRange, scopeConversion]
@@ -1388,6 +1393,10 @@ function InvestmentsView() {
           </div>
         )}
 
+        {/* Said once, dismissibly, when per-day rates first restate what a
+            reader had already seen here (the ruling, 22 Aug §6.4) — this
+            chart is one of the affected surfaces. */}
+        <HistoricRatesRestatementNotice visible={scopeHistorical} />
         {/* Performance Chart */}
         <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
         {/* Wraps: seven pills at ~90px each need ~630px, and a phone offers

--- a/src/pages/NetWorthReport.tsx
+++ b/src/pages/NetWorthReport.tsx
@@ -23,6 +23,7 @@ import { buildNetWorthSnapshots, netWorthAxisTicks, netWorthPointToken, netWorth
 import { buildReportDrillPath } from '../utils/reportDrillLink';
 import { withProvenance } from '../utils/navigationProvenance';
 import ConvertedTotalNote from '../components/ConvertedTotalNote';
+import HistoricRatesRestatementNotice from '../components/HistoricRatesRestatementNotice';
 import { useNetWorthConversion } from '../hooks/useNetWorthConversion';
 import { useArrivalAction } from '../hooks/useArrivalFocus';
 import { resolveEffectiveOpeningDates } from '../utils/openingDates';
@@ -164,11 +165,17 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
    * net-worth card also calls, so the two surfaces cannot disagree about the
    * same money (ruling C). See useNetWorthConversion for the whole account.
    */
-  const { conversion, provenance: ratesProvenance } = useNetWorthConversion(accounts);
+  const {
+    conversion,
+    seriesConversion,
+    conversionAt,
+    historical,
+    provenance: ratesProvenance,
+  } = useNetWorthConversion(accounts, { range: picker.range });
 
   const snapshots = useMemo(
-    () => buildNetWorthSnapshots(accounts, sortedTransactions, picker.range, new Date(), conversion ?? undefined),
-    [accounts, sortedTransactions, picker.range, conversion]
+    () => buildNetWorthSnapshots(accounts, sortedTransactions, picker.range, new Date(), seriesConversion ?? undefined),
+    [accounts, sortedTransactions, picker.range, seriesConversion]
   );
 
   /**
@@ -304,6 +311,16 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
   const [drillView, setDrillView] = useState<'groups' | 'grouped' | 'all'>('groups');
   const [drillSort, setDrillSort] = useState<'value-desc' | 'value-asc' | 'name' | 'name-desc'>('value-desc');
 
+  /**
+   * The factors in force for the drilled DAY: that day's own reference rates
+   * when the history is loaded (the owner's backdated-rates ask, 22 Aug),
+   * today's rates while degraded — never a mixture.
+   */
+  const drillConversion = useMemo(
+    () => (drillDate && conversionAt ? conversionAt(drillDate) : conversion),
+    [drillDate, conversionAt, conversion]
+  );
+
   const drillGroups = useMemo(() => {
     const sorted = [...drillBalances].sort((a, b) => {
       switch (drillSort) {
@@ -333,13 +350,13 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
           // number nobody quoted. Wears ≈ and the sheet's provenance line
           // when any conversion (or unconverted residue) is in it.
           subtotal: entries.reduce((sum, e) => {
-            const factor = conversion?.factors.get(e.account.id);
+            const factor = drillConversion?.factors.get(e.account.id);
             return sum.plus(factor ? e.balance.times(factor) : e.balance);
           }, toDecimal(0)),
           holdsForeign: entries.some(e => (e.account.currency || displayCurrency) !== displayCurrency),
         };
       });
-  }, [drillBalances, drillSort, conversion, displayCurrency]);
+  }, [drillBalances, drillSort, drillConversion, displayCurrency]);
 
   const drillAll = useMemo(
     () => drillGroups.flatMap(group => group.entries),
@@ -396,6 +413,9 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
         colours — which is also what stops green and red here from being
         decoration.
       */}
+      {/* Said once, dismissibly, when per-day rates first restate what a
+          reader had already seen (the ruling, 22 Aug §6.4). */}
+      <HistoricRatesRestatementNotice visible={historical && conversion !== null} />
       <div className="mb-6 space-y-2">
         <NetWorthSummary
           netWorth={latest ? formatCurrency(latest.netWorth) : '—'}
@@ -412,11 +432,33 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
             As at <span className="font-medium text-gray-900 dark:text-gray-100">{latest.label}</span>.
           </p>
         )}
-        {/* The SAME provenance note the summary card carries everywhere else
-            (ruling C reaching this surface, Claude Design 22 Aug §1) — only
-            when a conversion is actually in the figures. Rendered nothing for
-            the single-currency majority, per the data-health rule. */}
-        {conversion && (
+        {/* THE PAGE'S ONE RATE-BASIS LINE (the ruling, 22 Aug §6.2): with the
+            ECB history in force, one sentence carries every qualification —
+            the daily basis, the weekend carry-forward, and (only when the
+            window actually reaches back that far) the pre-1999 substitution.
+            Degraded, the SAME ConvertedTotalNote as every other summary card:
+            today's-rates basis, honestly stated. Rendered nothing for the
+            single-currency majority, per the data-health rule. */}
+        {historical && conversion && (
+          <p className="text-dense text-gray-500 dark:text-gray-400" data-testid="historic-rates-basis">
+            ≈ Converted at each day&rsquo;s ECB reference rate. Weekends and holidays
+            carry the previous business day&rsquo;s rate.
+            {earliest && earliest.date < new Date(1999, 0, 4)
+              ? <> Balances before 4 Jan 1999 use the earliest rate available.</>
+              : null}
+          </p>
+        )}
+        {historical && seriesConversion && seriesConversion.unconverted.length > 0 && (
+          // A currency with NO series at all is still counted native — the
+          // wrong-total warning outranks any basis line, exactly as it does
+          // on the live path below.
+          <ConvertedTotalNote
+            provenance={null}
+            unconverted={seriesConversion.unconverted}
+            displayCurrency={displayCurrency}
+          />
+        )}
+        {!historical && conversion && (
           <ConvertedTotalNote
             provenance={conversion.factors.size > 0 ? ratesProvenance : null}
             unconverted={conversion.unconverted}
@@ -800,25 +842,33 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
                   {drillHoldsForeign ? '≈ ' : ''}
                   {formatCurrency(
                     drillBalances.reduce((sum, e) => {
-                      const factor = conversion?.factors.get(e.account.id);
+                      const factor = drillConversion?.factors.get(e.account.id);
                       return sum.plus(factor ? e.balance.times(factor) : e.balance);
                     }, toDecimal(0)).toNumber()
                   )}
                 </span>
               </div>
-              {/* THE RATE BASIS, SAID (Claude Design, 22 Aug §1): a historic
-                  drill converts at SOME date's rate, and which one is a real
-                  decision the reader cannot infer. The app holds no
-                  historical rate table, so the answer is today's — defensible
-                  only if stated. Rendered nothing when nothing converted. */}
+              {/* THE RATE BASIS, SAID (Claude Design, 22 Aug §1 and the
+                  ruling §6.2/§6.3): a historic drill converts at SOME date's
+                  rate, and which one is a real decision the reader cannot
+                  infer. With the ECB history loaded the answer is the day's
+                  own reference rate; degraded, it is today's — defensible
+                  only if stated, so each basis states itself. The ≈ stays
+                  either way: a converted figure is a valuation, not a
+                  recorded amount. Rendered nothing when nothing converted. */}
               {drillHoldsForeign && (
                 <p className="pt-2 text-dense text-gray-500 dark:text-gray-400">
-                  ≈ marks totals holding another currency, converted at{' '}
-                  {ratesProvenance
-                    ? <>today&rsquo;s rates (as of {ratesProvenance.asOf.toLocaleTimeString(getDateLocale(), { hour: '2-digit', minute: '2-digit' })})</>
-                    : 'no available rate — those amounts are counted unconverted'}
-                  {' '}applied to that day&rsquo;s balances. Each account&rsquo;s own
-                  figure is shown in its own currency.
+                  {historical
+                    ? <>≈ marks totals holding another currency, converted at this
+                      day&rsquo;s ECB reference rate. Weekends and holidays carry the
+                      previous business day&rsquo;s rate. Each account&rsquo;s own
+                      figure is shown in its own currency.</>
+                    : <>≈ marks totals holding another currency, converted at{' '}
+                      {ratesProvenance
+                        ? <>today&rsquo;s rates (as of {ratesProvenance.asOf.toLocaleTimeString(getDateLocale(), { hour: '2-digit', minute: '2-digit' })})</>
+                        : 'no available rate — those amounts are counted unconverted'}
+                      {' '}applied to that day&rsquo;s balances. Each account&rsquo;s own
+                      figure is shown in its own currency.</>}
                 </p>
               )}
             </div>

--- a/src/services/historicalRatesService.test.ts
+++ b/src/services/historicalRatesService.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  getHistoricalRates,
+  fxDayKey,
+  __resetHistoricalRatesForTests,
+} from './historicalRatesService';
+
+/**
+ * The on-device ECB history (the owner's backdated-rates ask, 22 Aug).
+ * The provider is stubbed — these specs pin the CONTRACT: what is fetched,
+ * how gaps carry, and what a dead provider degrades to.
+ *
+ * Every figure here is invented; the repo is public.
+ */
+
+type RangeBody = { rates: Record<string, Record<string, number>> };
+
+const respondWith = (bodies: RangeBody[]): { calls: string[] } => {
+  const calls: string[] = [];
+  let call = 0;
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    calls.push(String(url));
+    const body = bodies[Math.min(call, bodies.length - 1)];
+    call += 1;
+    return { ok: true, json: async () => body } as unknown as Response;
+  }));
+  return { calls };
+};
+
+const providerDead = (): void => {
+  vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('offline'); }));
+};
+
+beforeEach(async () => {
+  await __resetHistoricalRatesForTests();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('getHistoricalRates', () => {
+  it('answers a business day with its own rate, in units per GBP', async () => {
+    respondWith([{ rates: { '2017-07-28': { USD: 1.3 }, '2017-07-31': { USD: 1.32 } } }]);
+    const rates = await getHistoricalRates(['USD'], new Date(2017, 6, 28), new Date(2017, 6, 31));
+    expect(rates.rateOn(new Date(2017, 6, 31), 'USD')).toBe(1.32);
+    expect(rates.provenance?.source).toBe('ecb-history');
+  });
+
+  it('carries a weekend from the previous business day, and GBP is always 1', async () => {
+    respondWith([{ rates: { '2017-07-28': { USD: 1.3 }, '2017-07-31': { USD: 1.32 } } }]);
+    const rates = await getHistoricalRates(['USD'], new Date(2017, 6, 28), new Date(2017, 6, 31));
+    // Saturday the 29th answers with Friday the 28th's rate.
+    expect(rates.rateOn(new Date(2017, 6, 29), 'USD')).toBe(1.3);
+    expect(rates.rateOn(new Date(2017, 6, 29), 'GBP')).toBe(1);
+  });
+
+  it('carries the earliest rate backward before the series begins, and the newest forward past its end', async () => {
+    respondWith([{ rates: { '2017-07-28': { USD: 1.3 }, '2017-07-31': { USD: 1.32 } } }]);
+    const rates = await getHistoricalRates(['USD'], new Date(2017, 6, 28), new Date(2017, 6, 31));
+    expect(rates.rateOn(new Date(1990, 0, 1), 'USD')).toBe(1.3);
+    expect(rates.rateOn(new Date(2020, 0, 1), 'USD')).toBe(1.32);
+  });
+
+  it('clamps the request to the ECB epoch and asks for the currencies once each', async () => {
+    const { calls } = respondWith([{ rates: { '1999-01-04': { USD: 1.65 } } }]);
+    await getHistoricalRates(['USD', 'GBP'], new Date(1980, 0, 1), new Date(1999, 0, 10));
+    expect(calls).toHaveLength(1);
+    // The span starts at the epoch, never 1980, and GBP is not requested —
+    // it is the pivot, answered as 1 without a fetch.
+    expect(calls[0]).toContain('/1999-01-04..1999-01-10');
+    expect(calls[0]).toContain('symbols=USD');
+    expect(calls[0]).not.toContain('GBP,');
+  });
+
+  it('extends a cached span with only the missing tail', async () => {
+    const { calls } = respondWith([
+      { rates: { '2026-08-20': { USD: 1.3 } } },
+      { rates: { '2026-08-21': { USD: 1.31 } } },
+    ]);
+    await getHistoricalRates(['USD'], new Date(2026, 7, 20), new Date(2026, 7, 20));
+    const extended = await getHistoricalRates(['USD'], new Date(2026, 7, 20), new Date(2026, 7, 21));
+    expect(calls).toHaveLength(2);
+    expect(calls[1]).toContain('/2026-08-21..2026-08-21');
+    expect(extended.rateOn(new Date(2026, 7, 21), 'USD')).toBe(1.31);
+    // The first day's rate survived the merge.
+    expect(extended.rateOn(new Date(2026, 7, 20), 'USD')).toBe(1.3);
+  });
+
+  it('degrades to nothing — null provenance, the currency unavailable — when the provider is dead and nothing is cached', async () => {
+    providerDead();
+    const rates = await getHistoricalRates(['USD'], new Date(2017, 6, 28), new Date(2017, 6, 31));
+    expect(rates.provenance).toBeNull();
+    expect(rates.unavailable).toEqual(['USD']);
+    expect(rates.rateOn(new Date(2017, 6, 31), 'USD')).toBeNull();
+  });
+
+  it('still answers from what the device already holds when the provider dies later', async () => {
+    respondWith([{ rates: { '2026-08-20': { USD: 1.3 } } }]);
+    await getHistoricalRates(['USD'], new Date(2026, 7, 20), new Date(2026, 7, 20));
+    vi.unstubAllGlobals();
+    providerDead();
+    const rates = await getHistoricalRates(['USD'], new Date(2026, 7, 20), new Date(2026, 7, 22));
+    // The held day answers, and the missing tail carries forward from it.
+    expect(rates.rateOn(new Date(2026, 7, 20), 'USD')).toBe(1.3);
+    expect(rates.rateOn(new Date(2026, 7, 22), 'USD')).toBe(1.3);
+  });
+});
+
+describe('fxDayKey', () => {
+  it('is local-time, zero-padded, ISO-ordered', () => {
+    expect(fxDayKey(new Date(2026, 0, 5))).toBe('2026-01-05');
+  });
+});

--- a/src/services/historicalRatesService.ts
+++ b/src/services/historicalRatesService.ts
@@ -1,0 +1,324 @@
+/**
+ * Daily exchange-rate HISTORY, held on the device (owner, 22 Aug: "can we get
+ * backdated currency figures by day and hold them somewhere to be referenced
+ * against and used for backdated calculations?").
+ *
+ * SOURCE — the European Central Bank's reference rates, via frankfurter.dev:
+ * free, keyless, one HTTPS GET for a whole date range, daily figures back to
+ * 4 January 1999. Verified before this was written: a range beginning on a
+ * weekend answers from the previous business day, and a full year of one
+ * pair is ~7 KB, so the complete history of a currency is a single small
+ * request made once.
+ *
+ * WHY ON-DEVICE AND NOT A SERVER TABLE: the reports that need history run in
+ * the desktop edition too, and desktop-reachable code may not import
+ * Supabase (see docs/edition-gating.md). A plain fetch plus IndexedDB works
+ * identically in both editions, costs no migration, and degrades offline to
+ * whatever history the device already holds. The seam is this module's
+ * exported functions — a server-backed store could stand behind them later
+ * without a caller changing.
+ *
+ * UNITS — the table speaks the app's one dialect: units of a currency per
+ * £1 (the FALLBACK_RATES convention in currency-decimal.ts), GBP the pivot,
+ * so A→B is rateOf(B)/rateOf(A) everywhere and no module needs to know
+ * which base the provider used.
+ *
+ * GAPS — the ECB publishes business days only. A weekend or holiday carries
+ * the previous business day's rate forward; a date before the table begins
+ * carries the earliest rate backward; a date past the newest fetch carries
+ * the newest forward. Every surface that shows a figure built on this says
+ * the basis out loud — the carrying is a stated policy, not a guess.
+ *
+ * One rule stands above this table: a rate RECORDED at transfer time (the
+ * cross-currency dialog's confirmed conversions) always beats a reference
+ * rate — that is the actual money that moved. This history is for VALUATION,
+ * never for rewriting recorded transfers.
+ */
+
+const PROVIDER_ORIGIN = 'https://api.frankfurter.dev';
+export const HISTORICAL_RATES_PROVIDER = 'European Central Bank reference rates';
+/** The first date the ECB series exists for. */
+const SERIES_EPOCH = '1999-01-04';
+
+const DB_NAME = 'wealthtracker-fx-history';
+const STORE = 'rates';
+const OPEN_TIMEOUT_MS = 10_000;
+
+export interface HistoricalRatesProvenance {
+  source: 'ecb-history';
+  /** The newest rate date the table holds — how fresh the history is. */
+  asOf: Date;
+}
+
+export interface HistoricalRates {
+  /**
+   * Units of `currency` per £1 on `date`, carrying business days across gaps
+   * as documented above. Null when the currency has no data at all.
+   */
+  rateOn(date: Date, currency: string): number | null;
+  provenance: HistoricalRatesProvenance | null;
+  /** Currencies asked for that the provider has no series for. */
+  unavailable: readonly string[];
+}
+
+interface CurrencyHistory {
+  currency: string;
+  /** First and last date keys the `rates` record spans (inclusive). */
+  from: string;
+  through: string;
+  /** Rate per date key, business days only. */
+  rates: Record<string, number>;
+}
+
+export function fxDayKey(date: Date): string {
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
+/* ───────────────────────── storage ─────────────────────────
+ * IndexedDB when the browser grants it, a module Map when it does not
+ * (private-mode Safari, a torn-down test) — history then lives for the
+ * session, which still spares the provider repeat fetches.
+ */
+
+const memoryStore = new Map<string, CurrencyHistory>();
+let dbPromise: Promise<IDBDatabase | null> | null = null;
+let openedDb: IDBDatabase | null = null;
+
+function openDb(): Promise<IDBDatabase | null> {
+  if (dbPromise) return dbPromise;
+  dbPromise = new Promise(resolve => {
+    if (typeof indexedDB === 'undefined') {
+      resolve(null);
+      return;
+    }
+    const timer = setTimeout(() => resolve(null), OPEN_TIMEOUT_MS);
+    try {
+      const request = indexedDB.open(DB_NAME, 1);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(STORE)) {
+          db.createObjectStore(STORE, { keyPath: 'currency' });
+        }
+      };
+      request.onsuccess = () => {
+        clearTimeout(timer);
+        openedDb = request.result;
+        resolve(request.result);
+      };
+      request.onerror = () => {
+        clearTimeout(timer);
+        resolve(null);
+      };
+    } catch {
+      clearTimeout(timer);
+      resolve(null);
+    }
+  });
+  return dbPromise;
+}
+
+async function readHistory(currency: string): Promise<CurrencyHistory | null> {
+  const db = await openDb();
+  if (!db) return memoryStore.get(currency) ?? null;
+  return new Promise(resolve => {
+    try {
+      const request = db.transaction(STORE, 'readonly').objectStore(STORE).get(currency);
+      request.onsuccess = () => resolve((request.result as CurrencyHistory | undefined) ?? null);
+      request.onerror = () => resolve(null);
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+async function writeHistory(history: CurrencyHistory): Promise<void> {
+  const db = await openDb();
+  if (!db) {
+    memoryStore.set(history.currency, history);
+    return;
+  }
+  await new Promise<void>(resolve => {
+    try {
+      const request = db.transaction(STORE, 'readwrite').objectStore(STORE).put(history);
+      request.onsuccess = () => resolve();
+      request.onerror = () => resolve();
+    } catch {
+      resolve();
+    }
+  });
+}
+
+/* ───────────────────────── fetching ───────────────────────── */
+
+interface RangeResponse {
+  rates?: Record<string, Record<string, number>>;
+}
+
+async function fetchRange(
+  currencies: readonly string[],
+  fromKey: string,
+  toKey: string
+): Promise<Record<string, Record<string, number>> | null> {
+  try {
+    const symbols = currencies.join(',');
+    const response = await fetch(
+      `${PROVIDER_ORIGIN}/v1/${fromKey}..${toKey}?base=GBP&symbols=${symbols}`
+    );
+    if (!response.ok) return null;
+    const body = (await response.json()) as RangeResponse;
+    return body.rates ?? null;
+  } catch {
+    return null;
+  }
+}
+
+const addDays = (key: string, days: number): string => {
+  const [y, m, d] = key.split('-').map(Number);
+  const date = new Date(y, m - 1, d + days);
+  return fxDayKey(date);
+};
+
+const maxKey = (a: string, b: string): string => (a >= b ? a : b);
+
+/**
+ * In-flight requests keyed by their span, so two surfaces asking for the same
+ * history in the same render burst share one provider call.
+ */
+const inFlight = new Map<string, Promise<HistoricalRates>>();
+
+/**
+ * The history for `currencies` (ISO codes, GBP allowed and answered as 1)
+ * covering [from, to]. Cached spans are extended incrementally — the common
+ * daily case fetches only the missing tail.
+ */
+export async function getHistoricalRates(
+  currencies: readonly string[],
+  from: Date,
+  to: Date
+): Promise<HistoricalRates> {
+  const wanted = [...new Set(currencies.filter(c => c && c !== 'GBP'))].sort();
+  const fromKey = maxKey(fxDayKey(from), SERIES_EPOCH);
+  const toKey = maxKey(fxDayKey(to), fromKey);
+  const flightKey = `${wanted.join(',')}|${fromKey}|${toKey}`;
+  const standing = inFlight.get(flightKey);
+  if (standing) return standing;
+
+  const flight = (async (): Promise<HistoricalRates> => {
+    const histories = new Map<string, CurrencyHistory>();
+    const toFetchWhole: string[] = [];
+    const toExtend: Array<{ currency: string; fromKey: string }> = [];
+
+    for (const currency of wanted) {
+      const held = await readHistory(currency);
+      if (!held || held.from > fromKey) {
+        // Nothing, or a hole before what we hold: refetch the whole span
+        // (the payload is small enough that backfilling-in-place is not
+        // worth the bookkeeping).
+        toFetchWhole.push(currency);
+      } else {
+        histories.set(currency, held);
+        if (held.through < toKey) toExtend.push({ currency, fromKey: addDays(held.through, 1) });
+      }
+    }
+
+    if (toFetchWhole.length > 0) {
+      const fetched = await fetchRange(toFetchWhole, fromKey, toKey);
+      if (fetched) {
+        for (const currency of toFetchWhole) {
+          const rates: Record<string, number> = {};
+          for (const [day, byCurrency] of Object.entries(fetched)) {
+            if (byCurrency[currency] !== undefined) rates[day] = byCurrency[currency];
+          }
+          if (Object.keys(rates).length > 0) {
+            const history: CurrencyHistory = { currency, from: fromKey, through: toKey, rates };
+            histories.set(currency, history);
+            await writeHistory(history);
+          }
+        }
+      }
+    }
+
+    for (const { currency, fromKey: extendFrom } of toExtend) {
+      const held = histories.get(currency);
+      if (!held) continue;
+      const fetched = await fetchRange([currency], extendFrom, toKey);
+      if (fetched) {
+        for (const [day, byCurrency] of Object.entries(fetched)) {
+          if (byCurrency[currency] !== undefined) held.rates[day] = byCurrency[currency];
+        }
+      }
+      // `through` advances even when the fetch failed or returned nothing —
+      // otherwise an offline day would retry the same span forever. The
+      // carry-forward answers the gap either way.
+      held.through = toKey;
+      await writeHistory(held);
+    }
+
+    const unavailable = wanted.filter(c => !histories.has(c));
+    let newest: string | null = null;
+    for (const history of histories.values()) {
+      for (const day of Object.keys(history.rates)) {
+        if (newest === null || day > newest) newest = day;
+      }
+    }
+
+    const sortedKeysByCurrency = new Map<string, string[]>();
+    for (const [currency, history] of histories) {
+      sortedKeysByCurrency.set(currency, Object.keys(history.rates).sort());
+    }
+
+    return {
+      rateOn(date: Date, currency: string): number | null {
+        if (currency === 'GBP') return 1;
+        const history = histories.get(currency);
+        const keys = sortedKeysByCurrency.get(currency);
+        if (!history || !keys || keys.length === 0) return null;
+        const wantedKey = fxDayKey(date);
+        // Binary search for the newest key ≤ wantedKey; before the epoch the
+        // earliest carries backward, past the newest the last carries forward.
+        let lo = 0;
+        let hi = keys.length - 1;
+        if (wantedKey < keys[0]) return history.rates[keys[0]];
+        if (wantedKey >= keys[hi]) return history.rates[keys[hi]];
+        while (lo < hi) {
+          const mid = Math.ceil((lo + hi) / 2);
+          if (keys[mid] <= wantedKey) lo = mid;
+          else hi = mid - 1;
+        }
+        return history.rates[keys[lo]];
+      },
+      provenance: newest === null
+        ? null
+        : (() => {
+            const [y, m, d] = newest.split('-').map(Number);
+            return { source: 'ecb-history' as const, asOf: new Date(y, m - 1, d) };
+          })(),
+      unavailable,
+    };
+  })();
+
+  inFlight.set(flightKey, flight);
+  try {
+    return await flight;
+  } finally {
+    inFlight.delete(flightKey);
+  }
+}
+
+/** Test seam: forget everything held, on-device store included. */
+export async function __resetHistoricalRatesForTests(): Promise<void> {
+  memoryStore.clear();
+  inFlight.clear();
+  openedDb?.close();
+  openedDb = null;
+  dbPromise = null;
+  if (typeof indexedDB === 'undefined') return;
+  await new Promise<void>(resolve => {
+    const request = indexedDB.deleteDatabase(DB_NAME);
+    request.onsuccess = () => resolve();
+    request.onerror = () => resolve();
+    request.onblocked = () => resolve();
+  });
+}

--- a/src/utils/__tests__/currencyAggregationCensus.test.ts
+++ b/src/utils/__tests__/currencyAggregationCensus.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+/**
+ * THE STANDING CURRENCY-AGGREGATION CENSUS (owner, 22 Aug: "is it possible
+ * to do some sort of audit across the app to look for the lack of currency
+ * conversions … It is important for a financial app that this is the case").
+ *
+ * The 22 Aug audit found the app's cross-account money sums were largely
+ * currency-blind — native units summed as display units, a dollar counted
+ * as a pound. The findings live in the audit and its ruling; THIS file is
+ * what stops the list growing silently: every call site of the aggregation
+ * primitives that caused the findings must be CLASSIFIED here. A new caller
+ * fails this test until someone says which honest state it is in — the
+ * ruling's four-state table, where only "sum native, silently" is
+ * unacceptable.
+ *
+ * WHAT THIS CANNOT SEE: a hand-rolled `reduce` over amounts uses no
+ * primitive and passes this census unseen. The fence covers the primitives
+ * that produced the audit's findings; the audit itself is the tool for the
+ * rest, and this header is the honest statement of the gap.
+ *
+ * Statuses:
+ * - 'converts'            — passes a conversion (the ≈ + provenance path)
+ * - 'excludes-and-states' — leaves foreign accounts out AND says so in the UI
+ * - 'native-known'        — sums native, recorded by the audit, awaiting its
+ *                           phase in the ruling's order. New code may NOT
+ *                           enter at this status: convert or exclude-and-say.
+ */
+
+const PRIMITIVES = [
+  'computeIncomeExpense',
+  'calculateTotalBalance',
+  'calculateNetWorth',
+  'buildNetWorthSnapshots',
+  'buildPortfolioHistory',
+] as const;
+
+type Status = 'converts' | 'excludes-and-states' | 'native-known';
+
+/** file (repo-relative, posix) → the statuses of the primitives it calls. */
+const LEDGER: Record<string, Partial<Record<(typeof PRIMITIVES)[number], Status>>> = {
+  // ── the defining modules — a definition is not a call site ──
+  'src/utils/incomeExpense.ts': { computeIncomeExpense: 'native-known' },
+  'src/utils/calculations-decimal.ts': {
+    calculateTotalBalance: 'native-known',
+    calculateNetWorth: 'native-known',
+  },
+  'src/utils/netWorthSeries.ts': { buildNetWorthSnapshots: 'converts' },
+  'src/utils/portfolioSummary.ts': {
+    buildNetWorthSnapshots: 'converts',
+    buildPortfolioHistory: 'converts',
+    // portfolio value/allocation/returns — audit P2, awaiting its phase.
+    calculateTotalBalance: 'native-known',
+  },
+
+  // ── converted surfaces ──
+  'src/pages/NetWorthReport.tsx': { buildNetWorthSnapshots: 'converts' },
+  'src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx': {
+    buildNetWorthSnapshots: 'converts',
+  },
+  'src/pages/Investments.tsx': { buildPortfolioHistory: 'converts' },
+  // Partitions by currency before it sums (currencySubtotalsForBand).
+  'src/pages/Accounts.tsx': { calculateTotalBalance: 'converts' },
+
+  // ── the audit's known native sums, phase-ordered in the ruling ──
+  'src/hooks/useReportDataset.ts': { computeIncomeExpense: 'native-known' },
+  'src/components/dashboard/ImprovedDashboard.tsx': { computeIncomeExpense: 'native-known' },
+  'src/pages/Calendar.tsx': { computeIncomeExpense: 'native-known' },
+  'src/pages/Categorisation.tsx': { computeIncomeExpense: 'native-known' },
+  'src/pages/reports/PeriodComparisonReport.tsx': { computeIncomeExpense: 'native-known' },
+  'src/utils/categoryHealth.ts': { computeIncomeExpense: 'native-known' },
+};
+
+const SRC = join(process.cwd(), 'src');
+
+function walk(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__' || entry === 'test') continue;
+      walk(full, out);
+    } else if (/\.(ts|tsx)$/.test(entry) && !/\.test\.(ts|tsx)$/.test(entry)) {
+      out.push(full);
+    }
+  }
+}
+
+describe('currency-aggregation census — no new unclassified money sums', () => {
+  const files: string[] = [];
+  walk(SRC, files);
+
+  const found = new Map<string, Set<string>>();
+  for (const file of files) {
+    const source = readFileSync(file, 'utf8');
+    const rel = relative(process.cwd(), file).split('\\').join('/');
+    for (const primitive of PRIMITIVES) {
+      // A call or a definition — either makes the file part of the census.
+      if (new RegExp(`\\b${primitive}\\s*\\(`).test(source)) {
+        const set = found.get(rel) ?? new Set<string>();
+        set.add(primitive);
+        found.set(rel, set);
+      }
+    }
+  }
+
+  it('every caller of an aggregation primitive is classified', () => {
+    const unclassified: string[] = [];
+    for (const [file, primitives] of found) {
+      for (const primitive of primitives) {
+        if (LEDGER[file]?.[primitive as (typeof PRIMITIVES)[number]] === undefined) {
+          unclassified.push(`${file} → ${primitive}`);
+        }
+      }
+    }
+    expect(
+      unclassified,
+      'New cross-account money aggregation with no classification. Convert it ' +
+      '(the ≈ + provenance path), exclude foreign accounts AND say so, or — ' +
+      'for existing audited debt only — record it native-known. Then add it ' +
+      'to the LEDGER in this file with the status it earned.'
+    ).toEqual([]);
+  });
+
+  it('the ledger carries no stale entries', () => {
+    const stale: string[] = [];
+    for (const [file, statuses] of Object.entries(LEDGER)) {
+      for (const primitive of Object.keys(statuses)) {
+        if (!found.get(file)?.has(primitive)) {
+          stale.push(`${file} → ${primitive}`);
+        }
+      }
+    }
+    expect(
+      stale,
+      'A ledger entry no longer matches the code — the call moved or was ' +
+      'removed. Delete or update the entry so the census stays true.'
+    ).toEqual([]);
+  });
+
+  it('is not vacuous: the fence actually sees the known call sites', () => {
+    expect(found.get('src/hooks/useReportDataset.ts')?.has('computeIncomeExpense')).toBe(true);
+    expect(found.get('src/pages/NetWorthReport.tsx')?.has('buildNetWorthSnapshots')).toBe(true);
+  });
+});

--- a/src/utils/netWorthSeries.test.ts
+++ b/src/utils/netWorthSeries.test.ts
@@ -225,4 +225,20 @@ describe('buildNetWorthSnapshots — currency conversion at the summing', () => 
     // Native fallback: the figure carries the residue the caller must say.
     expect(on(snaps, 14)?.netWorth).toBe(1200);
   });
+
+  it('a DATED conversion values each snapshot at its own day\'s rates', () => {
+    // The owner's backdated-rates ask (22 Aug): a 2017 balance at 2017's
+    // rate, not today's. Here the pound strengthens mid-month — the dollar
+    // account is worth £100 on the 10th and £80 on the 20th, with the
+    // sterling side untouched. One walk, two different rates, each point
+    // converting at its own.
+    const dated = {
+      at: (date: Date) =>
+        buildNetWorthConversion(book, { GBP: 1, USD: date.getDate() < 15 ? 2 : 2.5 }, 'GBP'),
+      unconverted: [] as const,
+    };
+    const snaps = buildNetWorthSnapshots(book, [], RANGE, new Date(2026, 2, 28), dated);
+    expect(on(snaps, 10)?.netWorth).toBe(1100);
+    expect(on(snaps, 20)?.netWorth).toBe(1080);
+  });
 });

--- a/src/utils/netWorthSeries.ts
+++ b/src/utils/netWorthSeries.ts
@@ -91,12 +91,29 @@ export function netWorthPointToken(date: Date): string {
  * Point cadence: daily for windows under ~3 months, month-end beyond (the
  * Money cadence), always ending on the window's final day.
  */
+/**
+ * Per-DATE conversion: each snapshot converts at its own day's rates (the
+ * owner's backdated-rates ask, 22 Aug — a 2017 balance at 2017's rate). The
+ * static NetWorthConversion remains for callers valuing everything at one
+ * day's rates; the walk takes either.
+ */
+export interface NetWorthConversionByDate {
+  /** The factors in force on `date` — that day's reference rates. */
+  at(date: Date): NetWorthConversion | null;
+  /** Currencies with no history at all — counted native and reported. */
+  unconverted: readonly string[];
+}
+
+const isDatedConversion = (
+  c: NetWorthConversion | NetWorthConversionByDate
+): c is NetWorthConversionByDate => typeof (c as NetWorthConversionByDate).at === 'function';
+
 export function buildNetWorthSnapshots(
   accounts: Account[],
   transactions: Transaction[],
   range: PeriodRange,
   now: Date = new Date(),
-  conversion?: NetWorthConversion
+  conversion?: NetWorthConversion | NetWorthConversionByDate
 ): NetWorthSnapshot[] {
   if (accounts.length === 0) return [];
 
@@ -167,12 +184,16 @@ export function buildNetWorthSnapshots(
     }
     let assets = toDecimal(0);
     let liabilities = toDecimal(0);
+    // Into the display currency where a factor exists; native (and reported
+    // by the caller as unconverted) where it does not. Balances stay native
+    // through the walk — the transactions are native — and convert only at
+    // the summing, so one rate refresh never has to replay the history. A
+    // dated conversion resolves THIS point's factors: the day's own rates.
+    const active = conversion === undefined
+      ? undefined
+      : isDatedConversion(conversion) ? conversion.at(point) ?? undefined : conversion;
     for (const [accountId, native] of balances.entries()) {
-      // Into the display currency where a factor exists; native (and reported
-      // by the caller as unconverted) where it does not. Balances stay native
-      // through the walk — the transactions are native — and convert only at
-      // the summing, so one rate refresh never has to replay the history.
-      const factor = conversion?.factors.get(accountId);
+      const factor = active?.factors.get(accountId);
       const b = factor ? native.times(factor) : native;
       if (b.greaterThan(0)) assets = assets.plus(b);
       else liabilities = liabilities.plus(b.abs());

--- a/src/utils/portfolioSummary.ts
+++ b/src/utils/portfolioSummary.ts
@@ -5,7 +5,7 @@ import { calculateTotalBalance } from './calculations-decimal';
 import { buildTopLevelIdByAccountId, groupByTopLevelId } from './accountNesting';
 import { buildCategoryKindLookup, classifyFlow } from './incomeExpense';
 import { expandSplitTransactions, type SplitExpandedTransaction } from './transactionSplits';
-import { buildNetWorthSnapshots, type NetWorthConversion } from './netWorthSeries';
+import { buildNetWorthSnapshots, type NetWorthConversion, type NetWorthConversionByDate } from './netWorthSeries';
 import type { PeriodRange } from '../hooks/usePeriod';
 
 /**
@@ -348,9 +348,10 @@ export function buildPortfolioHistory(
    * The same conversion the net-worth surfaces pass (currency audit, 22 Aug):
    * this was the one caller of buildNetWorthSnapshots that kept summing a
    * foreign member's native units as display units after the walk learned to
-   * convert. Omitted, the single-currency portfolio behaves exactly as before.
+   * convert. Dated, each point converts at its own day's reference rate.
+   * Omitted, the single-currency portfolio behaves exactly as before.
    */
-  conversion?: NetWorthConversion
+  conversion?: NetWorthConversion | NetWorthConversionByDate
 ): PortfolioHistoryPoint[] {
   const memberIds = new Set(memberAccounts.map(a => a.id));
   return buildNetWorthSnapshots(


### PR DESCRIPTION
The owner's two asks (22 Aug): backdated currency figures by day, and a standing audit against unconverted foreign sums. Design's ruling §6 (RULING_CURRENCY_DISCLOSURE) is built in.

## The history, on the device

`historicalRatesService` fetches the **ECB's daily reference rates** (frankfurter.dev — keyless, one GET per span, series back to 4 Jan 1999) into its own small IndexedDB store, memory when a browser refuses one. On-device rather than a Supabase table because these reports run in the **desktop edition**, which may not import Supabase — a plain fetch + IndexedDB behaves identically in both editions, costs no migration, and degrades offline to whatever the device holds. Spans extend incrementally (the daily case fetches only the missing tail); units are per-GBP, the app's one conversion dialect; weekends carry the previous business day, the epoch carries backward, the newest forward. Eight specs pin the contract, provider stubbed; the reset seam clears the on-device store too.

## Each snapshot at its own day's rate

`buildNetWorthSnapshots` accepts a **dated** conversion (`NetWorthConversionByDate.at(date)`); one shared hook (`useNetWorthConversion` + history window) feeds the report, the dashboard net-worth card, and the Investments performance chart, so the three surfaces restate together (ruling C). The drill converts at `conversionAt(drillDate)` — the day's own rate, never today's. When history cannot be had, everything degrades to exactly the previous behaviour — today's rates, the old caveat honestly stated — never to silence.

## Said out loud (ruling §6.2–§6.4)

- One basis line per page: *"≈ Converted at each day's ECB reference rate. Weekends and holidays carry the previous business day's rate."* — the pre-1999 clause renders only when the window reaches back that far.
- **The ≈ stays**: a converted figure is a valuation, not a recorded amount.
- **`HistoricRatesRestatementNotice`**: one-time, dismissible (a preference, not a tab), on the report and the Investments chart — historic figures changed; *your recorded transactions are unchanged*. Recorded transfer rates still beat the reference table everywhere.

Verified live: the report fetched real ECB history, the demo's dollar accounts re-valued (the headline visibly restated against the live-quote basis), the drill's foot states the day's-rate basis with an ≈-marked total, and the dismissal survives reload.

## The census guard

`currencyAggregationCensus.test.ts`: every call site of the aggregation primitives behind the audit's findings must be classified in its ledger (converts / excludes-and-states / native-known-audited). A new unclassified caller **fails the suite by name**; a stale ledger entry fails as stale. Proven non-vacuous: a probe caller was added, the suite failed naming it, and passed on removal. The header states the fence's honest gap (hand-rolled reduces pass unseen — the audit is the tool for those).

Every figure in the tests is invented; the repo is public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)