### PR TITLE
Batch B — every primary action fill wears the token pair, both grounds

### DIFF
--- a/src/components/ArchiveManager.tsx
+++ b/src/components/ArchiveManager.tsx
@@ -315,7 +315,7 @@ export default function ArchiveManager() {
             onClick={event => { event.stopPropagation(); void handleArchive(account.id); }}
             disabled={busy || !cutoff || impact.willHide === 0}
             title={!cutoff ? 'Pick a date range above' : describeArchiveConsequence(impact, cutoff)}
-            className="px-3 py-1.5 text-sm rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed inline-flex items-center gap-1"
+            className="px-3 py-1.5 text-sm rounded-lg bg-primary-action text-on-primary-action hover:bg-primary-action-hover disabled:opacity-40 disabled:cursor-not-allowed inline-flex items-center gap-1"
           >
             {busy ? 'Working…' : impact.willHide > 0 ? `Archive ${impact.willHide.toLocaleString()}` : 'Archive'}
           </button>
@@ -497,7 +497,7 @@ export default function ArchiveManager() {
               onClick={saveOverride}
               disabled={draftDate === '' || !draftAcknowledged}
               title={draftDate === '' ? 'Choose a date first' : !draftAcknowledged ? 'Tick the acknowledgement first' : undefined}
-              className="px-4 py-2 text-sm rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed"
+              className="px-4 py-2 text-sm rounded-lg bg-primary-action text-on-primary-action hover:bg-primary-action-hover disabled:opacity-40 disabled:cursor-not-allowed"
             >
               Use this date
             </button>

--- a/src/components/BulkCategorizeModal.tsx
+++ b/src/components/BulkCategorizeModal.tsx
@@ -384,7 +384,7 @@ export default function BulkCategorizeModal({ isOpen, onClose }: Props): React.J
               type="button"
               onClick={() => void handleApply()}
               disabled={applying || ready.length === 0}
-              className="justify-center px-4 py-2 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="justify-center px-4 py-2 text-sm font-medium rounded-lg bg-primary-action text-on-primary-action hover:bg-primary-action-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {applying ? 'Applying…' : `Categorise ${rowsCovered.toLocaleString()} transaction${rowsCovered === 1 ? '' : 's'}`}
             </button>

--- a/src/components/IncomeExpenseBreakdownModal.tsx
+++ b/src/components/IncomeExpenseBreakdownModal.tsx
@@ -337,7 +337,7 @@ export default function IncomeExpenseBreakdownModal({
             type="button"
             onClick={() => void handleSave()}
             disabled={saving}
-            className="px-4 py-1.5 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors disabled:opacity-60 disabled:cursor-wait"
+            className="px-4 py-1.5 text-sm font-medium rounded-lg bg-primary-action text-on-primary-action hover:bg-primary-action-hover transition-colors disabled:opacity-60 disabled:cursor-wait"
           >
             {saving ? 'Saving…' : `Save ${pendingIds.length}`}
           </button>

--- a/src/components/LoadTestDataModal.tsx
+++ b/src/components/LoadTestDataModal.tsx
@@ -187,7 +187,7 @@ export default function LoadTestDataModal({ isOpen, onClose }: Props): React.JSX
             <button
               onClick={() => { void handleLoad(); }}
               disabled={phase === 'loading'}
-              className="flex-1 justify-center px-4 py-2 bg-[#1a2332] dark:bg-blue-600 text-white rounded-lg hover:bg-[#243044] dark:hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed"
+              className="flex-1 justify-center px-4 py-2 bg-primary-action text-on-primary-action rounded-lg hover:bg-primary-action-hover disabled:opacity-40 disabled:cursor-not-allowed"
             >
               {phase === 'loading' ? 'Loading…' : phase === 'failed' ? 'Try again' : 'Load test data'}
             </button>

--- a/src/components/MsMoneyImportModal.tsx
+++ b/src/components/MsMoneyImportModal.tsx
@@ -128,7 +128,7 @@ export default function MsMoneyImportModal({ isOpen, onClose, onBackup, onExecut
               </p>
               <input ref={inputRef} type="file" accept=".mny" onChange={onInputChange} className="hidden" />
               <button onClick={() => inputRef.current?.click()}
-                className="px-5 py-3 bg-[#1a2332] dark:bg-blue-600 text-white rounded-lg hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors inline-flex items-center gap-2 font-medium">
+                className="px-5 py-3 bg-primary-action text-on-primary-action rounded-lg hover:bg-primary-action-hover transition-colors inline-flex items-center gap-2 font-medium">
                 <UploadIcon size={20} />
                 Choose Microsoft Money file
               </button>
@@ -244,7 +244,7 @@ export default function MsMoneyImportModal({ isOpen, onClose, onBackup, onExecut
                 {s.accounts.total} accounts and {s.transactions.imported.toLocaleString()} transactions are now in WealthTracker.
               </p>
               <button onClick={handleClose}
-                className="px-5 py-2 bg-[#1a2332] dark:bg-blue-600 text-white rounded-lg hover:bg-[#2d3a4d] dark:hover:bg-blue-700 font-medium">
+                className="px-5 py-2 bg-primary-action text-on-primary-action rounded-lg hover:bg-primary-action-hover font-medium">
                 Done
               </button>
             </div>
@@ -262,7 +262,7 @@ export default function MsMoneyImportModal({ isOpen, onClose, onBackup, onExecut
                   Close
                 </button>
                 <button onClick={reset}
-                  className="px-4 py-2 bg-[#1a2332] dark:bg-blue-600 text-white rounded-lg hover:bg-[#2d3a4d] dark:hover:bg-blue-700">
+                  className="px-4 py-2 bg-primary-action text-on-primary-action rounded-lg hover:bg-primary-action-hover">
                   Try another file
                 </button>
               </div>

--- a/src/components/RenamePayeesModal.tsx
+++ b/src/components/RenamePayeesModal.tsx
@@ -229,7 +229,7 @@ export default function RenamePayeesModal({
             <button
               type="submit"
               disabled={!canRename}
-              className="justify-center px-4 py-2 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="justify-center px-4 py-2 text-sm font-medium rounded-lg bg-primary-action text-on-primary-action hover:bg-primary-action-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {renaming
                 ? 'Renaming…'

--- a/src/components/TransferSweepModal.tsx
+++ b/src/components/TransferSweepModal.tsx
@@ -1170,7 +1170,7 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
                 type="button"
                 onClick={() => void handleApply()}
                 disabled={applying || chosen.length === 0}
-                className="justify-center px-4 py-2 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="justify-center px-4 py-2 text-sm font-medium rounded-lg bg-primary-action text-on-primary-action hover:bg-primary-action-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {applying ? 'Linking…' : `Link ${chosen.length.toLocaleString()} pair${chosen.length === 1 ? '' : 's'}`}
               </button>
@@ -1232,7 +1232,7 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
                   setSelected(next);
                   setInspecting(null);
                 }}
-                className="px-4 py-2 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors"
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-primary-action text-on-primary-action hover:bg-primary-action-hover transition-colors"
               >
                 Yes — select this pair
               </button>
@@ -1301,7 +1301,7 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
                   setSelected(next);
                   setInspectingLeg(null);
                 }}
-                className="px-4 py-2 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors"
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-primary-action text-on-primary-action hover:bg-primary-action-hover transition-colors"
               >
                 Yes — select this line
               </button>
@@ -1429,7 +1429,7 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
                 type="button"
                 disabled={resolving || (needsAdjustmentCategory(reviewing) && !adjustmentCategory)}
                 onClick={() => void handleStranded(reviewing)}
-                className="justify-center px-4 py-2 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="justify-center px-4 py-2 text-sm font-medium rounded-lg bg-primary-action text-on-primary-action hover:bg-primary-action-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {resolving ? 'Working…' : STRANDED_CONFIRM[reviewing.kind]}
               </button>
@@ -1507,7 +1507,7 @@ export default function TransferSweepModal({ isOpen, onClose }: Props): React.JS
                     }
                   })();
                 }}
-                className="px-4 py-2 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors disabled:opacity-50"
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-primary-action text-on-primary-action hover:bg-primary-action-hover transition-colors disabled:opacity-50"
               >
                 {reopening ? 'Re-opening…' : 'Re-open and view'}
               </button>

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -1282,14 +1282,14 @@ export function ImprovedDashboard() {
               <button
                 type="button"
                 onClick={selectAllAccounts}
-                className="px-4 py-2 min-h-[44px] sm:min-h-0 sm:py-1.5 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors"
+                className="px-4 py-2 min-h-[44px] sm:min-h-0 sm:py-1.5 text-sm font-medium rounded-lg bg-primary-action text-on-primary-action hover:bg-primary-action-hover transition-colors"
               >
                 Select all
               </button>
               <button
                 type="button"
                 onClick={clearAllAccounts}
-                className="px-4 py-2 min-h-[44px] sm:min-h-0 sm:py-1.5 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors"
+                className="px-4 py-2 min-h-[44px] sm:min-h-0 sm:py-1.5 text-sm font-medium rounded-lg bg-primary-action text-on-primary-action hover:bg-primary-action-hover transition-colors"
               >
                 Clear all
               </button>

--- a/src/components/reports/ReportAccountMultiSelect.tsx
+++ b/src/components/reports/ReportAccountMultiSelect.tsx
@@ -219,7 +219,7 @@ export default function ReportAccountMultiSelect({
               <button
                 type="button"
                 onClick={save}
-                className="px-3 py-1 text-sm font-medium rounded-md bg-[#1a2332] dark:bg-blue-600 text-white hover:opacity-90"
+                className="px-3 py-1 text-sm font-medium rounded-md bg-primary-action text-on-primary-action hover:opacity-90"
               >
                 Save
               </button>

--- a/src/components/settings/BankFeedRefreshSettings.tsx
+++ b/src/components/settings/BankFeedRefreshSettings.tsx
@@ -62,7 +62,7 @@ export default function BankFeedRefreshSettings(): React.JSX.Element | null {
             key={value}
             className={`flex items-start gap-3 rounded-xl border p-3 cursor-pointer transition-colors ${
               prefs.mode === value
-                ? 'border-[#1a2332] dark:border-blue-500 bg-gray-50 dark:bg-gray-700/50'
+                ? 'border-[#1a2332] dark:border-[#94a3b8] bg-gray-50 dark:bg-gray-700/50'
                 : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
             }`}
           >

--- a/src/components/sweeps/DismissSuggestionPrompt.tsx
+++ b/src/components/sweeps/DismissSuggestionPrompt.tsx
@@ -89,7 +89,7 @@ export default function DismissSuggestionPrompt({
             type="button"
             onClick={onDismiss}
             disabled={saving}
-            className="justify-center px-4 py-2 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="justify-center px-4 py-2 text-sm font-medium rounded-lg bg-primary-action text-on-primary-action hover:bg-primary-action-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {saving ? (savingLabel ?? 'Saving…') : 'Yes — never offer it again'}
           </button>

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -230,7 +230,11 @@ const TOOLBAR_QUIET_IDLE =
   'border-line-strong dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-surface-tertiary dark:hover:bg-gray-700';
 /** The same button, switched on. A state of the one style, not a second style. */
 const TOOLBAR_QUIET_ACTIVE =
-  'border-[#1a2332] dark:border-blue-500 text-[#1a2332] dark:text-blue-400 bg-surface-secondary dark:bg-gray-700';
+  // Dark side wears the focus-family slate, not a blue: blue means link in
+  // this app, and a selected border already has a dark ruling (index.css's
+  // `.dark .border-primary`) — same family as the focus ring, no second
+  // highlight colour (Claude Design's canon ruling, 22 Aug §2/§6).
+  'border-[#1a2332] dark:border-[#94a3b8] text-[#1a2332] dark:text-[#94a3b8] bg-surface-secondary dark:bg-gray-700';
 
 /** The sortable columns, named as their headers name them. */
 const SORT_FIELD_LABELS: Record<TransactionSortField, string> = {
@@ -3015,7 +3019,7 @@ export default function AccountTransactions() {
                 type="button"
                 onClick={() => { void handleReopenAccount(); }}
                 disabled={reopening}
-                className="px-4 py-2 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-primary-action text-on-primary-action hover:bg-primary-action-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {reopening ? 'Re-opening…' : 'Re-open and view'}
               </button>

--- a/src/pages/EnhancedImport.tsx
+++ b/src/pages/EnhancedImport.tsx
@@ -129,7 +129,7 @@ export default function EnhancedImport(): React.JSX.Element {
           onClick={() => setShowMsMoneyImport(true)}
           className="w-full mb-6 text-left rounded-2xl border border-[#1a2332]/15 dark:border-blue-500/30 bg-[#1a2332]/[0.03] dark:bg-blue-500/10 hover:bg-[#1a2332]/[0.06] dark:hover:bg-blue-500/20 transition-colors p-5 flex items-center gap-4"
         >
-          <span className="shrink-0 grid place-items-center h-12 w-12 rounded-xl bg-[#1a2332] dark:bg-blue-600 text-white">
+          <span className="shrink-0 grid place-items-center h-12 w-12 rounded-xl bg-primary-action text-on-primary-action">
             <DatabaseIcon size={24} />
           </span>
           <span className="min-w-0">

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -36,7 +36,7 @@ export default function NotFound(): React.JSX.Element {
         <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
           <Link
             to="/dashboard"
-            className="inline-flex items-center justify-center rounded-lg bg-[#1a2332] px-4 py-2 text-sm font-medium text-white hover:bg-[#2d3a4d] dark:bg-blue-600 dark:hover:bg-blue-700 transition-colors"
+            className="inline-flex items-center justify-center rounded-lg bg-primary-action px-4 py-2 text-sm font-medium text-on-primary-action hover:bg-primary-action-hover transition-colors"
           >
             Go to your dashboard
           </Link>

--- a/src/pages/Reconciliation.tsx
+++ b/src/pages/Reconciliation.tsx
@@ -772,7 +772,7 @@ export default function Reconciliation() {
             className={`flex items-center gap-2 px-4 py-2 border rounded-lg transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed ${
               balanceConfirmed
                 ? NEXT_ACTION_YELLOW
-                : 'border-transparent bg-[#1a2332] dark:bg-blue-600 text-white'
+                : 'border-transparent bg-primary-action text-on-primary-action'
             }`}
           >
             <CheckCircleIcon size={18} />

--- a/src/pages/__tests__/Reconciliation.yellowThread.test.tsx
+++ b/src/pages/__tests__/Reconciliation.yellowThread.test.tsx
@@ -222,7 +222,10 @@ describe('Reconciliation — the yellow that travels', () => {
 
     const finalize = finalizeButton();
     expect(amber(finalize)).toEqual([]);
-    expect(finalize).toHaveClass('bg-[#1a2332]', 'text-white');
+    // The ordinary primary is now the ground-aware TOKEN pair (the canon
+    // ruling, 22 Aug) — which is a stronger version of what this spec always
+    // meant: the quiet Finalize wears the app's one primary, by name.
+    expect(finalize).toHaveClass('bg-primary-action', 'text-on-primary-action');
     expect(finalize).toHaveClass('disabled:opacity-50', 'disabled:cursor-not-allowed');
   });
 

--- a/src/pages/settings/DataManagement.tsx
+++ b/src/pages/settings/DataManagement.tsx
@@ -533,7 +533,7 @@ function LinkCard({ to, icon: Icon, title, description }: {
       to={to}
       className="w-full text-left rounded-xl border border-[#1a2332]/15 dark:border-blue-500/30 bg-[#1a2332]/[0.03] dark:bg-blue-500/10 hover:bg-[#1a2332]/[0.06] dark:hover:bg-blue-500/20 transition-colors p-4 flex items-center gap-3"
     >
-      <span className="shrink-0 grid place-items-center h-10 w-10 rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white">
+      <span className="shrink-0 grid place-items-center h-10 w-10 rounded-lg bg-primary-action text-on-primary-action">
         <Icon size={20} />
       </span>
       <span className="min-w-0">

--- a/src/pages/settings/PayeeCleanup.tsx
+++ b/src/pages/settings/PayeeCleanup.tsx
@@ -937,7 +937,7 @@ export default function PayeeCleanup(): React.JSX.Element {
               onClick={() => setRenameOpen(true)}
               disabled={selected.size === 0}
               aria-describedby="payee-bulk-help"
-              className="px-4 py-2 text-sm font-medium rounded-lg bg-[#1a2332] dark:bg-blue-600 text-white hover:bg-[#2d3a4d] dark:hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="px-4 py-2 text-sm font-medium rounded-lg bg-primary-action text-on-primary-action hover:bg-primary-action-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Rename selected…
             </button>


### PR DESCRIPTION
The owner's dark + light eyeball of the Accounts pilot on production was the gate (the canon ruling, 22 Aug §4) — **passed 23 Aug**. The other primary fills now move.

**24 action fills across 16 files** leave their invented `dark:bg-blue-600` for `bg-primary-action` / `text-on-primary-action` / `hover:bg-primary-action-hover` — navy-on-white in light (pixel-identical), inverted near-white-with-navy-label on dark, exactly the approved pilot. LoadTestDataModal's one-off `#243044` light hover joins the token's `#2d3a4d`; NotFound's interleaved variant handled by hand.

**Two selected-state blues** the fill census couldn't see (borders, not fills): the register toolbar's active chip (whose `dark:text-blue-400` was blue as non-link text — disqualified by the ruling's own §2) and the bank-feed chooser's selected tile. Both join the **focus-family slate `#94a3b8`**, per the dark ruling `index.css` already carries for selected borders: one family, never a second highlight colour.

**What deliberately stays blue**, awaiting Design's neither-category ruling: the two progress-bar fills, ImportProgress's pair, ToggleSwitch's ON track, the two tinted CTA washes — and, newly added to that list, MsMoneyImportModal's loading spinner border. The post-sweep census shows exactly those and nothing else.

The yellow-thread spec pinning Finalize's quiet state now asserts the token pair by name — a stronger version of what it always meant. Verified live: a swept surface computes `rgb(26,35,50)`/white in light and `rgb(241,243,247)`/`rgb(26,35,50)` in dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)