### PR TITLE
The flows seam — every spending report converts at each transaction's own day's rate

### DIFF
--- a/src/components/HistoricRatesRestatementNotice.tsx
+++ b/src/components/HistoricRatesRestatementNotice.tsx
@@ -21,13 +21,23 @@ const DISMISSAL_KEY = 'money_management_fx_history_restatement_dismissed';
 
 export default function HistoricRatesRestatementNotice({
   visible,
+  storageKey = DISMISSAL_KEY,
+  children,
 }: {
   /** The surface's own gate: spans currencies AND the history is in force. */
   visible: boolean;
+  /**
+   * A restatement is an EVENT, and each event says itself once: the balances'
+   * restatement and the report flows' restatement are different changes a
+   * reader met at different times, so each carries its own dismissal key.
+   */
+  storageKey?: string;
+  /** The statement itself; the default is the balances' wording. */
+  children?: React.ReactNode;
 }): React.JSX.Element | null {
   const [dismissed, setDismissed] = useState<boolean>(() => {
     try {
-      return preferences.getItem(DISMISSAL_KEY) === 'true';
+      return preferences.getItem(storageKey) === 'true';
     } catch {
       return false;
     }
@@ -38,19 +48,23 @@ export default function HistoricRatesRestatementNotice({
   return (
     <div className="mb-6 flex items-start gap-3 rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-5 py-4">
       <div className="flex-1 text-sm text-gray-700 dark:text-gray-300">
-        <span className="font-semibold text-gray-900 dark:text-white">
-          Historic figures have been recalculated.
-        </span>{' '}
-        Balances in other currencies are now converted at the reference rate for each
-        date, rather than today&rsquo;s rate, so figures may differ from what you saw
-        previously. Your recorded transactions are unchanged.
+        {children ?? (
+          <>
+            <span className="font-semibold text-gray-900 dark:text-white">
+              Historic figures have been recalculated.
+            </span>{' '}
+            Balances in other currencies are now converted at the reference rate for each
+            date, rather than today&rsquo;s rate, so figures may differ from what you saw
+            previously. Your recorded transactions are unchanged.
+          </>
+        )}
       </div>
       <button
         type="button"
         onClick={() => {
           setDismissed(true);
           try {
-            preferences.setItem(DISMISSAL_KEY, 'true');
+            preferences.setItem(storageKey, 'true');
           } catch {
             // The notice still leaves this render; it may reappear next
             // session, which errs on the side of saying it again.

--- a/src/components/MixedCurrencyDisclosure.tsx
+++ b/src/components/MixedCurrencyDisclosure.tsx
@@ -1,8 +1,6 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { useApp } from '../contexts/AppContextSupabase';
+import React from 'react';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
-import { dataPort } from '@data';
-import type { Account } from '../types';
+import { useLedgerSpansCurrencies } from '../hooks/useLedgerSpansCurrencies';
 
 /**
  * PHASE 0 of the currency programme (the disclosure ruling, 22 Aug §2):
@@ -22,32 +20,6 @@ import type { Account } from '../types';
  * One line per page, under the page's primary total — when a surface
  * converts, its mount of this line is deleted in the same commit.
  */
-
-/**
- * Whether ANY account — open or closed — is held in something other than
- * the display currency. Closed included for the measured reason the name
- * and currency lookups include them: history lives there.
- */
-export function useLedgerSpansCurrencies(): boolean {
-  const { accounts } = useApp();
-  const { displayCurrency } = useCurrencyDecimal();
-  const [closed, setClosed] = useState<Account[]>([]);
-
-  useEffect(() => {
-    let cancelled = false;
-    dataPort.listClosedAccounts()
-      .then(list => { if (!cancelled) setClosed(list); })
-      .catch(() => { /* the open accounts still answer; nothing breaks */ });
-    return () => { cancelled = true; };
-  }, []);
-
-  return useMemo(
-    () =>
-      accounts.some(a => (a.currency || displayCurrency) !== displayCurrency) ||
-      closed.some(a => (a.currency || displayCurrency) !== displayCurrency),
-    [accounts, closed, displayCurrency]
-  );
-}
 
 export default function MixedCurrencyDisclosure({
   className = '',

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -20,6 +20,7 @@ import { useApp } from '../../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import { useConvertedNetWorth, type AccountBalanceEntry } from '../../hooks/useConvertedNetWorth';
 import { useNetWorthConversion } from '../../hooks/useNetWorthConversion';
+import { useFlowConvert } from '../../hooks/useFlowConvert';
 import MixedCurrencyDisclosure from '../MixedCurrencyDisclosure';
 import { preserveDemoParam } from '../../utils/navigation';
 import EmptyState from '../EmptyState';
@@ -298,6 +299,7 @@ export function ImprovedDashboard() {
   // the trio's conversion, so the drill cannot quote a different rate than
   // the card it opens from. Null on a single-currency ledger.
   const { conversion: rowConversion } = useNetWorthConversion(accounts);
+  const flowConvert = useFlowConvert(accounts);
 
   // Calculate key metrics — all money sums use Decimal arithmetic (float math
   // is banned on currency values; IEEE-754 drifts on long sums).
@@ -387,17 +389,21 @@ export function ImprovedDashboard() {
   // these same totals, so both always describe one and the same window.
   const performance = useMemo(() => {
     const { from, to } = performancePeriod.range;
+    // The flows seam (ruling C): the same per-date resolver the reports use,
+    // so this card and the report it opens cannot sum on different bases.
     const flows = computeIncomeExpense(transactions, transactionSplits, categories, {
       from: from ?? undefined,
       to: to ?? undefined,
+      convert: flowConvert,
     });
     return {
       income: flows.income.toNumber(),
       expenses: flows.expenses.toNumber(),
       incomeRows: flows.incomeRows,
       expenseRows: flows.expenseRows,
+      holdsForeign: flows.holdsForeign,
     };
-  }, [transactions, transactionSplits, categories, performancePeriod.range]);
+  }, [transactions, transactionSplits, categories, performancePeriod.range, flowConvert]);
 
   // Generate net worth data for chart - ONLY REAL DATA
   const netWorthData = useMemo(() => {

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -28,6 +28,7 @@ import { WIDGET_CHART_HEIGHT } from './widgetChrome';
 import { useReportDrill } from './useReportDrill';
 import { useHistoricalAccounts } from '../../../hooks/useHistoricalAccounts';
 import { useNetWorthConversion } from '../../../hooks/useNetWorthConversion';
+import { useFlowConvert } from '../../../hooks/useFlowConvert';
 
 /**
  * Compact, live versions of the Reports-hub reports for the Dashboard's
@@ -207,9 +208,12 @@ export function IncomeExpenseTrendWidget({ picker, pin }: {
   picker: UsePeriodResult;
   pin?: CardPeriodPin;
 }): React.JSX.Element {
-  const { transactions, transactionSplits, categories } = useApp();
+  const { transactions, transactionSplits, categories, accounts } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   const openReport = useReportDrill();
+  // The flows seam (ruling C): the same per-date resolver the report this
+  // card opens uses, so the two cannot sum on different bases.
+  const convert = useFlowConvert(accounts);
   // Recharts' default tooltip is black-on-white whatever the page's mode —
   // the themed style is the difference between a label and a glare in dark.
   const chartTooltipStyle = useChartTooltipStyle();
@@ -222,8 +226,8 @@ export function IncomeExpenseTrendWidget({ picker, pin }: {
       if (range.to && time > range.to.getTime()) return false;
       return true;
     });
-    return buildMonthlyTrend(rows, categories);
-  }, [transactions, transactionSplits, categories, range]);
+    return buildMonthlyTrend(rows, categories, convert);
+  }, [transactions, transactionSplits, categories, range, convert]);
 
   const open = (focus?: string): void =>
     openReport('income-and-spending-over-time', { period: picker, focus });
@@ -292,9 +296,12 @@ export function ExpenseCategoriesWidget({ picker, pin }: {
   picker: UsePeriodResult;
   pin?: CardPeriodPin;
 }): React.JSX.Element {
-  const { transactions, transactionSplits, categories } = useApp();
+  const { transactions, transactionSplits, categories, accounts } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   const openReport = useReportDrill();
+  // The flows seam (ruling C): the same per-date resolver the report this
+  // card opens uses, so the two cannot sum on different bases.
+  const convert = useFlowConvert(accounts);
   // Recharts' default tooltip is black-on-white whatever the page's mode —
   // the themed style is the difference between a label and a glare in dark.
   const chartTooltipStyle = useChartTooltipStyle();
@@ -313,7 +320,7 @@ export function ExpenseCategoriesWidget({ picker, pin }: {
     // FIVE, from the palette, not six. Six slices against a five-colour ramp
     // meant the sixth was painted like the first — reported by the owner as
     // "the pie is split into 5 sections and the legend lists 6".
-    const top = computeExpenseCategoryNetTotals(rows, categories).slice(0, MAX_CATEGORICAL_SERIES);
+    const top = computeExpenseCategoryNetTotals(rows, categories, convert).slice(0, MAX_CATEGORICAL_SERIES);
     /*
      * The share is of THE SLICES SHOWN, not of all spending — the ring is the
      * top six and the percentages have to add up to the ring the reader is
@@ -327,7 +334,7 @@ export function ExpenseCategoriesWidget({ picker, pin }: {
       value,
       share: shown > 0 ? (value / shown) * 100 : 0,
     }));
-  }, [transactions, transactionSplits, categories, range]);
+  }, [transactions, transactionSplits, categories, range, convert]);
 
   const open = (focus?: string): void =>
     openReport('spending-by-category', { period: picker, focus });

--- a/src/components/reports/IncomeExpenseSummaryCards.tsx
+++ b/src/components/reports/IncomeExpenseSummaryCards.tsx
@@ -38,6 +38,11 @@ export default function IncomeExpenseSummaryCards({
   const { formatCurrency } = useCurrencyDecimal();
   const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
 
+  // The seam's own flag: ≈ only when a conversion is actually inside the
+  // figures (the ruling §6.3 — a converted figure is a valuation, and the
+  // marker says which kind of number the reader is holding).
+  const approx = flows.holdsForeign ? '\u2248 ' : '';
+
   const summary = useMemo(() => {
     const net = flows.income.minus(flows.expenses);
     const savingsRate = flows.income.greaterThan(0)
@@ -75,7 +80,7 @@ export default function IncomeExpenseSummaryCards({
           {/* div, not p: the loading skeleton renders block elements and a
               <div> inside <p> is invalid DOM nesting */}
           <div className="text-2xl font-bold text-green-700 dark:text-green-400">
-            {isLoading ? <SkeletonText className="w-32 h-8" /> : formatCurrency(summary.income)}
+            {isLoading ? <SkeletonText className="w-32 h-8" /> : `${approx}${formatCurrency(summary.income)}`}
           </div>
         </button>
 
@@ -91,7 +96,7 @@ export default function IncomeExpenseSummaryCards({
         >
           <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Total Expenses</p>
           <div className="text-2xl font-bold text-red-600 dark:text-red-400">
-            {isLoading ? <SkeletonText className="w-32 h-8" /> : formatCurrency(summary.expenses)}
+            {isLoading ? <SkeletonText className="w-32 h-8" /> : `${approx}${formatCurrency(summary.expenses)}`}
           </div>
         </button>
 
@@ -100,7 +105,7 @@ export default function IncomeExpenseSummaryCards({
           <div className={`text-2xl font-bold ${
             summary.net >= 0 ? 'text-green-700 dark:text-green-400' : 'text-red-600 dark:text-red-400'
           }`}>
-            {isLoading ? <SkeletonText className="w-32 h-8" /> : formatCurrency(summary.net)}
+            {isLoading ? <SkeletonText className="w-32 h-8" /> : `${approx}${formatCurrency(summary.net)}`}
           </div>
         </div>
 

--- a/src/components/reports/ReportCurrencyNote.test.tsx
+++ b/src/components/reports/ReportCurrencyNote.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ReportCurrencyNote from './ReportCurrencyNote';
+import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import { __resetHistoricalRatesForTests } from '../../services/historicalRatesService';
+import { preferences } from '../../services/preferencesService';
+import type { Account, Transaction } from '../../types';
+
+/**
+ * The flows reports' one currency line (the disclosure ruling, 22 Aug §6.2
+ * and §7 phase 1): the basis when the ECB history is in force, the Phase 0
+ * disclosure while degraded, nothing for a single-currency ledger.
+ *
+ * Every figure here is invented; the repo is public.
+ */
+
+vi.mock('@data', () => ({
+  dataPort: {
+    listClosedAccounts: vi.fn(async () => []),
+  },
+}));
+
+vi.mock('../../hooks/useCurrencyDecimal', () => ({
+  useCurrencyDecimal: () => ({ displayCurrency: 'GBP' }),
+}));
+
+const account = (id: string, currency: string): Account =>
+  ({ id, name: id, type: 'current', balance: 100, currency, isActive: true } as unknown as Account);
+const txn = (id: string, date: Date): Transaction =>
+  ({ id, accountId: 'usd', amount: 10, date, description: id, type: 'income', category: '' } as unknown as Transaction);
+
+const historyResponds = (): void => {
+  vi.stubGlobal('fetch', vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ rates: { '2026-08-21': { USD: 1.3 } } }),
+  }) as unknown as Response));
+};
+
+const providerDead = (): void => {
+  vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('offline'); }));
+};
+
+beforeEach(async () => {
+  await __resetHistoricalRatesForTests();
+  preferences.setItem('money_management_fx_flows_restatement_dismissed', '');
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  __resetAppContextValue();
+});
+
+describe('ReportCurrencyNote', () => {
+  it('states the daily basis — and the flows restatement, once — when the history is in force', async () => {
+    historyResponds();
+    __setAppContextValue({
+      accounts: [account('gbp', 'GBP'), account('usd', 'USD')],
+      transactions: [txn('t1', new Date(2026, 7, 20))],
+    });
+    render(<ReportCurrencyNote />);
+    expect(await screen.findByTestId('report-currency-basis')).toHaveTextContent(
+      /Converted at each day.s ECB reference rate/
+    );
+    // The window never reaches 1999 — the third clause is noise and absent.
+    expect(screen.getByTestId('report-currency-basis')).not.toHaveTextContent(/1999/);
+    expect(screen.getByText(/Report figures have been recalculated/)).toBeInTheDocument();
+  });
+
+  it('falls back to the Phase 0 disclosure while the history cannot be had', async () => {
+    providerDead();
+    __setAppContextValue({
+      accounts: [account('gbp', 'GBP'), account('usd', 'USD')],
+      transactions: [],
+    });
+    render(<ReportCurrencyNote />);
+    expect(await screen.findByTestId('mixed-currency-disclosure')).toBeInTheDocument();
+    expect(screen.queryByTestId('report-currency-basis')).not.toBeInTheDocument();
+  });
+
+  it('says nothing to a single-currency ledger', () => {
+    historyResponds();
+    __setAppContextValue({ accounts: [account('gbp', 'GBP')], transactions: [] });
+    const { container } = render(<ReportCurrencyNote />);
+    expect(container.querySelector('[data-testid]')).toBeNull();
+  });
+});

--- a/src/components/reports/ReportCurrencyNote.tsx
+++ b/src/components/reports/ReportCurrencyNote.tsx
@@ -1,0 +1,61 @@
+import React, { useMemo } from 'react';
+import { useApp } from '../../contexts/AppContextSupabase';
+import { useNetWorthConversion } from '../../hooks/useNetWorthConversion';
+import { useLedgerSpansCurrencies } from '../../hooks/useLedgerSpansCurrencies';
+import MixedCurrencyDisclosure from '../MixedCurrencyDisclosure';
+import HistoricRatesRestatementNotice from '../HistoricRatesRestatementNotice';
+
+/**
+ * The rate-basis line for a report whose totals convert through the flows
+ * seam (the disclosure ruling, 22 Aug §6.2 and §7 phase 1) — mounted by the
+ * hub for every report the registry flags 'flows', so the note and the
+ * figures cannot come from different mechanisms: this reads the SAME hook
+ * the report dataset builds its factors from.
+ *
+ * Three states, the same ladder the seam itself walks:
+ * - single-currency ledger → nothing (the data-health rule);
+ * - the ECB history in force → one basis line, every qualification in it,
+ *   the pre-1999 clause only when the ledger actually reaches back that far;
+ * - degraded (no history) → the seam does not convert, so the Phase 0
+ *   mixed-currency disclosure keeps saying the totals are native. Never a
+ *   third basis nobody stated.
+ */
+export default function ReportCurrencyNote(): React.JSX.Element | null {
+  const { accounts, transactions } = useApp();
+  const spans = useLedgerSpansCurrencies();
+  const { historical } = useNetWorthConversion(accounts, { range: { from: null, to: null } });
+
+  // The third clause is real only when a transaction predates the series.
+  const reachesPreEpoch = useMemo(() => {
+    if (!historical) return false;
+    const epoch = new Date(1999, 0, 4).getTime();
+    return transactions.some(t => new Date(t.date).getTime() < epoch);
+  }, [transactions, historical]);
+
+  if (!spans) return null;
+  if (!historical) return <MixedCurrencyDisclosure />;
+
+  return (
+    <>
+      {/* Figures a reader had already seen changed when the flows converted
+          (the ruling §6.4) — said once, dismissibly, under its own key: the
+          balances' restatement was a different event, already said. */}
+      <HistoricRatesRestatementNotice
+        visible={true}
+        storageKey="money_management_fx_flows_restatement_dismissed"
+      >
+        <span className="font-semibold text-gray-900 dark:text-white">
+          Report figures have been recalculated.
+        </span>{' '}
+        Amounts in other currencies are now converted at the reference rate for each
+        transaction&rsquo;s own date, so totals may differ from what you saw
+        previously. Your recorded transactions are unchanged.
+      </HistoricRatesRestatementNotice>
+      <p className="text-dense text-gray-500 dark:text-gray-400" data-testid="report-currency-basis">
+        ≈ Converted at each day&rsquo;s ECB reference rate. Weekends and holidays carry
+        the previous business day&rsquo;s rate.
+        {reachesPreEpoch ? <> Amounts before 4 Jan 1999 use the earliest rate available.</> : null}
+      </p>
+    </>
+  );
+}

--- a/src/hooks/useFlowConvert.ts
+++ b/src/hooks/useFlowConvert.ts
@@ -1,0 +1,31 @@
+import { useMemo } from 'react';
+import type { Account } from '../types';
+import type { FlowFactorResolver } from '../utils/incomeExpense';
+import { useNetWorthConversion } from './useNetWorthConversion';
+
+/**
+ * THE FLOWS SEAM'S RESOLVER (the disclosure ruling, 22 Aug §7 phase 1):
+ * each row's factor into the display currency at the row's OWN date, from
+ * the same ECB history the net-worth series values itself against — so a
+ * 2017 dollar purchase converts at 2017's rate, never today's.
+ *
+ * ONE hook for every surface that aggregates flows — the report dataset,
+ * the dashboard's income-and-expenses card, the report widgets — which is
+ * ruling C by construction: surfaces that share the resolver cannot sum the
+ * same money on different bases.
+ *
+ * Undefined while the history is unavailable: the aggregators then stay
+ * NATIVE and the surface's mixed-currency disclosure keeps saying so. The
+ * seam converts on the real basis or not at all, never on a third one
+ * nobody stated. The whole history is fetched (one small cached request),
+ * so a row outside any particular window still resolves at its own date.
+ */
+export function useFlowConvert(accounts: readonly Account[]): FlowFactorResolver | undefined {
+  const { conversionAt, historical } = useNetWorthConversion(accounts, {
+    range: { from: null, to: null },
+  });
+  return useMemo<FlowFactorResolver | undefined>(() => {
+    if (!historical || conversionAt === null) return undefined;
+    return row => conversionAt(new Date(row.date))?.factors.get(row.accountId) ?? null;
+  }, [historical, conversionAt]);
+}

--- a/src/hooks/useLedgerSpansCurrencies.ts
+++ b/src/hooks/useLedgerSpansCurrencies.ts
@@ -1,0 +1,32 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useApp } from '../contexts/AppContextSupabase';
+import { useCurrencyDecimal } from './useCurrencyDecimal';
+import { dataPort } from '@data';
+import type { Account } from '../types';
+
+/**
+ * Whether ANY account — open or closed — is held in something other than
+ * the display currency. Closed included for the measured reason the name
+ * and currency lookups include them: history lives there.
+ */
+export function useLedgerSpansCurrencies(): boolean {
+  const { accounts } = useApp();
+  const { displayCurrency } = useCurrencyDecimal();
+  const [closed, setClosed] = useState<Account[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    dataPort.listClosedAccounts()
+      .then(list => { if (!cancelled) setClosed(list); })
+      .catch(() => { /* the open accounts still answer; nothing breaks */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  return useMemo(
+    () =>
+      accounts.some(a => (a.currency || displayCurrency) !== displayCurrency) ||
+      closed.some(a => (a.currency || displayCurrency) !== displayCurrency),
+    [accounts, closed, displayCurrency]
+  );
+}
+

--- a/src/hooks/useReportDataset.ts
+++ b/src/hooks/useReportDataset.ts
@@ -1,7 +1,8 @@
 import { useMemo } from 'react';
 import { useApp } from '../contexts/AppContextSupabase';
-import { computeIncomeExpense, type IncomeExpenseBreakdown } from '../utils/incomeExpense';
+import { computeIncomeExpense, type FlowFactorResolver, type IncomeExpenseBreakdown } from '../utils/incomeExpense';
 import { expandSplitTransactions, type SplitExpandedTransaction } from '../utils/transactionSplits';
+import { useNetWorthConversion } from './useNetWorthConversion';
 import type { UsePeriodResult } from './usePeriod';
 import type { Account, Category, Transaction, TransactionSplit } from '../types';
 
@@ -32,6 +33,19 @@ export interface ReportDataset {
   /** Period- and account-filtered, split-expanded. */
   rows: SplitExpandedTransaction[];
   flows: IncomeExpenseBreakdown;
+  /**
+   * THE FLOWS SEAM (the disclosure ruling, 22 Aug §7 phase 1): each row's
+   * factor into the display currency, at the row's OWN date, from the ECB
+   * history the net-worth series already uses — so a 2017 dollar purchase
+   * converts at 2017's rate, never today's. Undefined while the history is
+   * unavailable: the totals then stay NATIVE and the hub's mixed-currency
+   * disclosure keeps saying so — the seam converts on the real basis or not
+   * at all, never on a third one nobody stated. Pages pass this to every
+   * aggregator they run over the dataset's rows (payee, matrix, netting,
+   * trend, comparison) so no report can sum on a different basis than its
+   * own summary cards.
+   */
+  convert?: FlowFactorResolver;
 }
 
 export function useReportDataset(picker: UsePeriodResult, scope: ReportAccountScope): ReportDataset {
@@ -52,8 +66,21 @@ export function useReportDataset(picker: UsePeriodResult, scope: ReportAccountSc
     [accountTransactions, transactionSplits, inRange]
   );
 
+  // The WHOLE history is fetched (from: null → the ECB epoch, one small
+  // cached request) rather than the picker's window, because comparison
+  // reports reach for rows before the window and a factor resolved outside
+  // the fetched span would carry the wrong rate.
+  const { conversionAt, historical } = useNetWorthConversion(accounts, {
+    range: { from: null, to: picker.range.to ?? null },
+  });
+
+  const convert = useMemo<FlowFactorResolver | undefined>(() => {
+    if (!historical || conversionAt === null) return undefined;
+    return row => conversionAt(new Date(row.date))?.factors.get(row.accountId) ?? null;
+  }, [historical, conversionAt]);
+
   // Already expanded, so splits are passed empty — no double expansion.
-  const flows = useMemo(() => computeIncomeExpense(rows, [], categories), [rows, categories]);
+  const flows = useMemo(() => computeIncomeExpense(rows, [], categories, { convert }), [rows, categories, convert]);
 
   return {
     accounts,
@@ -63,5 +90,6 @@ export function useReportDataset(picker: UsePeriodResult, scope: ReportAccountSc
     transactionSplits,
     rows,
     flows,
+    convert,
   };
 }

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -35,7 +35,7 @@ const CUMULATIVE_KEY = 'reports.monthlyIncomeExpenses.cumulative.v1';
 
 export default function Reports({ picker }: ReportViewProps): React.JSX.Element {
   const selection = useReportAccountSelection();
-  const { accounts, categories, rows, flows, allTransactions } = useReportDataset(picker, selection.scope);
+  const { accounts, categories, rows, flows, allTransactions, convert } = useReportDataset(picker, selection.scope);
   const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   // Gains, losses & adjustments are net-worth movements, not day-to-day income
@@ -60,9 +60,9 @@ export default function Reports({ picker }: ReportViewProps): React.JSX.Element 
   // The Money-style category × month matrix, built from the SAME classified
   // rows as the summary cards so the two can never disagree.
   const matrix = useMemo(() => {
-    const monthly = buildMonthlyCategoryMatrix(flows.incomeRows, flows.expenseRows, categories, picker.range);
+    const monthly = buildMonthlyCategoryMatrix(flows.incomeRows, flows.expenseRows, categories, picker.range, { convert });
     return cumulative ? toCumulativeMatrix(monthly) : monthly;
-  }, [flows, categories, picker.range, cumulative]);
+  }, [flows, categories, picker.range, cumulative, convert]);
 
   const firstColumnKey = matrix.months[0]?.key ?? null;
 

--- a/src/pages/ReportsHub.tsx
+++ b/src/pages/ReportsHub.tsx
@@ -11,6 +11,7 @@ import { readProvenance, returnState } from '../utils/navigationProvenance';
 import { hasReportArrival, readReportArrival, stripReportArrival } from '../utils/reportDrillLink';
 import ReportGallery from './reports/ReportGallery';
 import MixedCurrencyDisclosure from '../components/MixedCurrencyDisclosure';
+import ReportCurrencyNote from '../components/reports/ReportCurrencyNote';
 import { findReport } from './reports/reportRegistry';
 
 /** The window a report gets when it states no preference of its own. */
@@ -153,11 +154,13 @@ export default function ReportsHub(): React.JSX.Element {
 
         {ReportView ? (
           <Suspense fallback={<SkeletonCard className="h-96" />}>
-            {/* Phase 0 (the disclosure ruling, 22 Aug §2): a report whose
-                totals still sum native units says so, ONCE, above the
-                figures — until its conversion phase flips `converts` in the
-                registry. Renders nothing for a single-currency ledger. */}
-            {!report?.converts && <MixedCurrencyDisclosure />}
+            {/* The registry's currency ladder (the disclosure ruling, 22 Aug):
+                'self' reports carry their own notes; 'flows' reports get the
+                basis line (or the Phase 0 disclosure while degraded); a
+                still-native report gets the Phase 0 disclosure. One mount,
+                every report — nothing for a single-currency ledger. */}
+            {report?.currency === 'flows' && <ReportCurrencyNote />}
+            {report?.currency === undefined && <MixedCurrencyDisclosure />}
             <ReportView picker={picker} focus={focus} />
           </Suspense>
         ) : (

--- a/src/pages/reports/IncomeSpendingOverTimeReport.tsx
+++ b/src/pages/reports/IncomeSpendingOverTimeReport.tsx
@@ -57,7 +57,7 @@ export default function IncomeSpendingOverTimeReport({ picker, focus }: ReportVi
   // row below is highlighted and scrolled into view, with both figures on it a
   // click from the transactions behind them.
   const monthFocus = useArrivalRowFocus(focus);
-  const { accounts, categories, rows, flows } = useReportDataset(picker, selection.scope);
+  const { accounts, categories, rows, flows, convert } = useReportDataset(picker, selection.scope);
   const { formatCurrency } = useCurrencyDecimal();
   // Recharts' default tooltip is black-on-white whatever the mode.
   const chartTooltipStyle = useChartTooltipStyle();
@@ -76,7 +76,7 @@ export default function IncomeSpendingOverTimeReport({ picker, focus }: ReportVi
   const cumulativeToggle = useCumulativeReport(CUMULATIVE_KEY);
   const { cumulative } = cumulativeToggle;
 
-  const trend = useMemo(() => buildMonthlyTrend(rows, categories), [rows, categories]);
+  const trend = useMemo(() => buildMonthlyTrend(rows, categories, convert), [rows, categories, convert]);
   const series = useMemo(
     () => (cumulative ? toCumulativeTrend(trend) : trend),
     [trend, cumulative]

--- a/src/pages/reports/PeriodComparisonReport.tsx
+++ b/src/pages/reports/PeriodComparisonReport.tsx
@@ -57,7 +57,7 @@ const formatWindow = (window: { from: Date; to: Date }): string => {
 
 export default function PeriodComparisonReport({ picker }: ReportViewProps): React.JSX.Element {
   const selection = useReportAccountSelection();
-  const { accounts, categories, accountTransactions, transactionSplits, rows, flows } =
+  const { accounts, categories, accountTransactions, transactionSplits, rows, flows, convert } =
     useReportDataset(picker, selection.scope);
   const { formatCurrency } = useCurrencyDecimal();
   // Recharts' default tooltip is black-on-white whatever the mode.
@@ -94,17 +94,17 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
   // BOTH windows are measured from the resolved bounds, so the two figures
   // are always like for like.
   const currentFlows = useMemo(
-    () => (ranges ? computeIncomeExpense(accountTransactions, transactionSplits, categories, ranges.current) : null),
-    [ranges, accountTransactions, transactionSplits, categories]
+    () => (ranges ? computeIncomeExpense(accountTransactions, transactionSplits, categories, { ...ranges.current, convert }) : null),
+    [ranges, accountTransactions, transactionSplits, categories, convert]
   );
   const previousFlows = useMemo(
-    () => (ranges ? computeIncomeExpense(accountTransactions, transactionSplits, categories, ranges.previous) : null),
-    [ranges, accountTransactions, transactionSplits, categories]
+    () => (ranges ? computeIncomeExpense(accountTransactions, transactionSplits, categories, { ...ranges.previous, convert }) : null),
+    [ranges, accountTransactions, transactionSplits, categories, convert]
   );
 
   const comparison = useMemo(
-    () => (currentFlows && previousFlows ? buildPeriodComparison(currentFlows, previousFlows, categories) : null),
-    [currentFlows, previousFlows, categories]
+    () => (currentFlows && previousFlows ? buildPeriodComparison(currentFlows, previousFlows, categories, convert) : null),
+    [currentFlows, previousFlows, categories, convert]
   );
 
   /**
@@ -204,6 +204,9 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
     return good ? 'text-green-700 dark:text-green-400' : 'text-red-600 dark:text-red-400';
   };
 
+  // ≈ when a conversion is inside either window's figures (ruling §6.3).
+  const approx = (currentFlows?.holdsForeign || previousFlows?.holdsForeign) ? '\u2248 ' : '';
+
   const summaryCard = (
     label: string,
     figure: ComparisonFigure,
@@ -214,7 +217,7 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
       <p className="text-xs text-gray-500 uppercase tracking-wider font-medium">{label}</p>
       {bucket === null ? (
         <p className={`text-page font-bold mt-1 ${figure.current < 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white'}`}>
-          {money(figure.current)}
+          {approx}{money(figure.current)}
         </p>
       ) : (
         <button
@@ -225,7 +228,7 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
           }`}
           title={`${label} — view these transactions`}
         >
-          {money(figure.current)}
+          {approx}{money(figure.current)}
         </button>
       )}
       <p className="text-sm mt-2">

--- a/src/pages/reports/SpendingByCategoryReport.tsx
+++ b/src/pages/reports/SpendingByCategoryReport.tsx
@@ -39,7 +39,7 @@ export default function SpendingByCategoryReport({ picker, focus }: ReportViewPr
   // category; its row in the ranked table below is highlighted and scrolled to,
   // where the share, the count and the way into its transactions all are.
   const categoryFocus = useArrivalRowFocus(focus);
-  const { accounts, categories, rows, flows } = useReportDataset(picker, selection.scope);
+  const { accounts, categories, rows, flows, convert } = useReportDataset(picker, selection.scope);
   const { formatCurrency } = useCurrencyDecimal();
   // Recharts' default tooltip is black-on-white whatever the mode.
   const chartTooltipStyle = useChartTooltipStyle();
@@ -49,8 +49,8 @@ export default function SpendingByCategoryReport({ picker, focus }: ReportViewPr
   // Shared implementation — the same totals the Dashboard widget and the PDF
   // export use, so the three can never drift.
   const totals = useMemo(
-    () => computeExpenseCategoryNetTotals(rows, categories),
-    [rows, categories]
+    () => computeExpenseCategoryNetTotals(rows, categories, convert),
+    [rows, categories, convert]
   );
 
   const counts = useMemo(() => {
@@ -114,7 +114,7 @@ export default function SpendingByCategoryReport({ picker, focus }: ReportViewPr
             Where the money went
           </h2>
           <span className="text-card font-bold tabular-nums text-red-600 dark:text-red-400">
-            {formatCurrency(flows.expenses)}
+            {flows.holdsForeign ? '\u2248 ' : ''}{formatCurrency(flows.expenses)}
           </span>
         </div>
         <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">

--- a/src/pages/reports/SpendingByPayeeReport.tsx
+++ b/src/pages/reports/SpendingByPayeeReport.tsx
@@ -38,7 +38,7 @@ export default function SpendingByPayeeReport({ picker }: ReportViewProps): Reac
   // pie slice.
   const ramp = useCategoricalRamp();
   const selection = useReportAccountSelection();
-  const { accounts, categories, rows, flows } = useReportDataset(picker, selection.scope);
+  const { accounts, categories, rows, flows, convert } = useReportDataset(picker, selection.scope);
   const { formatCurrency } = useCurrencyDecimal();
   // Recharts' default tooltip is black-on-white whatever the mode.
   const chartTooltipStyle = useChartTooltipStyle();
@@ -54,8 +54,8 @@ export default function SpendingByPayeeReport({ picker }: ReportViewProps): Reac
 
   const sideRows = side === 'income' ? flows.incomeRows : flows.expenseRows;
   const totals = useMemo(
-    () => buildPayeeTotals(sideRows, side, categories),
-    [sideRows, side, categories]
+    () => buildPayeeTotals(sideRows, side, categories, convert),
+    [sideRows, side, categories, convert]
   );
 
   // The datum fields are `payee`/`name`, never `key`: recharts spreads datum
@@ -132,7 +132,7 @@ export default function SpendingByPayeeReport({ picker }: ReportViewProps): Reac
           <span className={`text-card font-bold tabular-nums ${
             side === 'income' ? 'text-green-700 dark:text-green-400' : 'text-red-600 dark:text-red-400'
           }`}>
-            {money(totals.total)}
+            {flows.holdsForeign ? '\u2248 ' : ''}{money(totals.total)}
           </span>
         </div>
         <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">

--- a/src/pages/reports/reportRegistry.ts
+++ b/src/pages/reports/reportRegistry.ts
@@ -89,13 +89,21 @@ export interface ReportDefinition {
    */
   ownsPeriodBar?: boolean;
   /**
-   * True once this report CONVERTS foreign currencies into the display one
-   * (with ≈ and its own basis line). Until then the hub mounts the Phase 0
-   * mixed-currency disclosure above it (the disclosure ruling, 22 Aug §2) —
-   * a still-native total says so rather than presenting mixed units as one
-   * figure. Flipping this flag is part of the commit that converts a report.
+   * How this report handles a ledger that spans currencies (the disclosure
+   * ruling, 22 Aug §2, and the flows seam, §7 phase 1):
+   *
+   * - 'self'  — the report converts AND renders its own basis/provenance
+   *             notes (the net-worth series). The hub mounts nothing.
+   * - 'flows' — the report's totals convert through the shared flows seam
+   *             (per-transaction-date ECB factors from useReportDataset).
+   *             The hub mounts ReportCurrencyNote, which states the basis
+   *             when the history is in force and falls back to the Phase 0
+   *             mixed-currency disclosure while degraded.
+   * - absent  — still native. The hub mounts the Phase 0 disclosure.
+   *
+   * Moving a report up this ladder is part of the commit that converts it.
    */
-  converts?: boolean;
+  currency?: 'self' | 'flows';
   component: LazyExoticComponent<ComponentType<ReportViewProps>>;
 }
 
@@ -118,7 +126,7 @@ export const REPORTS: ReportDefinition[] = [
     usesPeriod: true,
     ownsPeriodBar: true,
     // Converts at each day's ECB reference rate, with its own basis line.
-    converts: true,
+    currency: 'self',
     // The whole history is the point of this one — a month of net worth is a
     // dot, and even a year says little about the direction of travel.
     defaultPeriod: 'all',
@@ -152,6 +160,8 @@ export const REPORTS: ReportDefinition[] = [
     group: 'spending',
     icon: CalendarIcon,
     usesPeriod: true,
+    // Totals convert through the shared flows seam (per-date ECB factors).
+    currency: 'flows',
     component: lazyWithRecovery(() => import('../Reports')),
   },
   {
@@ -161,6 +171,8 @@ export const REPORTS: ReportDefinition[] = [
     group: 'spending',
     icon: PieChartIcon,
     usesPeriod: true,
+    // Totals convert through the shared flows seam (per-date ECB factors).
+    currency: 'flows',
     component: lazyWithRecovery(() => import('./SpendingByCategoryReport')),
   },
   {
@@ -173,6 +185,8 @@ export const REPORTS: ReportDefinition[] = [
     // Month-by-month bars need enough months to compare, and a year covers the
     // seasonal swings (Christmas, holidays, annual bills) exactly once.
     defaultPeriod: 'last-12-months',
+    // Totals convert through the shared flows seam (per-date ECB factors).
+    currency: 'flows',
     component: lazyWithRecovery(() => import('./IncomeSpendingOverTimeReport')),
   },
   {
@@ -182,6 +196,8 @@ export const REPORTS: ReportDefinition[] = [
     group: 'spending',
     icon: UsersIcon,
     usesPeriod: true,
+    // Totals convert through the shared flows seam (per-date ECB factors).
+    currency: 'flows',
     component: lazyWithRecovery(() => import('./SpendingByPayeeReport')),
   },
   /*
@@ -203,6 +219,8 @@ export const REPORTS: ReportDefinition[] = [
     group: 'spending',
     icon: RepeatIcon,
     usesPeriod: true,
+    // Totals convert through the shared flows seam (per-date ECB factors).
+    currency: 'flows',
     component: lazyWithRecovery(() => import('./PeriodComparisonReport')),
   },
   {

--- a/src/services/__tests__/notificationService.test.ts
+++ b/src/services/__tests__/notificationService.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { NotificationService, type NotificationRule } from '../notificationService';
+import type { Budget, Category, Transaction } from '../../types';
 
 const createStorage = () => {
   const data = new Map<string, string>();
@@ -119,5 +120,62 @@ describe('NotificationService (deterministic)', () => {
 
     expect(newRule.id).toBe(`rule-${fixedNow}`);
     expect(newRule.created.getTime()).toBe(fixedNow);
+  });
+});
+
+/**
+ * A silent exclusion fails like a silent conversion (the disclosure ruling,
+ * 22 Aug §4): the budget maths correctly leaves out accounts in another
+ * currency, and the alert built on it must SAY so — the Budget card's own
+ * sentence, on the alert it qualifies.
+ * Every figure here is invented; the repo is public.
+ */
+describe('budget alerts say what they leave out', () => {
+  const rule: NotificationRule = {
+    id: 'r-90',
+    name: 'Half spent',
+    type: 'budget',
+    enabled: true,
+    priority: 'high',
+    conditions: [{ field: 'percentage_spent', operator: 'greater_than', value: 50 }],
+    actions: [{
+      type: 'show_notification',
+      config: { title: 'Budget alert', message: '{categoryName} is at {percentage}%.' }
+    }]
+  };
+
+  const categories: Category[] = [
+    { id: 'cat-food', name: 'Food', type: 'expense', level: 'detail' }
+  ];
+  const budgets: Budget[] = [
+    { id: 'b1', categoryId: 'cat-food', amount: 100, period: 'monthly', isActive: true, createdAt: new Date(fixedNow) }
+  ];
+  const spend = (accountId: string, id: string): Transaction[] => ([
+    { id, accountId, amount: -80, category: 'cat-food', date: new Date(fixedNow), type: 'expense', description: 'shop' }
+  ]);
+
+  it('appends the exclusion sentence when foreign-account rows were left out', () => {
+    const { service } = createService();
+    service.addRule(rule);
+    const alerts = service.checkBudgetAlerts(budgets, spend('acc-gbp', 't-gbp'), categories, {
+      foreignAccountIds: new Set(['acc-usd']),
+      // A row on the excluded account, in the same window and category —
+      // what the total leaves out and the sentence must own up to.
+      transactionSplits: [],
+    });
+    // The GBP-only pass has nothing excluded: no caveat.
+    expect(alerts.length).toBeGreaterThan(0);
+    expect(alerts[0].message).not.toMatch(/another currency/);
+
+    const withForeign = service.checkBudgetAlerts(
+      budgets,
+      [...spend('acc-gbp', 't-gbp'), ...spend('acc-usd', 't-usd')],
+      categories,
+      { foreignAccountIds: new Set(['acc-usd']), transactionSplits: [] }
+    );
+    expect(withForeign.length).toBeGreaterThan(0);
+    expect(withForeign[0].message).toMatch(
+      /Spending on accounts in another currency is left out, so you have spent more than this\./
+    );
   });
 });

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -389,7 +389,7 @@ export class NotificationService {
       // The Budget page's calculation, not a second one: the budget's OWN
       // period window, split lines expanded, refunds netted, Decimal throughout.
       const amount = getEffectiveBudgetAmount(budget);
-      const { spent: spentDecimal } = calculateBudgetSpend(budget, prepared, {
+      const { spent: spentDecimal, excludedForeignCount } = calculateBudgetSpend(budget, prepared, {
         now,
         foreignAccountIds: context.foreignAccountIds
       });
@@ -423,6 +423,14 @@ export class NotificationService {
           });
 
           if (notification) {
+            // A silent exclusion fails like a silent conversion (the
+            // disclosure ruling, 22 Aug §4): the exclusion was already
+            // correct — the Budget card's own rule — but an alert built on
+            // it could not say so, and the reader could not audit what they
+            // weren't told. The card's sentence, on the alert it qualifies.
+            if (excludedForeignCount > 0) {
+              notification.message = `${notification.message} Spending on accounts in another currency is left out, so you have spent more than this.`;
+            }
             notifications.push(notification);
             this.updateRuleLastTriggered(rule.id, now);
           }

--- a/src/utils/__tests__/currencyAggregationCensus.test.ts
+++ b/src/utils/__tests__/currencyAggregationCensus.test.ts
@@ -42,7 +42,9 @@ type Status = 'converts' | 'excludes-and-states' | 'native-known';
 /** file (repo-relative, posix) → the statuses of the primitives it calls. */
 const LEDGER: Record<string, Partial<Record<(typeof PRIMITIVES)[number], Status>>> = {
   // ── the defining modules — a definition is not a call site ──
-  'src/utils/incomeExpense.ts': { computeIncomeExpense: 'native-known' },
+  // The flows seam lives in the primitive itself; callers pass per-date
+  // factors (useFlowConvert / useReportDataset) or honestly disclose.
+  'src/utils/incomeExpense.ts': { computeIncomeExpense: 'converts' },
   'src/utils/calculations-decimal.ts': {
     calculateTotalBalance: 'native-known',
     calculateNetWorth: 'native-known',
@@ -65,11 +67,11 @@ const LEDGER: Record<string, Partial<Record<(typeof PRIMITIVES)[number], Status>
   'src/pages/Accounts.tsx': { calculateTotalBalance: 'converts' },
 
   // ── the audit's known native sums, phase-ordered in the ruling ──
-  'src/hooks/useReportDataset.ts': { computeIncomeExpense: 'native-known' },
-  'src/components/dashboard/ImprovedDashboard.tsx': { computeIncomeExpense: 'native-known' },
+  'src/hooks/useReportDataset.ts': { computeIncomeExpense: 'converts' },
+  'src/components/dashboard/ImprovedDashboard.tsx': { computeIncomeExpense: 'converts' },
   'src/pages/Calendar.tsx': { computeIncomeExpense: 'native-known' },
   'src/pages/Categorisation.tsx': { computeIncomeExpense: 'native-known' },
-  'src/pages/reports/PeriodComparisonReport.tsx': { computeIncomeExpense: 'native-known' },
+  'src/pages/reports/PeriodComparisonReport.tsx': { computeIncomeExpense: 'converts' },
   'src/utils/categoryHealth.ts': { computeIncomeExpense: 'native-known' },
 };
 

--- a/src/utils/categoryNetting.ts
+++ b/src/utils/categoryNetting.ts
@@ -1,5 +1,5 @@
 import { toDecimal } from './decimal';
-import { categoryKindOf } from './incomeExpense';
+import { categoryKindOf, type FlowFactorResolver } from './incomeExpense';
 import type { Transaction, Category } from '../types';
 
 export interface CategoryNetTotal {
@@ -55,7 +55,9 @@ export function bucketByCategoryDirection(
 
 export function computeExpenseCategoryNetTotals(
   transactions: Transaction[],
-  categories: Category[]
+  categories: Category[],
+  /** The flows seam: per-row factor into the display currency (see incomeExpense). */
+  convert?: FlowFactorResolver
 ): CategoryNetTotal[] {
   const categoryById = new Map(categories.map(c => [c.id, c]));
   const totals = new Map<string, ReturnType<typeof toDecimal>>();
@@ -66,10 +68,12 @@ export function computeExpenseCategoryNetTotals(
     // category to have resolved to the expense tree).
     if (bucketByCategoryDirection(t, categoryById) !== 'expense') continue;
 
+    const factor = convert?.(t) ?? null;
+    const amount = factor !== null ? toDecimal(t.amount).times(factor) : toDecimal(t.amount);
     const previous = totals.get(t.category) ?? toDecimal(0);
     // Signed convention: spending is negative, so negate to accumulate spend;
     // an income-row refund (+) filed under this category nets the total down.
-    totals.set(t.category, previous.minus(toDecimal(t.amount)));
+    totals.set(t.category, previous.minus(amount));
   }
 
   const entries = [...totals.entries()]

--- a/src/utils/incomeExpense.test.ts
+++ b/src/utils/incomeExpense.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { buildCategoryKindLookup, classifyFlow, computeIncomeExpense, bucketContribution } from './incomeExpense';
 import type { Category, Transaction, TransactionSplit } from '../types';
+import { toDecimal } from './decimal';
 
 const CATEGORIES: Category[] = [
   { id: 'type-income', name: 'Income', type: 'income', level: 'type', isSystem: true },
@@ -192,5 +193,42 @@ describe('bucketContribution', () => {
     expect(bucketContribution({ amount: -100 }, 'expense')).toBe(100);
     expect(bucketContribution({ amount: 40 }, 'expense')).toBe(-40); // refund credit
     expect(bucketContribution({ amount: 2500 }, 'income')).toBe(2500);
+  });
+});
+
+/**
+ * THE FLOWS SEAM (the disclosure ruling, 22 Aug §7 phase 1): amounts convert
+ * into the display currency at the summing when the caller hands over a
+ * per-row factor; without one, every figure is exactly what it always was.
+ * Every figure here is invented; the repo is public.
+ */
+describe('computeIncomeExpense — the flows seam', () => {
+  const transactions: Transaction[] = [
+    txn({ id: 'gbp', type: 'income', amount: 1000, category: 'cat-salary', accountId: 'acc-gbp' }),
+    txn({ id: 'usd', type: 'income', amount: 200, category: 'cat-salary', accountId: 'acc-usd' }),
+    txn({ id: 'usd-spend', type: 'expense', amount: -50, category: 'cat-groceries', accountId: 'acc-usd' }),
+  ];
+  // Two dollars to the pound, whatever the date — the resolver owns policy.
+  const convert = (row: Pick<Transaction, 'accountId' | 'date'>) =>
+    row.accountId === 'acc-usd' ? toDecimal(0.5) : null;
+
+  it('applies the factor at the sum and flags that a conversion is inside', () => {
+    const flows = computeIncomeExpense(transactions, [], CATEGORIES, { convert });
+    expect(flows.income.toNumber()).toBe(1100);   // 1000 + $200×0.5
+    expect(flows.expenses.toNumber()).toBe(25);   // $50×0.5
+    expect(flows.holdsForeign).toBe(true);
+  });
+
+  it('without a resolver the totals are native and unflagged — unchanged behaviour', () => {
+    const flows = computeIncomeExpense(transactions, [], CATEGORIES);
+    expect(flows.income.toNumber()).toBe(1200);
+    expect(flows.expenses.toNumber()).toBe(50);
+    expect(flows.holdsForeign).toBe(false);
+  });
+
+  it('rows themselves stay native — a row display keeps its own currency', () => {
+    const flows = computeIncomeExpense(transactions, [], CATEGORIES, { convert });
+    const usdRow = flows.incomeRows.find(r => r.id === 'usd');
+    expect(usdRow?.amount).toBe(200);
   });
 });

--- a/src/utils/incomeExpense.ts
+++ b/src/utils/incomeExpense.ts
@@ -118,7 +118,27 @@ export interface IncomeExpenseBreakdown {
    */
   revaluation: DecimalInstance;
   revaluationRows: SplitExpandedTransaction[];
+  /**
+   * True when a conversion factor was actually applied to any row — the
+   * gate for the ≈ on totals built from this breakdown. Always false when
+   * no resolver was passed (the totals are then native, and the surface's
+   * disclosure line is what says so).
+   */
+  holdsForeign: boolean;
 }
+
+/**
+ * A row's conversion factor into the display currency — the flows seam
+ * (the disclosure ruling, 22 Aug §7 phase 1). Null means "count native":
+ * the row is already in the display currency, or no rate could be had and
+ * the CALLER is responsible for saying so. The resolver owns the rate
+ * policy (the report dataset resolves at each transaction's own date from
+ * the ECB history); this module only applies what it is handed, exactly as
+ * the net-worth walk does.
+ */
+export type FlowFactorResolver = (
+  row: Pick<Transaction, 'accountId' | 'date'>
+) => DecimalInstance | null;
 
 /**
  * Aggregate income and expenses over a set of transactions using category
@@ -128,7 +148,7 @@ export function computeIncomeExpense(
   transactions: Transaction[],
   transactionSplits: TransactionSplit[],
   categories: Category[],
-  opts: { from?: Date; to?: Date } = {}
+  opts: { from?: Date; to?: Date; convert?: FlowFactorResolver } = {}
 ): IncomeExpenseBreakdown {
   const kinds = buildCategoryKindLookup(categories);
 
@@ -151,26 +171,32 @@ export function computeIncomeExpense(
   const uncategorizedRows: SplitExpandedTransaction[] = [];
   const revaluationRows: SplitExpandedTransaction[] = [];
 
+  let holdsForeign = false;
   for (const row of rows) {
     const kind = classifyFlow(row, kinds);
+    // Into the display currency where the resolver hands back a factor;
+    // native where it does not — the rows themselves stay untouched, so a
+    // row-level display keeps speaking its account's own currency.
+    const factor = opts.convert?.(row) ?? null;
+    if (factor !== null) holdsForeign = true;
+    const rowAmount = factor !== null ? toDecimal(row.amount).times(factor) : toDecimal(row.amount);
     if (kind === 'income') {
-      income = income.plus(toDecimal(row.amount));
+      income = income.plus(rowAmount);
       incomeRows.push(row);
     } else if (kind === 'expense') {
       // Expenses are stored negative, so negating yields positive spending —
       // and a positive-amount credit (refund) correctly SUBTRACTS.
-      expenses = expenses.plus(toDecimal(row.amount).negated());
+      expenses = expenses.plus(rowAmount.negated());
       expenseRows.push(row);
     } else if (kind === 'revaluation') {
       // Signed as stored: an upward revaluation (+) and a downward one (−) net
       // against each other. Deliberately touches NEITHER income nor expenses —
       // a value change is not money earned or spent.
-      revaluation = revaluation.plus(toDecimal(row.amount));
+      revaluation = revaluation.plus(rowAmount);
       revaluationRows.push(row);
     } else if (kind === 'uncategorized') {
-      const amount = toDecimal(row.amount);
-      if (amount.greaterThanOrEqualTo(0)) uncategorizedIn = uncategorizedIn.plus(amount);
-      else uncategorizedOut = uncategorizedOut.plus(amount.abs());
+      if (rowAmount.greaterThanOrEqualTo(0)) uncategorizedIn = uncategorizedIn.plus(rowAmount);
+      else uncategorizedOut = uncategorizedOut.plus(rowAmount.abs());
       uncategorizedRows.push(row);
     }
   }
@@ -178,7 +204,7 @@ export function computeIncomeExpense(
   return {
     income, expenses, incomeRows, expenseRows,
     uncategorizedRows, uncategorizedIn, uncategorizedOut,
-    revaluation, revaluationRows,
+    revaluation, revaluationRows, holdsForeign,
   };
 }
 

--- a/src/utils/monthlyCategoryMatrix.ts
+++ b/src/utils/monthlyCategoryMatrix.ts
@@ -1,6 +1,7 @@
 import type { Category } from '../types';
 import type { PeriodRange } from '../hooks/usePeriod';
 import type { SplitExpandedTransaction } from './transactionSplits';
+import type { FlowFactorResolver } from './incomeExpense';
 import { toDecimal, type DecimalInstance } from './decimal';
 import { getDateLocale } from '../utils/dateFormatter';
 
@@ -126,7 +127,8 @@ function buildSide(
   byId: ReadonlyMap<string, Category>,
   monthIndex: ReadonlyMap<string, number>,
   monthCount: number,
-  bucket: 'income' | 'expense'
+  bucket: 'income' | 'expense',
+  convert?: FlowFactorResolver
 ): { groups: MatrixGroup[]; values: number[]; total: DecimalInstance } {
   const groups = new Map<string, GroupBucket>();
   const sideValues = zeros(monthCount);
@@ -139,8 +141,11 @@ function buildSide(
     if (!category) continue;
 
     // Spending is stored negative — negate so the expense side reads as a
-    // positive magnitude and a refund credit subtracts.
-    const value = bucket === 'income' ? toDecimal(row.amount) : toDecimal(row.amount).negated();
+    // positive magnitude and a refund credit subtracts. The flows seam
+    // converts into the display currency where a factor is handed back.
+    const factor = convert?.(row) ?? null;
+    const rowAmount = factor !== null ? toDecimal(row.amount).times(factor) : toDecimal(row.amount);
+    const value = bucket === 'income' ? rowAmount : rowAmount.negated();
     const index = monthIndex.get(monthKeyOf(row.date));
 
     const groupCategory = groupCategoryOf(category, byId);
@@ -240,7 +245,7 @@ export function buildMonthlyCategoryMatrix(
   expenseRows: SplitExpandedTransaction[],
   categories: Category[],
   range: PeriodRange,
-  opts: { now?: Date; maxMonths?: number } = {}
+  opts: { now?: Date; maxMonths?: number; convert?: FlowFactorResolver } = {}
 ): MonthlyCategoryMatrix {
   const now = opts.now ?? new Date();
   const maxMonths = opts.maxMonths ?? DEFAULT_MAX_MONTHS;
@@ -249,8 +254,8 @@ export function buildMonthlyCategoryMatrix(
   const { months, omittedMonths } = enumerateMonths(range, [incomeRows, expenseRows], now, maxMonths);
   const monthIndex = new Map(months.map((m, i) => [m.key, i]));
 
-  const income = buildSide(incomeRows, byId, monthIndex, months.length, 'income');
-  const expense = buildSide(expenseRows, byId, monthIndex, months.length, 'expense');
+  const income = buildSide(incomeRows, byId, monthIndex, months.length, 'income', opts.convert);
+  const expense = buildSide(expenseRows, byId, monthIndex, months.length, 'expense', opts.convert);
 
   const netValues = months.map((_, i) =>
     toDecimal(income.values[i]).minus(toDecimal(expense.values[i])).toNumber()

--- a/src/utils/monthlyTrend.ts
+++ b/src/utils/monthlyTrend.ts
@@ -1,6 +1,7 @@
 import type { Category, Transaction } from '../types';
 import { toDecimal, type DecimalInstance } from './decimal';
 import { bucketByCategoryDirection } from './categoryNetting';
+import type { FlowFactorResolver } from './incomeExpense';
 import { getDateLocale } from '../utils/dateFormatter';
 
 export interface MonthlyTrendPoint {
@@ -21,7 +22,12 @@ export interface MonthlyTrendPoint {
  * `rows` must already be split-expanded (each split line lands in ITS
  * category's month).
  */
-export function buildMonthlyTrend(rows: Transaction[], categories: Category[]): MonthlyTrendPoint[] {
+export function buildMonthlyTrend(
+  rows: Transaction[],
+  categories: Category[],
+  /** The flows seam: per-row factor into the display currency (see incomeExpense). */
+  convert?: FlowFactorResolver
+): MonthlyTrendPoint[] {
   const monthlyData: Record<string, { income: DecimalInstance; expenses: DecimalInstance }> = {};
   const categoryById = new Map(categories.map(c => [c.id, c]));
 
@@ -33,11 +39,13 @@ export function buildMonthlyTrend(rows: Transaction[], categories: Category[]): 
       monthlyData[monthKey] = { income: toDecimal(0), expenses: toDecimal(0) };
     }
 
+    const factor = convert?.(t) ?? null;
+    const amount = factor !== null ? toDecimal(t.amount).times(factor) : toDecimal(t.amount);
     if (bucket === 'income') {
-      monthlyData[monthKey].income = monthlyData[monthKey].income.plus(t.amount);
+      monthlyData[monthKey].income = monthlyData[monthKey].income.plus(amount);
     } else {
       // Spending is negative; negate so refunds net the month down.
-      monthlyData[monthKey].expenses = monthlyData[monthKey].expenses.minus(t.amount);
+      monthlyData[monthKey].expenses = monthlyData[monthKey].expenses.minus(amount);
     }
   });
 

--- a/src/utils/periodComparison.ts
+++ b/src/utils/periodComparison.ts
@@ -1,6 +1,6 @@
 import type { Category } from '../types';
 import type { PeriodRange } from '../hooks/usePeriod';
-import type { IncomeExpenseBreakdown } from './incomeExpense';
+import type { IncomeExpenseBreakdown, FlowFactorResolver } from './incomeExpense';
 import type { SplitExpandedTransaction } from './transactionSplits';
 import { toDecimal } from './decimal';
 import { buildCategoryNameLookup } from './categoryNames';
@@ -149,11 +149,14 @@ function accumulate(
   rows: SplitExpandedTransaction[],
   bucket: Bucket,
   into: Map<string, ReturnType<typeof toDecimal>>,
-  identities: Map<string, RowIdentity>
+  identities: Map<string, RowIdentity>,
+  convert?: FlowFactorResolver
 ): void {
   for (const row of rows) {
     if (!row.category) continue;
-    const value = bucket === 'income' ? toDecimal(row.amount) : toDecimal(row.amount).negated();
+    const factor = convert?.(row) ?? null;
+    const rowAmount = factor !== null ? toDecimal(row.amount).times(factor) : toDecimal(row.amount);
+    const value = bucket === 'income' ? rowAmount : rowAmount.negated();
     const rowId = rowIdOf(bucket, row.category);
     identities.set(rowId, { bucket, categoryId: row.category });
     into.set(rowId, (into.get(rowId) ?? toDecimal(0)).plus(value));
@@ -163,7 +166,9 @@ function accumulate(
 export function buildPeriodComparison(
   current: IncomeExpenseBreakdown,
   previous: IncomeExpenseBreakdown,
-  categories: Category[]
+  categories: Category[],
+  /** The flows seam: per-row factor into the display currency (see incomeExpense). */
+  convert?: FlowFactorResolver
 ): PeriodComparison {
   const categoryName = buildCategoryNameLookup(categories);
   // Every row either window produced, keyed by side and category — so a row's
@@ -178,7 +183,7 @@ export function buildPeriodComparison(
     [previous.incomeRows, 'income', previousTotals],
     [previous.expenseRows, 'expense', previousTotals],
   ] as const) {
-    accumulate(rows, bucket, into, identities);
+    accumulate(rows, bucket, into, identities, convert);
   }
 
   const zero = toDecimal(0);

--- a/src/utils/spendingByPayee.ts
+++ b/src/utils/spendingByPayee.ts
@@ -3,6 +3,7 @@ import type { SplitExpandedTransaction } from './transactionSplits';
 import { toDecimal } from './decimal';
 import { normalizePayee, FALLBACK_BANK_DESCRIPTION } from './payeeAutoCategorize';
 import { buildCategoryNameLookup } from './categoryNames';
+import type { FlowFactorResolver } from './incomeExpense';
 
 /**
  * "Spending by payee" — the Microsoft Money report: who the money actually
@@ -79,7 +80,9 @@ interface PayeeAccumulator {
 export function buildPayeeTotals(
   rows: SplitExpandedTransaction[],
   bucket: 'income' | 'expense',
-  categories: Category[]
+  categories: Category[],
+  /** The flows seam: per-row factor into the display currency (see incomeExpense). */
+  convert?: FlowFactorResolver
 ): PayeeTotals {
   const categoryName = buildCategoryNameLookup(categories);
   const groups = new Map<string, PayeeAccumulator>();
@@ -87,9 +90,11 @@ export function buildPayeeTotals(
 
   for (const row of rows) {
     const payee = payeeKeyOf(row.description);
+    const factor = convert?.(row) ?? null;
+    const rowAmount = factor !== null ? toDecimal(row.amount).times(factor) : toDecimal(row.amount);
     // Spending is stored negative, so negate to read as a positive magnitude
     // and let a refund credit subtract.
-    const value = bucket === 'income' ? toDecimal(row.amount) : toDecimal(row.amount).negated();
+    const value = bucket === 'income' ? rowAmount : rowAmount.negated();
     const date = new Date(row.date);
     total = total.plus(value);
 


### PR DESCRIPTION
**Phases 1 and 3** of the disclosure ruling's §7 order (22 Aug) — with #382–#388, this completes every item of the ruling.

## The seam

`computeIncomeExpense` takes an optional per-row factor resolver and applies it **at the summing**; the rows stay native, so row displays keep their own currency. The same resolver threads through every self-summing aggregator — monthly trend, category matrix, payee totals, category netting, period comparison — so no report can sum on a different basis than its own summary cards. The breakdown now carries `holdsForeign`, the gate for `≈`.

## The policy, in one place

`useFlowConvert` (and `useReportDataset` through it) resolves each row **at its own date** from the ECB history #386 installed — a 2017 dollar purchase at 2017's rate, never today's. When the history cannot be had, the resolver is undefined: totals stay native and the Phase 0 disclosure keeps saying so. The seam converts on the real basis or not at all — never on a third one nobody stated. The whole history is fetched (one small cached request), so a comparison window before the picker's range still resolves correctly.

## The registry's ladder

`converts` grew into `currency: 'self' | 'flows' | absent`. The hub mounts per report: nothing for `'self'` (net-worth-over-time carries its own notes); **`ReportCurrencyNote`** for `'flows'` — the §6.2 basis line when the history is in force (pre-1999 clause only when the ledger reaches back that far), the Phase 0 disclosure while degraded, plus the **§6.4 restatement notice under its own dismissal key** (the flows' restatement is a different event from the balances'); the Phase 0 disclosure for the still-native rest. Five reports flip to `'flows'`.

## Ruling C, structurally

The dashboard's income-and-expenses card and both report widgets share the same resolver hook as the reports they open. The census ledger reclassifies four entries to `converts`; Calendar, Categorisation and categoryHealth remain honestly native-known behind their disclosure lines.

## Phase 3's silent exclusion (§4)

The budget **alert** now carries the Budget card's own sentence exactly when foreign-account rows were excluded from its figures — a silent exclusion fails like a silent conversion. The ruling's other named offender, `budgetRecommendationService`, has **no consumer anywhere** — reported to the owner as a deletion candidate (alongside the audit's CashFlowForecast finding) rather than dressed in furniture nobody renders.

Verified live: spending-by-category shows a converted `≈ £…` headline with basis line and restatement; monthly income & expenses wears ≈ on all three cards; account-balances (still native) keeps its Phase 0 line.

Every figure in the tests is invented; the repo is public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)