### PR TITLE
Every still-native total says so — Phase 0: quietly wrong becomes honestly limited

### DIFF
--- a/src/components/ExcelExport.tsx
+++ b/src/components/ExcelExport.tsx
@@ -139,14 +139,28 @@ export default function ExcelExport({ isOpen, onClose }: ExcelExportProps): Reac
       Institution: acc.institution || ''
     }));
 
+    // Phase 0 (the disclosure ruling, 22 Aug §2): the file's own Currency
+    // column proves the accounts can differ, and every total above sums them
+    // unit-for-unit. A spreadsheet outlives the app's caveats, so the sheet
+    // itself says so — until the exports' conversion phase. Nothing for a
+    // single-currency ledger.
+    const currencies = new Set(accounts.map(acc => acc.currency).filter(Boolean));
+    const overview: Array<{ Metric: string; Value: number | string }> = [
+      { Metric: 'Total Income', Value: income },
+      { Metric: 'Total Expenses', Value: expenses },
+      { Metric: 'Net Income', Value: toDecimal(income).minus(toDecimal(expenses)).toNumber() },
+      { Metric: 'Transaction Count', Value: filtered.length },
+      { Metric: 'Date Range', Value: `${options.dateRange.start?.toLocaleDateString()} - ${options.dateRange.end?.toLocaleDateString()}` }
+    ];
+    if (currencies.size > 1) {
+      overview.push({
+        Metric: 'Note',
+        Value: 'Totals mix currencies: amounts in another currency are counted unit-for-unit, not converted.',
+      });
+    }
+
     return {
-      overview: [
-        { Metric: 'Total Income', Value: income },
-        { Metric: 'Total Expenses', Value: expenses },
-        { Metric: 'Net Income', Value: toDecimal(income).minus(toDecimal(expenses)).toNumber() },
-        { Metric: 'Transaction Count', Value: filtered.length },
-        { Metric: 'Date Range', Value: `${options.dateRange.start?.toLocaleDateString()} - ${options.dateRange.end?.toLocaleDateString()}` }
-      ],
+      overview,
       categoryBreakdown,
       accountSummary
     };

--- a/src/components/MixedCurrencyDisclosure.test.tsx
+++ b/src/components/MixedCurrencyDisclosure.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import MixedCurrencyDisclosure from './MixedCurrencyDisclosure';
+import { __setAppContextValue, __resetAppContextValue } from '../test/mocks/AppContextSupabase';
+import type { Account } from '../types';
+
+/**
+ * Phase 0 of the currency programme (the disclosure ruling, 22 Aug §2):
+ * a still-native total says it mixes currencies — and says NOTHING to the
+ * single-currency majority, per the data-health rule.
+ *
+ * Every figure here is invented; the repo is public.
+ */
+
+const closedAccounts: Account[] = [];
+vi.mock('@data', () => ({
+  dataPort: {
+    listClosedAccounts: vi.fn(async () => closedAccounts),
+  },
+}));
+
+// The display currency alone — this component reads nothing else from it.
+vi.mock('../hooks/useCurrencyDecimal', () => ({
+  useCurrencyDecimal: () => ({ displayCurrency: 'GBP' }),
+}));
+
+const account = (id: string, currency: string): Account =>
+  ({ id, name: id, type: 'current', balance: 100, currency, isActive: true } as unknown as Account);
+
+afterEach(() => {
+  __resetAppContextValue();
+  closedAccounts.length = 0;
+});
+
+describe('MixedCurrencyDisclosure', () => {
+  it('says the totals mix currencies when a foreign account exists', async () => {
+    __setAppContextValue({ accounts: [account('gbp', 'GBP'), account('usd', 'USD')] });
+    render(<MixedCurrencyDisclosure />);
+    expect(await screen.findByTestId('mixed-currency-disclosure')).toHaveTextContent(
+      /mix currencies.*not converted/
+    );
+  });
+
+  it('says nothing to a single-currency ledger', () => {
+    __setAppContextValue({ accounts: [account('gbp', 'GBP')] });
+    const { container } = render(<MixedCurrencyDisclosure />);
+    expect(container.querySelector('[data-testid="mixed-currency-disclosure"]')).toBeNull();
+  });
+
+  it('counts CLOSED foreign accounts — history lives there', async () => {
+    __setAppContextValue({ accounts: [account('gbp', 'GBP')] });
+    closedAccounts.push(account('old-usd', 'USD'));
+    render(<MixedCurrencyDisclosure />);
+    await waitFor(() =>
+      expect(screen.getByTestId('mixed-currency-disclosure')).toBeInTheDocument()
+    );
+  });
+});

--- a/src/components/MixedCurrencyDisclosure.tsx
+++ b/src/components/MixedCurrencyDisclosure.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useApp } from '../contexts/AppContextSupabase';
+import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
+import { dataPort } from '@data';
+import type { Account } from '../types';
+
+/**
+ * PHASE 0 of the currency programme (the disclosure ruling, 22 Aug §2):
+ * a surface whose totals still sum native units says so, until its
+ * conversion phase arrives.
+ *
+ * The ruling's four-state table — convert-and-mark, exclude-and-say,
+ * sum-native-AND-SAY, sum-native-silently — has exactly one unacceptable
+ * row, and it is the one every P2–P5 surface was in. This line moves a
+ * surface to the third row for the cost of a sentence: "quietly wrong"
+ * becomes "honestly limited", and each later phase upgrades a stated
+ * limitation into a conversion instead of breaking a silence.
+ *
+ * Renders NOTHING for a single-currency ledger (the data-health rule: the
+ * overwhelmingly common case has no limitation to state). The check spans
+ * CLOSED accounts, because the totals this qualifies span their history.
+ * One line per page, under the page's primary total — when a surface
+ * converts, its mount of this line is deleted in the same commit.
+ */
+
+/**
+ * Whether ANY account — open or closed — is held in something other than
+ * the display currency. Closed included for the measured reason the name
+ * and currency lookups include them: history lives there.
+ */
+export function useLedgerSpansCurrencies(): boolean {
+  const { accounts } = useApp();
+  const { displayCurrency } = useCurrencyDecimal();
+  const [closed, setClosed] = useState<Account[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    dataPort.listClosedAccounts()
+      .then(list => { if (!cancelled) setClosed(list); })
+      .catch(() => { /* the open accounts still answer; nothing breaks */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  return useMemo(
+    () =>
+      accounts.some(a => (a.currency || displayCurrency) !== displayCurrency) ||
+      closed.some(a => (a.currency || displayCurrency) !== displayCurrency),
+    [accounts, closed, displayCurrency]
+  );
+}
+
+export default function MixedCurrencyDisclosure({
+  className = '',
+}: {
+  className?: string;
+}): React.JSX.Element | null {
+  const spans = useLedgerSpansCurrencies();
+  const { displayCurrency } = useCurrencyDecimal();
+
+  if (!spans) return null;
+
+  return (
+    <p
+      className={`text-dense text-gray-500 dark:text-gray-400 ${className}`.trim()}
+      data-testid="mixed-currency-disclosure"
+    >
+      Totals here mix currencies: amounts in another currency are counted
+      unit-for-unit, not converted into {displayCurrency}.
+    </p>
+  );
+}

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -20,6 +20,7 @@ import { useApp } from '../../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import { useConvertedNetWorth, type AccountBalanceEntry } from '../../hooks/useConvertedNetWorth';
 import { useNetWorthConversion } from '../../hooks/useNetWorthConversion';
+import MixedCurrencyDisclosure from '../MixedCurrencyDisclosure';
 import { preserveDemoParam } from '../../utils/navigation';
 import EmptyState from '../EmptyState';
 import FilteredEmptyState from '../FilteredEmptyState';
@@ -791,6 +792,10 @@ export function ImprovedDashboard() {
           />
         </div>
 
+        {/* Phase 0 (the disclosure ruling, 22 Aug §2): the two figures below
+            still sum native units — said until their conversion phase.
+            Nothing for a single-currency ledger. */}
+        <MixedCurrencyDisclosure className="mb-3" />
         {/* ─ NO TINTED GROUND (Claude Design §2, and §2.5 before it) ────────
             These were `bg-green-50` and `bg-red-50` side by side. The figures
             are already green and red; the tint said the same thing a second

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -5,6 +5,7 @@ import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { preserveDemoParam } from '../utils/navigation';
 import { ChevronLeftIcon, ChevronRightIcon } from '../components/icons';
 import PageWrapper from '../components/PageWrapper';
+import MixedCurrencyDisclosure from '../components/MixedCurrencyDisclosure';
 import PageTip from '../components/PageTip';
 import { toDecimal } from '../utils/decimal';
 import { getDateLocale } from '../utils/dateFormatter';
@@ -563,6 +564,10 @@ function CalendarView() {
 
   return (
     <PageWrapper title="Calendar">
+      {/* Phase 0 (the disclosure ruling, 22 Aug §2): the month figures and
+          the running balance still sum native units — said until their
+          conversion phase. Nothing for a single-currency ledger. */}
+      <MixedCurrencyDisclosure className="mb-3" />
       {/* Month summary bar — each figure tile is a DRILL into what made it
           up, the same popup the day cells open (owner, 19 Aug: "the
           'Income' / 'Expenditure' / 'Net' should be clickable"). */}

--- a/src/pages/FinancialSummaries.tsx
+++ b/src/pages/FinancialSummaries.tsx
@@ -3,6 +3,7 @@ import { useApp } from '../contexts/AppContextSupabase';
 import { expandSplitTransactions } from '../utils/transactionSplits';
 import { financialSummaryService } from '../services/financialSummaryService';
 import PageWrapper from '../components/PageWrapper';
+import MixedCurrencyDisclosure from '../components/MixedCurrencyDisclosure';
 import FinancialSummary from '../components/FinancialSummary';
 import { CalendarIcon, BarChart3Icon, TrendingUpIcon } from '../components/icons';
 import { format } from 'date-fns';
@@ -61,6 +62,10 @@ export default function FinancialSummaries() {
       }
     >
       <div className="space-y-6">
+        {/* Phase 0 (the disclosure ruling, 22 Aug §2): the summaries below
+            still sum native units — said until their conversion phase.
+            Nothing for a single-currency ledger. */}
+        <MixedCurrencyDisclosure />
         {/* Tab Navigation */}
         <div className="flex gap-2 bg-gray-100 dark:bg-gray-800 p-1 rounded-lg">
           <button

--- a/src/pages/Forecast.tsx
+++ b/src/pages/Forecast.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import PageWrapper from '../components/PageWrapper';
+import MixedCurrencyDisclosure from '../components/MixedCurrencyDisclosure';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { toDecimal } from '../utils/decimal';
@@ -682,6 +683,10 @@ function ForecastStatement(): React.JSX.Element {
        also went — what that side shows is history, so it says Actuals. */
     <PageWrapper title="Plan">
       <div className="max-w-[1400px] mx-auto space-y-6">
+        {/* Phase 0 (the disclosure ruling, 22 Aug §2): the P&L's category and
+            bucket totals still sum native units — said until their conversion
+            phase. Nothing for a single-currency ledger. */}
+        <MixedCurrencyDisclosure />
         <div className="flex flex-wrap items-center justify-between gap-3">
           {/* The tab, chosen the way the calendar chooses its view — a
               segmented control (owner, 19 Aug: "Lets have two tabs for now",

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -31,6 +31,7 @@ import ToggleSwitch from '../components/ui/ToggleSwitch';
 import { buildPortfolioSummary, buildPortfolioHistory } from '../utils/portfolioSummary';
 import { useNetWorthConversion } from '../hooks/useNetWorthConversion';
 import HistoricRatesRestatementNotice from '../components/HistoricRatesRestatementNotice';
+import MixedCurrencyDisclosure from '../components/MixedCurrencyDisclosure';
 import { useHistoricalAccounts } from '../hooks/useHistoricalAccounts';
 import { formatCurrencyCompact } from '../utils/currency-decimal';
 import { computePortfolioPerformance, scopeValueAt, scopeOpeningFlows } from '../utils/portfolioPerformance';
@@ -930,6 +931,12 @@ function InvestmentsView() {
       <div className="flex justify-end mb-2">
         <WholePoundsToggle />
       </div>
+      {/* Phase 0 (the disclosure ruling, 22 Aug §2): the portfolio value,
+          allocation and return figures still sum native units — said until
+          the Investments chain's conversion phase. The performance CHART
+          already converts (per-day reference rates); these totals do not
+          yet. Nothing for a single-currency ledger. */}
+      <MixedCurrencyDisclosure className="mb-3" />
       {/* Navigation Tabs */}
       <div className="flex space-x-1 bg-gray-100 dark:bg-gray-700 p-1 rounded-lg mb-6">
         <button

--- a/src/pages/RecurringPayments.tsx
+++ b/src/pages/RecurringPayments.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PageWrapper from '../components/PageWrapper';
 import RecurringCommitmentsReport from './reports/RecurringCommitmentsReport';
+import MixedCurrencyDisclosure from '../components/MixedCurrencyDisclosure';
 
 /**
  * Plan → Recurring Payments (owner's ruling, 18 Aug: the MENU says what the
@@ -16,6 +17,10 @@ import RecurringCommitmentsReport from './reports/RecurringCommitmentsReport';
 export default function RecurringPayments(): React.JSX.Element {
   return (
     <PageWrapper title="What I'm committed to">
+      {/* Phase 0 (the disclosure ruling, 22 Aug §2): the annual totals below
+          still sum each commitment in its account's own units — said here
+          until their conversion phase. Nothing for a single-currency ledger. */}
+      <MixedCurrencyDisclosure className="mb-4" />
       <RecurringCommitmentsReport />
     </PageWrapper>
   );

--- a/src/pages/ReportsHub.tsx
+++ b/src/pages/ReportsHub.tsx
@@ -10,6 +10,7 @@ import { preserveDemoParam } from '../utils/navigation';
 import { readProvenance, returnState } from '../utils/navigationProvenance';
 import { hasReportArrival, readReportArrival, stripReportArrival } from '../utils/reportDrillLink';
 import ReportGallery from './reports/ReportGallery';
+import MixedCurrencyDisclosure from '../components/MixedCurrencyDisclosure';
 import { findReport } from './reports/reportRegistry';
 
 /** The window a report gets when it states no preference of its own. */
@@ -152,6 +153,11 @@ export default function ReportsHub(): React.JSX.Element {
 
         {ReportView ? (
           <Suspense fallback={<SkeletonCard className="h-96" />}>
+            {/* Phase 0 (the disclosure ruling, 22 Aug §2): a report whose
+                totals still sum native units says so, ONCE, above the
+                figures — until its conversion phase flips `converts` in the
+                registry. Renders nothing for a single-currency ledger. */}
+            {!report?.converts && <MixedCurrencyDisclosure />}
             <ReportView picker={picker} focus={focus} />
           </Suspense>
         ) : (

--- a/src/pages/__tests__/Forecast.test.tsx
+++ b/src/pages/__tests__/Forecast.test.tsx
@@ -12,6 +12,8 @@ import type { Account, Category, ForecastAdjustment, SuggestionDismissal, Transa
 // `dataPort` — for now only to COUNT it on the Forecast tab.
 const seam = vi.hoisted(() => ({
   listForecastAdjustments: vi.fn(async (): Promise<ForecastAdjustment[]> => []),
+  // The Phase 0 mixed-currency disclosure asks for closed accounts too.
+  listClosedAccounts: vi.fn(async () => []),
 }));
 vi.mock('@data', () => ({ dataPort: seam }));
 

--- a/src/pages/reports/reportRegistry.ts
+++ b/src/pages/reports/reportRegistry.ts
@@ -88,6 +88,14 @@ export interface ReportDefinition {
    * just stands down from drawing a second copy above it.
    */
   ownsPeriodBar?: boolean;
+  /**
+   * True once this report CONVERTS foreign currencies into the display one
+   * (with ≈ and its own basis line). Until then the hub mounts the Phase 0
+   * mixed-currency disclosure above it (the disclosure ruling, 22 Aug §2) —
+   * a still-native total says so rather than presenting mixed units as one
+   * figure. Flipping this flag is part of the commit that converts a report.
+   */
+  converts?: boolean;
   component: LazyExoticComponent<ComponentType<ReportViewProps>>;
 }
 
@@ -109,6 +117,8 @@ export const REPORTS: ReportDefinition[] = [
     icon: TrendingUpIcon,
     usesPeriod: true,
     ownsPeriodBar: true,
+    // Converts at each day's ECB reference rate, with its own basis line.
+    converts: true,
     // The whole history is the point of this one — a month of net worth is a
     // dot, and even a year says little about the direction of travel.
     defaultPeriod: 'all',

--- a/src/utils/pdfExport.ts
+++ b/src/utils/pdfExport.ts
@@ -472,7 +472,20 @@ export async function generateDataExportPDF(data: DataExportPdfData): Promise<vo
     pdf.setFontSize(10);
     pdf.setTextColor(BLACK[0], BLACK[1], BLACK[2]);
     pdf.text(`Total of ${data.accounts.length} accounts: ${writer.money(total.toNumber())}`, margin, writer.y);
-    writer.y += 12;
+    writer.y += 6;
+    // Phase 0 (the disclosure ruling, 22 Aug §2): the Currency column above
+    // proves the rows can differ, and this total sums them unit-for-unit. A
+    // printed artefact outlives the app's caveats, so the artefact itself
+    // says so — until the exports' conversion phase.
+    if (data.accounts.some(a => (a.currency || data.currency) !== data.currency)) {
+      pdf.setFontSize(8);
+      pdf.text(
+        `This total mixes currencies: amounts in another currency are counted unit-for-unit, not converted into ${data.currency}.`,
+        margin,
+        writer.y
+      );
+    }
+    writer.y += 8;
   }
 
   if (data.transactions) {


### PR DESCRIPTION
The disclosure ruling's §2 (22 Aug): the four-state table for a total spanning currencies has one unacceptable row — *sum native, silently* — and every P2–P5 surface was in it. This batch moves them all to the stated row for the cost of a sentence, ahead of their conversion phases, so each later phase upgrades a stated limitation instead of breaking a silence.

## One component, one hook

`MixedCurrencyDisclosure` + `useLedgerSpansCurrencies` (closed accounts included — the totals it qualifies span their history). Renders **nothing** for the single-currency majority, per the data-health rule.

## The gallery, registry-driven

The hub mounts the line above every report whose registry entry lacks `converts` — **one mount covers nine reports**, and flipping the flag becomes part of the commit that converts a report. `net-worth-over-time` carries the flag today (it converts at per-day ECB rates with its own basis line, #386).

## The standalone surfaces

The Plan P&L, the Calendar's month figures and running balance, What I'm committed to, Financial Summaries, the Investments totals (whose chart already converts — the line says the *totals* do not yet), and the dashboard's income-and-expenses card.

## The artefacts say it themselves

The PDF's accounts total — printed beside the Currency column that proves the rows differ — and the Excel overview sheet carry the sentence *in the file*, because an export outlives the app's caveats. Both only when the ledger actually mixes.

Verified live: present on a native report and the Calendar, absent on the converted net-worth report, standard secondary text on both grounds. Three specs pin presence, single-currency silence, and the closed-account reach.

Design asked for captures of two surfaces in both modes when this lands — they'll be on production after merge for the owner to relay.

Every figure in the tests is invented; the repo is public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)