### PR TITLE
The Investments chain converts — value at today's rates, every flow at its own day's, FX drift landing in return

### DIFF
--- a/src/hooks/useNetWorthConversion.ts
+++ b/src/hooks/useNetWorthConversion.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { Account } from '../types';
 import type { PeriodRange } from './usePeriod';
 import {
@@ -48,6 +48,12 @@ export function useNetWorthConversion(
   seriesConversion: NetWorthConversion | NetWorthConversionByDate | null;
   /** Per-date factors for a drill into one day; null while degraded. */
   conversionAt: ((date: Date) => NetWorthConversion | null) | null;
+  /**
+   * Units-per-display-currency factor for an arbitrary CURRENCY at today's
+   * rates (for values keyed by listing currency rather than account —
+   * holdings). Null while rates are absent or for an unknown code.
+   */
+  rateFor: (currency: string) => DecimalInstance | null;
   /** True when per-date reference rates are in force for the series. */
   historical: boolean;
   provenance: RatesProvenance | null;
@@ -161,6 +167,15 @@ export function useNetWorthConversion(
     return { byDate: { at, unconverted }, at };
   }, [wantsHistory, historyState, accounts, displayCurrency, foreignCurrencies]);
 
+  const rateFor = useCallback((currency: string): DecimalInstance | null => {
+    if (!ratesState || currency === displayCurrency) return currency === displayCurrency ? toDecimal(1) : null;
+    const displayRate = ratesState.rates[displayCurrency];
+    const currencyRate = ratesState.rates[currency];
+    if (!displayRate || !currencyRate) return null;
+    // Units-per-GBP both sides, GBP the pivot — the app's one arithmetic.
+    return toDecimal(displayRate).dividedBy(toDecimal(currencyRate));
+  }, [ratesState, displayCurrency]);
+
   return {
     conversion,
     seriesConversion: dated?.byDate ?? conversion,
@@ -168,5 +183,6 @@ export function useNetWorthConversion(
     historical: dated !== null,
     provenance: ratesState?.provenance ?? null,
     displayCurrency,
+    rateFor,
   };
 }

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -30,6 +30,7 @@ import { WholePoundsScope, WholePoundsToggle } from '../contexts/WholePoundsCont
 import ToggleSwitch from '../components/ui/ToggleSwitch';
 import { buildPortfolioSummary, buildPortfolioHistory } from '../utils/portfolioSummary';
 import { useNetWorthConversion } from '../hooks/useNetWorthConversion';
+import { useFlowConvert } from '../hooks/useFlowConvert';
 import HistoricRatesRestatementNotice from '../components/HistoricRatesRestatementNotice';
 import MixedCurrencyDisclosure from '../components/MixedCurrencyDisclosure';
 import { useHistoricalAccounts } from '../hooks/useHistoricalAccounts';
@@ -449,9 +450,27 @@ function InvestmentsView() {
    * £0), which is what makes the contributions attribution sum true.
    */
   const historicalAccounts = useHistoricalAccounts(openAccounts);
+  /**
+   * ONE conversion source for the whole chain (the Investments chain,
+   * 23 Aug): balances at today's factors, valuations and flows at their own
+   * days' ECB rates, holdings by listing currency — over open AND CLOSED
+   * members, because the walks span their history. Null/undefined on an
+   * all-sterling ledger, which keeps every figure exactly as it was.
+   */
+  const {
+    seriesConversion: scopeConversion,
+    historical: scopeHistorical,
+    conversion,
+    conversionAt,
+    rateFor,
+  } = useNetWorthConversion(historicalAccounts, { range: { from: null, to: null } });
+  const flowConvert = useFlowConvert(historicalAccounts);
   const summary = useMemo(
-    () => buildPortfolioSummary({ accounts: historicalAccounts, transactions, transactionSplits, categories }),
-    [historicalAccounts, transactions, transactionSplits, categories]
+    () => buildPortfolioSummary({
+      accounts: historicalAccounts, transactions, transactionSplits, categories,
+      conversion: conversion ?? undefined, flowConvert,
+    }),
+    [historicalAccounts, transactions, transactionSplits, categories, conversion, flowConvert]
   );
 
   /**
@@ -566,8 +585,12 @@ function InvestmentsView() {
   // backdated-rates ask), so a currency's movement stops masquerading as
   // portfolio value. Null for the all-sterling scope, which keeps its
   // arithmetic untouched.
-  const { seriesConversion: scopeConversion, historical: scopeHistorical } =
-    useNetWorthConversion(scopeMembers, { range: historyRange });
+  /** ≈ gates (ruling §6.3): only where a conversion is actually inside. */
+  const scopeHoldsForeign = useMemo(
+    () => conversion !== null && scopeMembers.some(m => conversion.factors.has(m.id)),
+    [conversion, scopeMembers]
+  );
+  const scopeApprox = scopeHoldsForeign ? '\u2248 ' : '';
   const performanceData = useMemo(
     () => buildPortfolioHistory(scopeMembers, transactions, historyRange, new Date(), scopeConversion ?? undefined),
     [scopeMembers, transactions, historyRange, scopeConversion]
@@ -587,8 +610,9 @@ function InvestmentsView() {
       transactionSplits,
       categories,
       range: historyRange,
+      conversionAt: conversionAt ?? undefined,
     }),
-    [scopeMembers, transactions, transactionSplits, categories, historyRange]
+    [scopeMembers, transactions, transactionSplits, categories, historyRange, conversionAt]
   );
 
   /**
@@ -605,7 +629,7 @@ function InvestmentsView() {
       .map(root => ({
         accountId: root.id,
         name: root.name,
-        value: scopeValueAt(pairGroups.membersByTopLevelId.get(root.id) ?? [root], transactions, drillDate),
+        value: scopeValueAt(pairGroups.membersByTopLevelId.get(root.id) ?? [root], transactions, drillDate, conversionAt ?? undefined),
       }))
       .filter(row => !row.value.isZero())
       .sort((a, b) => b.value.minus(a.value).toNumber());
@@ -613,7 +637,7 @@ function InvestmentsView() {
       rows,
       total: rows.reduce((sum, row) => sum.plus(row.value), toDecimal(0)),
     };
-  }, [drillDate, historicalAccounts, pairGroups, performanceScope, transactions]);
+  }, [drillDate, historicalAccounts, pairGroups, performanceScope, transactions, conversionAt]);
 
   /**
    * Per-pair windowed performance, for the tile drills: the same maths as
@@ -625,6 +649,7 @@ function InvestmentsView() {
     for (const line of summary.lines) {
       if (performanceScope !== 'all' && line.accountId !== performanceScope) continue;
       byRoot.set(line.accountId, computePortfolioPerformance({
+        conversionAt: conversionAt ?? undefined,
         memberAccounts: pairGroups.membersByTopLevelId.get(line.accountId) ?? [],
         transactions,
         transactionSplits,
@@ -633,7 +658,7 @@ function InvestmentsView() {
       }));
     }
     return byRoot;
-  }, [summary.lines, performanceScope, pairGroups, transactions, transactionSplits, categories, historyRange]);
+  }, [summary.lines, performanceScope, pairGroups, transactions, transactionSplits, categories, historyRange, conversionAt]);
 
   const netPortfolioValue = useMemo(
     () => toDecimal(performance.endValue).minus(securedAgainstPortfolio.total),
@@ -748,8 +773,8 @@ function InvestmentsView() {
    * sleeve in the portfolio is a single Cash category.
    */
   const holdingAllocation = useMemo(
-    () => buildHoldingAllocation(holdings, summary.lines),
-    [holdings, summary.lines]
+    () => buildHoldingAllocation(holdings, summary.lines, rateFor),
+    [holdings, summary.lines, rateFor]
   );
 
   const holdingSlices = useMemo(
@@ -931,12 +956,27 @@ function InvestmentsView() {
       <div className="flex justify-end mb-2">
         <WholePoundsToggle />
       </div>
-      {/* Phase 0 (the disclosure ruling, 22 Aug §2): the portfolio value,
-          allocation and return figures still sum native units — said until
-          the Investments chain's conversion phase. The performance CHART
-          already converts (per-day reference rates); these totals do not
-          yet. Nothing for a single-currency ledger. */}
-      <MixedCurrencyDisclosure className="mb-3" />
+      {/* THE PAGE'S ONE RATE-BASIS LINE (ruling §6.2), now that the chain
+          converts (23 Aug): two bases, both said — balances are worth what
+          they are worth TODAY, flows moved on their own days. While the
+          history is absent the flows stay native and the line says that
+          instead; with no rates at all the Phase 0 disclosure stands.
+          Nothing for a single-currency ledger. */}
+      {conversion !== null && (
+        conversion.factors.size === 0 ? (
+          <MixedCurrencyDisclosure className="mb-3" />
+        ) : scopeHistorical ? (
+          <p className="mb-3 text-dense text-gray-500 dark:text-gray-400" data-testid="investments-rates-basis">
+            ≈ Balances converted at today’s rates; money in and out at each
+            day’s ECB reference rate.
+          </p>
+        ) : (
+          <p className="mb-3 text-dense text-gray-500 dark:text-gray-400" data-testid="investments-rates-basis">
+            ≈ Balances converted at today’s rates. Money in and out is counted
+            unit-for-unit until the rate history loads.
+          </p>
+        )
+      )}
       {/* Navigation Tabs */}
       <div className="flex space-x-1 bg-gray-100 dark:bg-gray-700 p-1 rounded-lg mb-6">
         <button
@@ -1013,7 +1053,7 @@ function InvestmentsView() {
                   : 'Portfolio Value'}
               </p>
               <p className="text-page font-bold text-gray-900 dark:text-white">
-                {formatCurrency(
+                {scopeApprox}{formatCurrency(
                   showNetPosition && securedAgainstPortfolio.names.length > 0
                     ? netPortfolioValue
                     : performance.endValue
@@ -1288,7 +1328,7 @@ function InvestmentsView() {
               const drillMembers = pairGroups.membersByTopLevelId.get(drillLine.accountId) ?? [];
               const windowRows = [
                 ...drillLine.contributionRows.filter(row => inWindow(row.date)),
-                ...scopeOpeningFlows(drillMembers, transactions)
+                ...scopeOpeningFlows(drillMembers, transactions, conversionAt ?? undefined)
                   .filter(o => inWindow(new Date(`${o.day}T00:00:00Z`)))
                   .map(o => ({
                     transactionId: `opening:${o.accountId}`,
@@ -1514,9 +1554,9 @@ function InvestmentsView() {
               </div>
               <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 mt-3">
                 {([
-                  ['Started at', formatCurrency(performance.startValue), ''],
-                  ['Put in', formatCurrency(performance.moneyIn), ''],
-                  ['Taken out', formatCurrency(performance.moneyOut), ''],
+                  ['Started at', `${scopeApprox}${formatCurrency(performance.startValue)}`, ''],
+                  ['Put in', `${scopeApprox}${formatCurrency(performance.moneyIn)}`, ''],
+                  ['Taken out', `${scopeApprox}${formatCurrency(performance.moneyOut)}`, ''],
                   ['Gain', performance.gain.greaterThan(0)
                     ? `+${formatCurrency(performance.gain)}`
                     : formatCurrency(performance.gain),
@@ -1524,7 +1564,7 @@ function InvestmentsView() {
                     : performance.gain.greaterThan(0)
                       ? 'text-green-600 dark:text-green-400'
                       : 'text-red-600 dark:text-red-400'],
-                  ['Ended at', formatCurrency(performance.endValue), ''],
+                  ['Ended at', `${scopeApprox}${formatCurrency(performance.endValue)}`, ''],
                 ] as const).map(([label, figure, colour]) => (
                   <div key={label}>
                     <p className="text-label uppercase tracking-wider text-gray-500 dark:text-gray-400">{label}</p>

--- a/src/utils/__tests__/currencyAggregationCensus.test.ts
+++ b/src/utils/__tests__/currencyAggregationCensus.test.ts
@@ -53,8 +53,9 @@ const LEDGER: Record<string, Partial<Record<(typeof PRIMITIVES)[number], Status>
   'src/utils/portfolioSummary.ts': {
     buildNetWorthSnapshots: 'converts',
     buildPortfolioHistory: 'converts',
-    // portfolio value/allocation/returns — audit P2, awaiting its phase.
-    calculateTotalBalance: 'native-known',
+    // The Investments chain converted 23 Aug: value at today's factors,
+    // contributions at their own dates, per-member at the summing.
+    calculateTotalBalance: 'converts',
   },
 
   // ── converted surfaces ──

--- a/src/utils/holdingAllocation.ts
+++ b/src/utils/holdingAllocation.ts
@@ -62,7 +62,13 @@ export const CASH_SLICE_LABEL = 'Cash';
 
 export function buildHoldingAllocation(
   holdings: readonly InvestmentHolding[],
-  lines: readonly PortfolioLine[]
+  lines: readonly PortfolioLine[],
+  /**
+   * Units-per-£1 factor for a holding's own currency at today's rates, or
+   * null to count native (the caller's disclosure then owns saying so).
+   * Currency-keyed, not account-keyed: a holding's currency is its listing's.
+   */
+  rateFor?: (currency: string) => DecimalInstance | null
 ): HoldingAllocation {
   const bySymbol = new Map<string, HoldingAllocationSlice>();
   let unpricedCount = 0;
@@ -75,18 +81,25 @@ export function buildHoldingAllocation(
     }
     if (holding.marketValue.lessThanOrEqualTo(0)) continue;
 
+    // Into the display currency where a rate exists (the Investments chain,
+    // 23 Aug): a dollar-listed holding merging by ticker into a sterling
+    // ring was mixed units in one slice. Native where no rate can be had —
+    // the caller's ≈/notes own saying so.
+    const factor = rateFor?.(holding.currency) ?? null;
+    const marketValue = factor ? holding.marketValue.times(factor) : holding.marketValue;
+
     // Apple in an ISA and Apple in a dealing account are ONE position. The
     // symbol is the identity; the name is only what to print, and two rows for
     // the same ticker can spell it differently.
     const key = (holding.symbol || holding.name).trim().toUpperCase();
     const existing = bySymbol.get(key);
     if (existing) {
-      existing.value = existing.value.plus(holding.marketValue);
+      existing.value = existing.value.plus(marketValue);
     } else {
       bySymbol.set(key, {
         key,
         label: holding.name?.trim() || holding.symbol,
-        value: holding.marketValue
+        value: marketValue
       });
     }
   }

--- a/src/utils/portfolioPerformance.test.ts
+++ b/src/utils/portfolioPerformance.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { computePortfolioPerformance, scopeValueAt } from './portfolioPerformance';
+import { toDecimal } from './decimal';
 import type { Account, Category, Transaction } from '../types';
 
 /**
@@ -222,5 +223,62 @@ describe('scopeValueAt — the drill\'s per-date valuation', () => {
     expect(scopeValueAt([INV], rows, new Date('2025-02-01T00:00:00Z')).toNumber()).toBe(1_000);
     expect(scopeValueAt([INV], rows, new Date('2025-03-01T00:00:00Z')).toNumber()).toBe(10_000);
     expect(scopeValueAt([INV], rows, new Date('2025-12-31T00:00:00Z')).toNumber()).toBe(10_500);
+  });
+});
+
+/**
+ * THE DATED CONVERSION SEAM (the Investments chain, 23 Aug). The decisive
+ * case is FX DRIFT: a dollar balance held across a rate move changes its
+ * sterling value with NO transaction, and that change must land in gain and
+ * TWR — a sterling-measured portfolio really did earn or lose it. Flows
+ * convert at their own day: the pounds that actually moved.
+ * Every figure here is invented; the repo is public.
+ */
+describe('computePortfolioPerformance — the dated conversion seam', () => {
+  const USD_INV = portfolio('acc-usd-inv', { currency: 'USD' });
+  // Two dollars to the pound until June 2025, four after — the pound
+  // strengthens, so a held dollar balance loses sterling value.
+  const conversionAt = (date: Date) => ({
+    factors: new Map([[USD_INV.id, toDecimal(date < new Date(2025, 5, 1) ? 0.5 : 0.25)]]),
+    unconverted: [] as string[],
+  });
+
+  const LEDGER = [
+    transferIn(USD_INV.id, '2025-01-10', 1000, EXTERNAL.id), // $1,000 in at £0.50/$ → £500 flow
+  ];
+
+  it('books FX drift on held money as (negative) gain, not as a flow', () => {
+    const result = computePortfolioPerformance({
+      memberAccounts: [USD_INV],
+      transactions: LEDGER,
+      transactionSplits: [],
+      categories: CATEGORIES,
+      range: { from: null, to: null },
+      now: new Date('2025-12-31T00:00:00Z'),
+      conversionAt,
+    });
+    // End value: $1,000 at December's £0.25/$ = £250.
+    expect(result.endValue.toNumber()).toBe(250);
+    // The January flow moved £500 of actual money.
+    expect(result.moneyIn.toNumber()).toBe(500);
+    // The £250 fall is the currency's doing — gain, never a flow.
+    expect(result.gain.toNumber()).toBe(-250);
+    // TWR sees the same halving: a −0.5 fraction (−50%) over the period.
+    expect(pct(result.twrPeriod)).toBeCloseTo(-0.5, 10);
+  });
+
+  it('values a cutoff at the cutoff day\'s own rate', () => {
+    expect(
+      scopeValueAt([USD_INV], LEDGER, new Date('2025-03-01T00:00:00Z'), conversionAt).toNumber()
+    ).toBe(500);
+    expect(
+      scopeValueAt([USD_INV], LEDGER, new Date('2025-09-01T00:00:00Z'), conversionAt).toNumber()
+    ).toBe(250);
+  });
+
+  it('without the seam every figure is native — unchanged behaviour', () => {
+    const result = compute([USD_INV], LEDGER, { from: null, to: null });
+    expect(result.endValue.toNumber()).toBe(1000);
+    expect(result.gain.toNumber()).toBe(0);
   });
 });

--- a/src/utils/portfolioPerformance.ts
+++ b/src/utils/portfolioPerformance.ts
@@ -5,6 +5,7 @@ import { expandSplitTransactions } from './transactionSplits';
 import { resolveEffectiveOpeningDates } from './openingDates';
 import { counterpartyAccountId, transferCategoryAccounts } from './portfolioSummary';
 import { dayOf } from './plWindow';
+import type { NetWorthConversion } from './netWorthSeries';
 
 /**
  * PORTFOLIO PERFORMANCE, the way the industry measures it — both ways.
@@ -61,6 +62,16 @@ export interface PortfolioPerformanceInput {
   /** Null/undefined bounds mean "from the beginning" / "until now". */
   range: { from?: Date | null; to?: Date | null };
   now?: Date;
+  /**
+   * The dated conversion seam (the Investments chain, 23 Aug): the factors
+   * in force on a given date, from the same ECB history every other dated
+   * surface reads. VALUATIONS convert each account's native balance at the
+   * VALUATION day's rate — so FX movement on held money lands in gain and
+   * TWR, where a sterling-measured portfolio truly earns or loses it — and
+   * FLOWS convert at their own day's rate, the pounds that actually moved.
+   * Omitted, every figure is exactly what it always was: native units.
+   */
+  conversionAt?: (date: Date) => NetWorthConversion | null;
 }
 
 export interface PortfolioPerformance {
@@ -94,6 +105,31 @@ const DAYS_PER_YEAR = toDecimal('365.25');
 /** Local day string → a comparable time (UTC midnight of that day). */
 const dayTime = (day: string): number => Date.parse(`${day}T00:00:00Z`);
 
+/** 'YYYY-MM-DD' → local Date, never the ISO/UTC parse that moves a boundary. */
+const dayToDate = (day: string): Date => {
+  const [y, m, d] = day.split('-').map(Number);
+  return new Date(y, m - 1, d);
+};
+
+/**
+ * A per-day factor lookup over the dated seam, memoised by day — the walks
+ * below ask for the same day once per account.
+ */
+const factorLookup = (
+  conversionAt: ((date: Date) => NetWorthConversion | null) | undefined
+): ((accountId: string, day: string) => DecimalInstance | null) => {
+  if (!conversionAt) return () => null;
+  const byDay = new Map<string, ReadonlyMap<string, DecimalInstance> | null>();
+  return (accountId, day) => {
+    let factors = byDay.get(day);
+    if (factors === undefined) {
+      factors = conversionAt(dayToDate(day))?.factors ?? null;
+      byDay.set(day, factors);
+    }
+    return factors?.get(accountId) ?? null;
+  };
+};
+
 /**
  * The scope's opening-balance flows — each account's dated opening lump, the
  * same resolution the performance walk counts as money in. Exposed so the
@@ -102,18 +138,22 @@ const dayTime = (day: string): number => Date.parse(`${day}T00:00:00Z`);
  */
 export function scopeOpeningFlows(
   memberAccounts: readonly Account[],
-  transactions: readonly Transaction[]
+  transactions: readonly Transaction[],
+  conversionAt?: (date: Date) => NetWorthConversion | null
 ): Array<{ accountId: string; day: string; amount: DecimalInstance }> {
   const memberIds = new Set(memberAccounts.map(a => a.id));
   const memberTransactions = transactions.filter(t => memberIds.has(t.accountId));
   const openingDates = resolveEffectiveOpeningDates([...memberAccounts], [...memberTransactions]);
+  const factorFor = factorLookup(conversionAt);
   const flows: Array<{ accountId: string; day: string; amount: DecimalInstance }> = [];
   for (const account of memberAccounts) {
     const opening = toDecimal(account.openingBalance ?? 0);
     if (opening.isZero()) continue;
     const effective = openingDates.get(account.id);
     if (effective === undefined) continue; // time-zero seed — never a window flow
-    flows.push({ accountId: account.id, day: dayOf(effective), amount: opening });
+    const day = dayOf(effective);
+    const factor = factorFor(account.id, day);
+    flows.push({ accountId: account.id, day, amount: factor ? opening.times(factor) : opening });
   }
   return flows;
 }
@@ -127,21 +167,35 @@ export function scopeOpeningFlows(
 export function scopeValueAt(
   memberAccounts: readonly Account[],
   transactions: readonly Transaction[],
-  date: Date
+  date: Date,
+  conversionAt?: (date: Date) => NetWorthConversion | null
 ): DecimalInstance {
   const memberIds = new Set(memberAccounts.map(a => a.id));
   const memberTransactions = transactions.filter(t => memberIds.has(t.accountId));
   const cutoff = dayOf(date);
   const openingDates = resolveEffectiveOpeningDates([...memberAccounts], [...memberTransactions]);
-  let value = ZERO;
+  const factorFor = factorLookup(conversionAt);
+  // Native per account first, ONE factor at the cutoff after: a balance held
+  // across a rate move changes its sterling value with no transaction, and
+  // only valuation-day conversion sees that.
+  const nativeById = new Map<string, DecimalInstance>();
   for (const account of memberAccounts) {
     const opening = toDecimal(account.openingBalance ?? 0);
     if (opening.isZero()) continue;
     const effective = openingDates.get(account.id);
-    if (effective === undefined || dayOf(effective) <= cutoff) value = value.plus(opening);
+    if (effective === undefined || dayOf(effective) <= cutoff) {
+      nativeById.set(account.id, (nativeById.get(account.id) ?? ZERO).plus(opening));
+    }
   }
   for (const row of memberTransactions) {
-    if (dayOf(row.date) <= cutoff) value = value.plus(toDecimal(row.amount));
+    if (dayOf(row.date) <= cutoff) {
+      nativeById.set(row.accountId, (nativeById.get(row.accountId) ?? ZERO).plus(toDecimal(row.amount)));
+    }
+  }
+  let value = ZERO;
+  for (const [accountId, native] of nativeById) {
+    const factor = factorFor(accountId, cutoff);
+    value = value.plus(factor ? native.times(factor) : native);
   }
   return value;
 }
@@ -152,15 +206,27 @@ export function computePortfolioPerformance(input: PortfolioPerformanceInput): P
 
   const memberIds = new Set(memberAccounts.map(a => a.id));
   const memberTransactions = transactions.filter(t => memberIds.has(t.accountId));
+  const factorFor = factorLookup(input.conversionAt);
 
   /**
-   * Every event that moves the scope's value, by local day:
-   * value[d] = the day's total change; flow[d] = the external part of it.
+   * Every event that moves the scope's value, PER ACCOUNT, by local day.
+   * Native deltas keep their account identity all the way to valuation,
+   * because a valuation at day D converts each account's native balance at
+   * D's OWN rate — a balance held across a rate move changes its sterling
+   * value with no transaction, and only valuation-day conversion sees that.
+   * Flows convert at their own day at bump time: they ARE points in time.
    */
-  const valueByDay = new Map<string, DecimalInstance>();
+  const nativeDeltaByDay = new Map<string, Map<string, DecimalInstance>>();
   const flowByDay = new Map<string, DecimalInstance>();
-  const bump = (map: Map<string, DecimalInstance>, day: string, amount: DecimalInstance): void => {
-    map.set(day, (map.get(day) ?? ZERO).plus(amount));
+  const bumpNative = (accountId: string, day: string, amount: DecimalInstance): void => {
+    const byDay = nativeDeltaByDay.get(accountId) ?? new Map<string, DecimalInstance>();
+    byDay.set(day, (byDay.get(day) ?? ZERO).plus(amount));
+    nativeDeltaByDay.set(accountId, byDay);
+  };
+  const bumpFlow = (accountId: string, day: string, native: DecimalInstance): void => {
+    const factor = factorFor(accountId, day);
+    const amount = factor ? native.times(factor) : native;
+    flowByDay.set(day, (flowByDay.get(day) ?? ZERO).plus(amount));
   };
 
   // Opening balances: money in, on their effective date. An account with no
@@ -173,8 +239,8 @@ export function computePortfolioPerformance(input: PortfolioPerformanceInput): P
     if (opening.isZero()) continue;
     const effective = openingDates.get(account.id);
     const day = effective === undefined ? TIME_ZERO : dayOf(effective);
-    bump(valueByDay, day, opening);
-    if (effective !== undefined) bump(flowByDay, day, opening);
+    bumpNative(account.id, day, opening);
+    if (effective !== undefined) bumpFlow(account.id, day, opening);
   }
 
   const categoryKinds = buildCategoryKindLookup([...categories]);
@@ -187,32 +253,57 @@ export function computePortfolioPerformance(input: PortfolioPerformanceInput): P
   for (const row of memberRows) {
     const day = dayOf(row.date);
     const amount = toDecimal(row.amount);
-    bump(valueByDay, day, amount);
+    bumpNative(row.accountId, day, amount);
     if (classifyFlow(row, categoryKinds) !== 'transfer') continue;
     const other = counterpartyAccountId(row, transactionsById, categoryAccounts);
     // Membership, not pair-equality: for a whole-portfolio scope a transfer
     // between two pairs is internal to the whole. Unidentified = external.
     if (other !== undefined && memberIds.has(other)) continue;
-    bump(flowByDay, day, amount);
+    bumpFlow(row.accountId, day, amount);
   }
 
-  const days = [...valueByDay.keys()].sort();
+  // Per-account prefix sums over each account's own sorted event days, so a
+  // valuation can ask "native balance as of D" with one binary search.
+  const nativeSeries = new Map<string, { days: string[]; prefixes: DecimalInstance[] }>();
+  for (const [accountId, byDay] of nativeDeltaByDay) {
+    const accountDays = [...byDay.keys()].sort();
+    const prefixes: DecimalInstance[] = [];
+    let running = ZERO;
+    for (const day of accountDays) {
+      running = running.plus(byDay.get(day) ?? ZERO);
+      prefixes.push(running);
+    }
+    nativeSeries.set(accountId, { days: accountDays, prefixes });
+  }
+  const nativeAsOf = (accountId: string, day: string): DecimalInstance => {
+    const series = nativeSeries.get(accountId);
+    if (!series || series.days.length === 0 || day < series.days[0]) return ZERO;
+    let lo = 0;
+    let hi = series.days.length - 1;
+    if (day >= series.days[hi]) return series.prefixes[hi];
+    while (lo < hi) {
+      const mid = Math.ceil((lo + hi) / 2);
+      if (series.days[mid] <= day) lo = mid;
+      else hi = mid - 1;
+    }
+    return series.prefixes[lo];
+  };
+
+  const days = [...new Set(
+    [...nativeDeltaByDay.values()].flatMap(byDay => [...byDay.keys()])
+  )].sort();
   const fromDay = range.from ? dayOf(range.from) : null;
   const toDay = dayOf(range.to ?? now);
 
-  /** Value at the END of `day` (inclusive walk). */
-  let running = ZERO;
-  const valueAtEndOf = new Map<string, DecimalInstance>();
-  for (const day of days) {
-    running = running.plus(valueByDay.get(day) ?? ZERO);
-    valueAtEndOf.set(day, running);
-  }
+  /** Value at the END of `day`: every account's native as of that day, each
+      converted at that day's own factor. */
   const valueAsOf = (day: string): DecimalInstance => {
-    // Last event day ≤ day. The list is sorted and short; linear is honest.
     let value = ZERO;
-    for (const eventDay of days) {
-      if (eventDay > day) break;
-      value = valueAtEndOf.get(eventDay) ?? value;
+    for (const accountId of nativeSeries.keys()) {
+      const native = nativeAsOf(accountId, day);
+      if (native.isZero()) continue;
+      const factor = factorFor(accountId, day);
+      value = value.plus(factor ? native.times(factor) : native);
     }
     return value;
   };

--- a/src/utils/portfolioSummary.test.ts
+++ b/src/utils/portfolioSummary.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { buildPortfolioSummary, buildPortfolioHistory } from './portfolioSummary';
 import { buildNetWorthConversion } from './netWorthSeries';
+import { toDecimal } from './decimal';
 import type { Account, Category, Transaction, TransactionSplit } from '../types';
 
 /**
@@ -397,5 +398,50 @@ describe('buildPortfolioHistory', () => {
       new Date(2026, 5, 30)
     );
     expect(native[native.length - 1].value).toBe(1200);
+  });
+});
+
+/**
+ * THE CURRENCY SEAMS (the Investments chain, 23 Aug): value converts at
+ * TODAY's factors — it is a current balance — and each contribution at its
+ * own date's factor, so total return is today's worth less the pounds
+ * actually put in. Every figure here is invented; the repo is public.
+ */
+describe('buildPortfolioSummary — the currency seams', () => {
+  const usdRoot = account({
+    id: 'inv-usd', name: 'Dollar Fund', type: 'investment',
+    currency: 'USD', openingBalance: 0, openingBalanceDate: new Date(2026, 0, 5),
+  });
+  const funding = {
+    id: 'c-1', accountId: 'inv-usd', date: new Date(2026, 0, 10), amount: 1000,
+    description: 'funding', category: 'tofrom-outside', type: 'transfer' as const,
+    transferAccountId: 'acc-outside',
+  };
+
+  it('values at today\'s factors, converts each contribution at its own date, and flags the ≈', () => {
+    const summary = buildPortfolioSummary({
+      accounts: [usdRoot],
+      transactions: [funding],
+      transactionSplits: [],
+      categories,
+      // Today: four dollars to the pound. The January contribution: two.
+      conversion: buildNetWorthConversion([usdRoot], { GBP: 1, USD: 4 }, 'GBP'),
+      flowConvert: () => toDecimal(0.5),
+    });
+    expect(summary.value.toNumber()).toBe(250);            // $1,000 at £0.25
+    expect(summary.netContributions.toNumber()).toBe(500); // $1,000 at £0.50, when it moved
+    expect(summary.totalReturn.toNumber()).toBe(-250);     // the currency's doing — return, honestly
+    expect(summary.holdsForeign).toBe(true);
+  });
+
+  it('without the seams the figures are native and unflagged — unchanged behaviour', () => {
+    const summary = buildPortfolioSummary({
+      accounts: [usdRoot],
+      transactions: [funding],
+      transactionSplits: [],
+      categories,
+    });
+    expect(summary.value.toNumber()).toBe(1000);
+    expect(summary.holdsForeign).toBe(false);
   });
 });

--- a/src/utils/portfolioSummary.ts
+++ b/src/utils/portfolioSummary.ts
@@ -3,7 +3,7 @@ import { toDecimal, sumDecimals, type DecimalInstance } from './decimal';
 import { toDecimalAccount, toDecimalTransaction } from './decimal-converters';
 import { calculateTotalBalance } from './calculations-decimal';
 import { buildTopLevelIdByAccountId, groupByTopLevelId } from './accountNesting';
-import { buildCategoryKindLookup, classifyFlow } from './incomeExpense';
+import { buildCategoryKindLookup, classifyFlow, type FlowFactorResolver } from './incomeExpense';
 import { expandSplitTransactions, type SplitExpandedTransaction } from './transactionSplits';
 import { buildNetWorthSnapshots, type NetWorthConversion, type NetWorthConversionByDate } from './netWorthSeries';
 import type { PeriodRange } from '../hooks/usePeriod';
@@ -118,6 +118,8 @@ export interface PortfolioSummary {
    */
   returnPercent: DecimalInstance | null;
   unattributedTransfers: UnattributedTransfers;
+  /** True when any conversion factor was applied — the ≈ gate. */
+  holdsForeign: boolean;
 }
 
 export interface PortfolioSummaryInput {
@@ -127,6 +129,19 @@ export interface PortfolioSummaryInput {
   /** Split lines, so a transfer leg inside a split is classified as one. */
   transactionSplits: readonly TransactionSplit[];
   categories: readonly Category[];
+  /**
+   * The currency seams (the Investments chain's conversion, 23 Aug). VALUE is
+   * a current balance, so it converts at TODAY's factors (`conversion` — the
+   * same per-account map every current-balance surface uses). CONTRIBUTIONS
+   * are historical flows, so each converts at ITS OWN date (`flowConvert` —
+   * the same resolver the report gallery sums through). Total return is then
+   * today's value less what was actually put in, measured in the pounds of
+   * the day it was put in — FX movement on held money lands in return, where
+   * a sterling-measured portfolio truly earns or loses it. Omitted, the
+   * arithmetic is exactly what it always was: native units.
+   */
+  conversion?: NetWorthConversion;
+  flowConvert?: FlowFactorResolver;
 }
 
 const ZERO = toDecimal(0);
@@ -214,8 +229,15 @@ export function buildPortfolioSummary(input: PortfolioSummaryInput): PortfolioSu
   const memberTransactions = transactions.filter(t => memberIds.has(t.accountId));
   const decimalTransactions = memberTransactions.map(toDecimalTransaction);
 
+  const factors = input.conversion?.factors;
+  let holdsForeign = false;
   const valueOf = (group: readonly Account[]): DecimalInstance =>
-    calculateTotalBalance(group.map(toDecimalAccount), decimalTransactions);
+    group.reduce((sum, member) => {
+      const native = calculateTotalBalance([toDecimalAccount(member)], decimalTransactions);
+      const factor = factors?.get(member.id);
+      if (factor) holdsForeign = true;
+      return sum.plus(factor ? native.times(factor) : native);
+    }, ZERO);
 
   const lineValues = roots.map(root => {
     const members = membersOf(root);
@@ -276,7 +298,11 @@ export function buildPortfolioSummary(input: PortfolioSummaryInput): PortfolioSu
     ) {
       continue;
     }
-    const amount = toDecimal(row.amount);
+    const flowFactor = input.flowConvert?.(row) ?? null;
+    if (flowFactor !== null) holdsForeign = true;
+    const amount = flowFactor !== null
+      ? toDecimal(row.amount).times(flowFactor)
+      : toDecimal(row.amount);
     netContributions = netContributions.plus(amount);
     const lineId = topLevelIdByAccountId.get(row.accountId) ?? row.accountId;
     contributionsByLine.set(lineId, (contributionsByLine.get(lineId) ?? ZERO).plus(amount));
@@ -317,6 +343,7 @@ export function buildPortfolioSummary(input: PortfolioSummaryInput): PortfolioSu
       ? totalReturn.dividedBy(netContributions).times(100)
       : null,
     unattributedTransfers: { count: unattributedCount, amount: unattributedAmount },
+    holdsForeign,
   };
 }
 


### PR DESCRIPTION
The audit's **P2** — the last big native island (owner: "please do", 23 Aug). With this, every money figure in the app either converts or stands behind a stated disclosure.

## The summary

Value is a current balance: each member converts at **today's factors** at the summing. Contributions are history: each converts at **its own date** through the same resolver the report gallery sums with. Total return is today's worth less the pounds actually put in — FX movement on held money lands in return, where a sterling-measured portfolio truly earns or loses it.

## The performance walk

Native deltas keep their account identity to the moment of valuation — per-account prefix sums, one factor at the **valuation day** — because a balance held across a rate move changes its sterling value with no transaction, and only valuation-day conversion sees that. Flows convert at their own day. TWR and MWR inherit both. The decisive spec: a held dollar balance across a rate halving books a −£250 gain, a −0.5 TWR fraction, and **nothing** in the flows.

## Holdings

A dollar-listed holding merging by ticker into a sterling ring was mixed units in one slice — slices convert by listing currency through the hook's new `rateFor`.

## One source on the page

A single conversion call over open **and closed** members feeds the chart, the tiles, both drills, the summary and the holdings ring. The Phase 0 disclosure retires for the ladder's top: *"≈ Balances converted at today's rates; money in and out at each day's ECB reference rate"*, degrading honestly to a partial-basis line while the history loads, and to the Phase 0 sentence when no rates exist. ≈ on the value tile and the Started/Put in/Taken out/Ended band when the scope actually holds foreign money.

Native path proven unchanged (all pre-existing portfolio suites pass untouched); the census ledger's last portfolio entry flips to `converts`. Verified live on the demo's dollar portfolio.

Every figure in the tests is invented; the repo is public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)