### PR TITLE
Every row wears its own currency's symbol — a $100 balance is not £100

### DIFF
--- a/src/components/BulkEditPanel.tsx
+++ b/src/components/BulkEditPanel.tsx
@@ -173,7 +173,7 @@ export default function BulkEditPanel({
               placeholder="Keep in current account"
               searchPlaceholder="Search or select account…"
               clearOption="Keep in current account"
-              formatLabel={(acc) => `${acc.name} (${formatCurrency(acc.balance)})`}
+              formatLabel={(acc) => `${acc.name} (${formatCurrency(acc.balance, acc.currency)})`}
               className="w-full px-3 py-2 h-[42px] border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800"
               ariaLabel="Move to account"
             />

--- a/src/components/IncomeExpenseBreakdownModal.tsx
+++ b/src/components/IncomeExpenseBreakdownModal.tsx
@@ -9,6 +9,7 @@ import { toDecimal } from '../utils/decimal';
 import type { Category } from '../types';
 import type { SplitExpandedTransaction } from '../utils/transactionSplits';
 import { getDateLocale } from '../utils/dateFormatter';
+import { useAccountCurrencies } from '../hooks/useAccountNames';
 
 /**
  * The income/expense breakdown pop-up, shared by the Dashboard and Reports —
@@ -65,6 +66,11 @@ export default function IncomeExpenseBreakdownModal({
   onApplyCategories,
 }: Props): React.JSX.Element {
   const { formatCurrency } = useCurrencyDecimal();
+  // Each row's OWN currency, closed accounts included — a $100 row must
+  // never print as £100 (the disclosure ruling, 22 Aug §3: a correct number
+  // wearing the wrong symbol is the most directly checkable falsehood in
+  // the app, and history lives in closed accounts).
+  const currencyOf = useAccountCurrencies();
   const inlineFiling = bucket === 'uncategorized' && onApplyCategories !== undefined;
 
   // Row id → chosen category ('' = choice cleared).
@@ -311,7 +317,7 @@ export default function IncomeExpenseBreakdownModal({
           </td>
         )}
         <td className={`block sm:table-cell py-2 text-sm font-medium text-right whitespace-nowrap tabular-nums ${rowColour}`}>
-          {formatCurrency(value)}
+          {formatCurrency(value, currencyOf(t.accountId))}
         </td>
       </tr>
     );

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -1315,7 +1315,7 @@ export function ImprovedDashboard() {
                             {account.name}
                           </span>
                           <span className="text-xs text-gray-500 dark:text-gray-400 ml-auto whitespace-nowrap">
-                            {formatCurrencyWithSymbol(getAccountBalance(account))}
+                            {formatCurrencyWithSymbol(getAccountBalance(account), account.currency)}
                           </span>
                         </button>
                       );
@@ -1364,7 +1364,7 @@ export function ImprovedDashboard() {
                     navigate(preserveDemoParam(`/accounts/${account.id}`, location.search));
                   }
                 }}
-                aria-label={`View ${account.name} account details. Balance: ${formatCurrencyWithSymbol(getAccountBalance(account))}. Hold Alt and press an arrow key to move this card.`}
+                aria-label={`View ${account.name} account details. Balance: ${formatCurrencyWithSymbol(getAccountBalance(account), account.currency)}. Hold Alt and press an arrow key to move this card.`}
               >
                 <div className="flex-1">
                   <p className="font-medium text-gray-900 dark:text-white">
@@ -1390,7 +1390,7 @@ export function ImprovedDashboard() {
                       ? 'text-red-600 dark:text-red-400'
                       : 'text-gray-900 dark:text-white'
                   }`}>
-                    {formatCurrencyWithSymbol(getAccountBalance(account))}
+                    {formatCurrencyWithSymbol(getAccountBalance(account), account.currency)}
                   </p>
                   {account.creditLimit && (
                     <p className="text-xs text-gray-500 dark:text-gray-400">

--- a/src/components/reports/ReportDrillModal.test.tsx
+++ b/src/components/reports/ReportDrillModal.test.tsx
@@ -33,7 +33,9 @@ interface AppData {
 const store = vi.hoisted(() => {
   const listeners = new Set<() => void>();
   const state = {
-    snapshot: { transactions: [], transactionSplits: [] } as AppData,
+    // accounts too: the breakdown rows resolve each row's own currency
+    // through useAccountCurrencies, which reads them from this context.
+    snapshot: { transactions: [], transactionSplits: [], accounts: [] } as AppData,
     subscribe(listener: () => void): () => void {
       listeners.add(listener);
       return () => { listeners.delete(listener); };

--- a/src/components/reports/TopTransactionsTable.tsx
+++ b/src/components/reports/TopTransactionsTable.tsx
@@ -6,6 +6,7 @@ import { selectTopTransactions } from '../../utils/topTransactions';
 import type { Category } from '../../types';
 import type { SplitExpandedTransaction } from '../../utils/transactionSplits';
 import { preferences } from '../../services/preferencesService';
+import { useAccountCurrencies } from '../../hooks/useAccountNames';
 
 /**
  * The biggest real money movements of the period, on the "Monthly income and
@@ -49,6 +50,11 @@ export default function TopTransactionsTable({
   onOpenTransaction: (transactionId: string) => void;
 }): React.JSX.Element {
   const { formatCurrency } = useCurrencyDecimal();
+  // Each row's OWN currency, closed accounts included — a $100 row must
+  // never print as £100 (the disclosure ruling, 22 Aug §3: a correct number
+  // wearing the wrong symbol is the most directly checkable falsehood in
+  // the app, and history lives in closed accounts).
+  const currencyOf = useAccountCurrencies();
   // A curiosity next to the matrix, so it starts hidden; the choice is
   // persisted like the report's other view preferences.
   const [show, setShow] = useState<boolean>(() => preferences.getItem(SHOW_KEY) === '1');
@@ -160,7 +166,7 @@ export default function TopTransactionsTable({
                       transaction.amount < 0 ? 'text-red-600 dark:text-red-400' : 'text-green-700 dark:text-green-400'
                     }`}>
                       {/* Amounts are stored signed; derive the sign from the value */}
-                      {transaction.amount < 0 ? '-' : '+'}{formatCurrency(Math.abs(transaction.amount))}
+                      {transaction.amount < 0 ? '-' : '+'}{formatCurrency(Math.abs(transaction.amount), currencyOf(transaction.accountId))}
                     </p>
                   </div>
                 </div>
@@ -232,7 +238,7 @@ export default function TopTransactionsTable({
                       transaction.amount < 0 ? 'text-red-600 dark:text-red-400' : 'text-green-700 dark:text-green-400'
                     }`}>
                       {/* Amounts are stored signed; derive the sign from the value */}
-                      {transaction.amount < 0 ? '-' : '+'}{formatCurrency(Math.abs(transaction.amount))}
+                      {transaction.amount < 0 ? '-' : '+'}{formatCurrency(Math.abs(transaction.amount), currencyOf(transaction.accountId))}
                     </td>
                   </tr>
                 ))

--- a/src/hooks/useAccountNames.ts
+++ b/src/hooks/useAccountNames.ts
@@ -33,3 +33,33 @@ export function useAccountNames(): (id: string) => string {
     return (id: string): string => byId.get(id) ?? 'Unknown account';
   }, [accounts, closed]);
 }
+
+/**
+ * Account-id → the account's own currency, including CLOSED accounts —
+ * closed for the same measured reason names need them: history lives there.
+ *
+ * For the row-level fix the disclosure ruling promoted (22 Aug §3): a $100
+ * row printed as £100 is a correct number wearing the wrong symbol, the most
+ * directly checkable falsehood in the app. Undefined for an unknown id, so
+ * the caller's formatter falls back to the display currency rather than
+ * inventing one.
+ */
+export function useAccountCurrencies(): (id: string) => string | undefined {
+  const { accounts } = useApp();
+  const [closed, setClosed] = useState<Account[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    dataPort.listClosedAccounts()
+      .then(list => { if (!cancelled) setClosed(list); })
+      .catch(() => { /* currencies fall back to the display one; nothing breaks */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  return useMemo(() => {
+    const byId = new Map<string, string>();
+    closed.forEach(a => byId.set(a.id, a.currency));
+    accounts.forEach(a => byId.set(a.id, a.currency));
+    return (id: string): string | undefined => byId.get(id);
+  }, [accounts, closed]);
+}

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -1769,7 +1769,7 @@ function InvestmentsView() {
                                   {debt.name}
                                 </Link>
                                 <span className="tabular-nums shrink-0 ml-3">
-                                  {formatCurrency(toDecimal(debt.balance ?? 0))}
+                                  {formatCurrency(toDecimal(debt.balance ?? 0), debt.currency)}
                                 </span>
                               </p>
                             ))}


### PR DESCRIPTION
The disclosure ruling's §3 (22 Aug), promoted above the totals: *"a correct number wearing the wrong symbol is a falsehood about a single fact the reader can check against their statement in five seconds"* — and the cheapest fix in the audit: pass the argument that was already there.

**Account rows** (the object in hand): the dashboard's three remaining account-card figures, BulkEditPanel's move-to-account labels, and the Investments page's secured-liability rows now pass `account.currency`.

**Transaction rows** (only an `accountId` in hand): a new `useAccountCurrencies` — `useAccountNames`' sibling, in its file, for its measured reason: **history lives in closed accounts**, and an open-only lookup would keep mislabelling exactly the rows most likely to be foreign. Top Transactions and the income/expense breakdown drill now format each row in its account's own currency, closed accounts included; an unknown id falls back to the display currency rather than inventing one.

Totals are untouched — those are the conversion programme's business, phase by phase (Phase 0 disclosure is next). This is only the rows telling the truth about themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)