### PR TITLE
The differential nightly dies before its first test — a PG17 GUC the runner's Postgres cannot parse

### DIFF
--- a/scripts/local-db/up.sh
+++ b/scripts/local-db/up.sh
@@ -50,7 +50,15 @@ SQL
 
 cd "$MIG" || exit 1
 BASE=20251030003814__initial-schema.sql
-run -v ON_ERROR_STOP=1 -f "$BASE" >/tmp/wt-base.log 2>&1 || { echo "baseline FAILED"; tail -5 /tmp/wt-base.log; exit 1; }
+# `SET transaction_timeout` is a PostgreSQL 17 parameter that pg_dump 17
+# writes into every dump. On the 16-and-earlier cluster CI's plain apt
+# install provides, it aborts the whole baseline ("unrecognized configuration
+# parameter") — which is why the differential nightly had never once gone
+# green: it died HERE, before a single test ran, every night. Dropped on
+# every server, 17 included: zero is the parameter's own default, so the
+# line never did anything except decide whether older servers could restore.
+grep -v '^SET transaction_timeout' "$BASE" > /tmp/wt-base-portable.sql
+run -v ON_ERROR_STOP=1 -f /tmp/wt-base-portable.sql >/tmp/wt-base.log 2>&1 || { echo "baseline FAILED"; tail -5 /tmp/wt-base.log; exit 1; }
 
 # Three passes: filename order is not dependency order (the baseline dump sorts
 # after files it already contains), so a migration can fail on pass 1 for want


### PR DESCRIPTION
The local-edition nightly's differential job has **never gone green** — not once in its recorded history. Every night, five seconds into `scripts/local-db/up.sh`, before a single spec ran:

```
psql:20251030003814__initial-schema.sql:13:
ERROR: unrecognized configuration parameter "transaction_timeout"
```

`SET transaction_timeout` is a **PostgreSQL 17** parameter that pg_dump 17 writes into every dump. The workflow installs plain `apt postgresql` (older), so the baseline aborted wholesale — and the desktop-shell job's green kept the run from looking dead. The differential lanes themselves were fine all along: they run green locally on PG17, which is exactly why nobody's local run ever showed it.

`up.sh` now applies the baseline through a filter that drops that one line, on every server: zero is the parameter's own default, so the SET never did anything except decide whether an older server could restore the dump. A census of the migration tree found it in the baseline alone.

**Verified locally end-to-end on PG17** (the happy path must not regress): cluster up with 0 unapplied, the 67-spec constraint-parity lane passes through the fixed script, teardown clean. Runner-side proof: a `workflow_dispatch` of the nightly right after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)