### PR TITLE
The balance reports convert on the identity's own terms — and the shares finally sum to one currency

### DIFF
--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -451,8 +451,15 @@ export function ImprovedDashboard() {
   // utils/accountDistribution). The card shows the slices a donut can carry;
   // the report behind it lists every account.
   const distribution = useMemo(
-    () => buildAccountDistribution(accounts, id => accountBalanceMap.get(id) ?? 0),
-    [accounts, accountBalanceMap]
+    // Converted through the same per-account factors the trio and the
+    // breakdown modal use (balance reports' conversion, 23 Aug), so a share
+    // of "together, your net worth" is a share of ONE currency.
+    () => buildAccountDistribution(accounts, id => {
+      const native = accountBalanceMap.get(id) ?? 0;
+      const factor = rowConversion?.factors.get(id);
+      return factor ? toDecimal(native).times(factor).toNumber() : native;
+    }),
+    [accounts, accountBalanceMap, rowConversion]
   );
   const pieData = distribution.slices;
 

--- a/src/pages/reports/AccountBalancesReport.tsx
+++ b/src/pages/reports/AccountBalancesReport.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { useApp } from '../../contexts/AppContextSupabase';
+import { useNetWorthConversion } from '../../hooks/useNetWorthConversion';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import ReportDrillModal, { type ReportDrillTarget } from '../../components/reports/ReportDrillModal';
 import { buildAccountBalanceReport, type AccountBalanceRow } from '../../utils/accountBalanceReport';
@@ -22,10 +23,16 @@ export default function AccountBalancesReport({ picker }: ReportViewProps): Reac
   const { formatCurrency } = useCurrencyDecimal();
   const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
 
+  // The dated seam (balance reports' conversion, 23 Aug): each movement at
+  // its own day's rate, openings at the window's start; null while the
+  // history is absent, when the totals stay native and the hub's disclosure
+  // says so.
+  const { conversionAt } = useNetWorthConversion(accounts, { range: { from: null, to: null } });
   const report = useMemo(
-    () => buildAccountBalanceReport(accounts, transactions, picker.range),
-    [accounts, transactions, picker.range]
+    () => buildAccountBalanceReport(accounts, transactions, picker.range, new Date(), conversionAt ?? undefined),
+    [accounts, transactions, picker.range, conversionAt]
   );
+  const approx = report.holdsForeign ? '≈ ' : '';
 
   const drillIntoAccount = (row: AccountBalanceRow): void => {
     const rows = transactions
@@ -57,7 +64,7 @@ export default function AccountBalancesReport({ picker }: ReportViewProps): Reac
           <p className="text-label uppercase tracking-wider font-medium text-gray-500 dark:text-gray-400">
             Total balance
           </p>
-          <p className="text-page font-bold mt-1">{money(report.netWorth)}</p>
+          <p className="text-page font-bold mt-1">{approx}{money(report.netWorth)}</p>
           <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">
             As at {report.asOf.toLocaleDateString(getDateLocale(), { day: 'numeric', month: 'long', year: 'numeric' })}
           </p>
@@ -65,13 +72,13 @@ export default function AccountBalancesReport({ picker }: ReportViewProps): Reac
         <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-line dark:border-gray-700">
           <p className="text-dense text-gray-500 uppercase tracking-wider font-medium">In credit</p>
           <p className="text-page font-semibold mt-1 text-primary dark:text-white">
-            {formatCurrency(report.assets)}
+            {approx}{formatCurrency(report.assets)}
           </p>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg p-6 border border-line dark:border-gray-700">
           <p className="text-dense text-gray-500 uppercase tracking-wider font-medium">Overdrawn / owed</p>
           <p className="text-page font-semibold mt-1 text-primary dark:text-white">
-            {formatCurrency(report.liabilities)}
+            {approx}{formatCurrency(report.liabilities)}
           </p>
         </div>
       </div>

--- a/src/pages/reports/AccountDistributionReport.tsx
+++ b/src/pages/reports/AccountDistributionReport.tsx
@@ -4,6 +4,9 @@ import { useApp } from '../../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import { PieChart, ResponsiveContainer } from '../../components/charts/DashboardCharts';
 import { categoricalColor, useCategoricalRamp } from '../../components/charts/chartColors';
+import { useNetWorthConversion } from '../../hooks/useNetWorthConversion';
+import ConvertedTotalNote from '../../components/ConvertedTotalNote';
+import { toDecimal } from '../../utils/decimal';
 import { computeAccountBalances } from '../../utils/accountBalances';
 import {
   ACCOUNT_DISTRIBUTION_REMAINDER_ID,
@@ -43,10 +46,24 @@ export default function AccountDistributionReport(): React.JSX.Element {
   // nothing checked, and exactly the drift the one-module rule removes.
   const ramp = useCategoricalRamp();
 
+  // A snapshot of NOW, so today's factors (the balance reports' conversion,
+  // 23 Aug): each balance converts before the shares are taken, so the
+  // footnote's claim — the shares sum to 100% across every account — is
+  // finally true of one currency. Native while no rate exists, and the note
+  // below says which state is in force.
+  const { conversion, provenance: ratesProvenance } = useNetWorthConversion(accounts);
   const distribution = useMemo(() => {
     const balances = computeAccountBalances(accounts, transactions, serverBalances);
-    return buildAccountDistribution(accounts, id => balances.get(id) ?? 0);
-  }, [accounts, transactions, serverBalances]);
+    return buildAccountDistribution(accounts, id => {
+      const native = balances.get(id) ?? 0;
+      const factor = conversion?.factors.get(id);
+      return factor ? toDecimal(native).times(factor).toNumber() : native;
+    });
+  }, [accounts, transactions, serverBalances, conversion]);
+  const holdsForeign = useMemo(
+    () => conversion !== null && conversion.factors.size > 0,
+    [conversion]
+  );
 
   /** Which colour each drawn slice got, so the table's swatches match the donut. */
   const sliceColours = useMemo(
@@ -81,7 +98,14 @@ export default function AccountDistributionReport(): React.JSX.Element {
               must be the one the Dashboard's headline shows — two totals for
               one page is the disagreement this report exists to prevent. */}
           <p className="text-label uppercase tracking-wider font-medium text-gray-500 dark:text-gray-400">Net worth</p>
-          <p className="text-page font-bold mt-1">{money(distribution.netWorth.toNumber())}</p>
+          <p className="text-page font-bold mt-1">{holdsForeign ? '≈ ' : ''}{money(distribution.netWorth.toNumber())}</p>
+          {conversion && (
+            <ConvertedTotalNote
+              provenance={conversion.factors.size > 0 ? ratesProvenance : null}
+              unconverted={conversion.unconverted}
+              displayCurrency={displayCurrency}
+            />
+          )}
           {/* What every share below is a share OF, said once. */}
           <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">Current balances — every share below is a contribution to this total</p>
         </div>
@@ -220,7 +244,7 @@ export default function AccountDistributionReport(): React.JSX.Element {
                   <td className={`px-4 py-3 text-body text-right font-bold tabular-nums ${
                     distribution.netWorth.lessThan(0) ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white'
                   }`}>
-                    {money(distribution.netWorth.toNumber())}
+                    {holdsForeign ? '≈ ' : ''}{money(distribution.netWorth.toNumber())}
                   </td>
                   <td className="px-4 py-3" />
                 </tr>

--- a/src/pages/reports/NetWorthStatementReport.tsx
+++ b/src/pages/reports/NetWorthStatementReport.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { useApp } from '../../contexts/AppContextSupabase';
+import { useNetWorthConversion } from '../../hooks/useNetWorthConversion';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import ReportDrillModal, { type ReportDrillTarget } from '../../components/reports/ReportDrillModal';
 import { buildAccountBalanceReport, type AccountBalanceRow } from '../../utils/accountBalanceReport';
@@ -24,10 +25,14 @@ export default function NetWorthStatementReport({ picker }: ReportViewProps): Re
   const { formatCurrency } = useCurrencyDecimal();
   const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
 
+  // The dated seam (balance reports' conversion, 23 Aug) — same terms as
+  // the Account Balances report, from the same util.
+  const { conversionAt } = useNetWorthConversion(accounts, { range: { from: null, to: null } });
   const report = useMemo(
-    () => buildAccountBalanceReport(accounts, transactions, picker.range),
-    [accounts, transactions, picker.range]
+    () => buildAccountBalanceReport(accounts, transactions, picker.range, new Date(), conversionAt ?? undefined),
+    [accounts, transactions, picker.range, conversionAt]
   );
+  const approx = report.holdsForeign ? '≈ ' : '';
 
   /** Which statement section each account sits under, e.g. "Savings". */
   const groupLabels = useMemo(() => {
@@ -147,9 +152,9 @@ export default function NetWorthStatementReport({ picker }: ReportViewProps): Re
           words became the override rather than the rule. Converting a surface
           is not permission to overwrite the words somebody chose for it. */}
       <NetWorthSummary
-        netWorth={money(report.netWorth)}
-        assets={formatCurrency(report.assets)}
-        liabilities={formatCurrency(report.liabilities)}
+        netWorth={`${approx}${money(report.netWorth)}`}
+        assets={`${approx}${formatCurrency(report.assets)}`}
+        liabilities={`${approx}${formatCurrency(report.liabilities)}`}
       />
 
       {/* As-at and change, in the caption voice the net-worth report uses for

--- a/src/pages/reports/reportRegistry.ts
+++ b/src/pages/reports/reportRegistry.ts
@@ -115,6 +115,9 @@ export const REPORTS: ReportDefinition[] = [
     group: 'what-i-have',
     icon: WalletIcon,
     usesPeriod: true,
+    // Totals convert on the per-day basis (each movement at its own day,
+    // openings at the window's start) — the hub's note states it.
+    currency: 'flows',
     component: lazyWithRecovery(() => import('./NetWorthStatementReport')),
   },
   {
@@ -139,6 +142,9 @@ export const REPORTS: ReportDefinition[] = [
     group: 'what-i-have',
     icon: LandmarkIcon,
     usesPeriod: true,
+    // Totals convert on the per-day basis (each movement at its own day,
+    // openings at the window's start) — the hub's note states it.
+    currency: 'flows',
     component: lazyWithRecovery(() => import('./AccountBalancesReport')),
   },
   {
@@ -151,6 +157,9 @@ export const REPORTS: ReportDefinition[] = [
     // March" to draw, so the hub's period picker is hidden rather than shown
     // governing nothing.
     usesPeriod: false,
+    // Converts at today's rates and carries its own ConvertedTotalNote — the
+    // current-balance treatment, not the flows basis.
+    currency: 'self',
     component: lazyWithRecovery(() => import('./AccountDistributionReport')),
   },
   {

--- a/src/utils/accountBalanceReport.test.ts
+++ b/src/utils/accountBalanceReport.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildAccountBalanceReport } from './accountBalanceReport';
+import { toDecimal } from './decimal';
 import type { Account, Transaction } from '../types';
 
 /** Synthetic fixtures only — no real accounts or amounts in this repo. */
@@ -168,5 +169,51 @@ describe('buildAccountBalanceReport', () => {
     const row = report.rows.find(r => r.accountId === 'acc-card');
     expect(row).toMatchObject({ opening: 0, moneyIn: 0, moneyOut: 200, change: -200, closing: -200 });
     expect(report.liabilities).toBe(200);
+  });
+});
+
+/**
+ * THE DATED CONVERSION SEAM (balance reports, 23 Aug): the table's contract
+ * is the accounting identity — opening + change = closing — so every column
+ * converts on the identity's own terms: each movement at its own day's rate,
+ * the opening column at the day the window opens. Rows stay native; only
+ * the totals wear the converted figures.
+ * Every figure here is invented; the repo is public.
+ */
+describe('buildAccountBalanceReport — the dated conversion seam', () => {
+  const usd = account({ id: 'acc-usd', name: 'Dollar Current', type: 'current', currency: 'USD' });
+  // Two dollars to the pound in January, four from February on.
+  const conversionAt = (date: Date) => ({
+    factors: new Map([['acc-usd', toDecimal(date < new Date(2026, 1, 1) ? 0.5 : 0.25)]]),
+    unconverted: [] as string[],
+  });
+  const rows: Transaction[] = [
+    txn({ id: 'pre', accountId: 'acc-usd', amount: 1000, date: new Date(2026, 0, 10) }),   // pre-window
+    txn({ id: 'in', accountId: 'acc-usd', amount: 400, date: new Date(2026, 1, 10) }),     // in-window
+  ];
+  const range = { from: new Date(2026, 1, 1), to: new Date(2026, 1, 28) };
+
+  it('converts each column at its basis and keeps the identity in the totals', () => {
+    const report = buildAccountBalanceReport([usd], rows, range, new Date(2026, 2, 1), conversionAt);
+    const row = report.rows[0];
+    // The row itself stays native, in its own currency.
+    expect(row.opening).toBe(1000);
+    expect(row.closing).toBe(1400);
+    // Opening at the window's opening day (31 Jan → £0.50/$): $1,000 = £500.
+    expect(row.openingConverted).toBe(500);
+    // The February movement at its own day (£0.25/$): $400 = £100.
+    expect(row.changeConverted).toBe(100);
+    // The identity holds in the converted figures the totals show.
+    expect(row.closingConverted).toBe(600);
+    expect(report.netWorth).toBe(600);
+    expect(report.openingNetWorth).toBe(500);
+    expect(report.holdsForeign).toBe(true);
+  });
+
+  it('without the seam every figure is native and unflagged — unchanged behaviour', () => {
+    const report = buildAccountBalanceReport([usd], rows, range);
+    expect(report.rows[0].closingConverted).toBe(1400);
+    expect(report.netWorth).toBe(1400);
+    expect(report.holdsForeign).toBe(false);
   });
 });

--- a/src/utils/accountBalanceReport.ts
+++ b/src/utils/accountBalanceReport.ts
@@ -1,6 +1,7 @@
 import type { Account, Transaction } from '../types';
 import type { PeriodRange } from '../hooks/usePeriod';
-import { toDecimal } from './decimal';
+import { dailyFactorLookup, type NetWorthConversion } from './netWorthSeries';
+import { toDecimal, type DecimalInstance } from './decimal';
 import { resolveEffectiveOpeningDates } from './openingDates';
 
 /**
@@ -32,6 +33,14 @@ export interface AccountBalanceRow {
   change: number;
   /** Balance at the end of the period. */
   closing: number;
+  /**
+   * The display-currency figures the group and report totals sum — equal to
+   * the native ones when nothing converted. The row's own printed figures
+   * stay native, in the account's own currency.
+   */
+  openingConverted: number;
+  changeConverted: number;
+  closingConverted: number;
   /** Transactions inside the period. */
   count: number;
 }
@@ -59,6 +68,8 @@ export interface AccountBalanceReport {
   change: number;
   /** The date the closing balances are stated at. */
   asOf: Date;
+  /** True when any conversion factor was applied — the ≈ gate. */
+  holdsForeign: boolean;
 }
 
 /** Presentation order and wording for account types. */
@@ -88,6 +99,10 @@ interface Accumulator {
   opening: ReturnType<typeof toDecimal>;
   moneyIn: ReturnType<typeof toDecimal>;
   moneyOut: ReturnType<typeof toDecimal>;
+  /** The same three in the display currency (equal when nothing converted). */
+  openingConverted: ReturnType<typeof toDecimal>;
+  moneyInConverted: ReturnType<typeof toDecimal>;
+  moneyOutConverted: ReturnType<typeof toDecimal>;
   count: number;
 }
 
@@ -95,11 +110,33 @@ export function buildAccountBalanceReport(
   accounts: Account[],
   transactions: Transaction[],
   range: PeriodRange,
-  now: Date = new Date()
+  now: Date = new Date(),
+  /**
+   * The dated conversion seam (the balance reports' conversion, 23 Aug).
+   * The table's contract is the accounting identity — opening + change =
+   * closing — so every column converts on the identity's own terms: each
+   * movement at ITS OWN day's rate, the opening column at the day the
+   * window opens (each lump at its own effective day on an all-time
+   * window). Rows stay native — they print their account's own currency —
+   * and only the group and report totals wear the converted figures.
+   * Omitted, every figure is exactly what it always was.
+   */
+  conversionAt?: (date: Date) => NetWorthConversion | null
 ): AccountBalanceReport {
   const asOf = range.to ?? now;
   const fromTime = range.from ? range.from.getTime() : null;
   const toTime = asOf.getTime();
+  const factorFor = dailyFactorLookup(conversionAt);
+  const dayKey = (d: Date): string =>
+    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  const openingBasisDay = fromTime !== null ? dayKey(new Date(fromTime - 86_400_000)) : null;
+  let holdsForeign = false;
+  const convert = (accountId: string, day: string, amount: DecimalInstance): DecimalInstance => {
+    const factor = factorFor(accountId, day);
+    if (factor === null) return amount;
+    holdsForeign = true;
+    return amount.times(factor);
+  };
 
   const openingDates = resolveEffectiveOpeningDates(accounts, transactions);
   const totals = new Map<string, Accumulator>();
@@ -108,6 +145,9 @@ export function buildAccountBalanceReport(
       opening: toDecimal(0),
       moneyIn: toDecimal(0),
       moneyOut: toDecimal(0),
+      openingConverted: toDecimal(0),
+      moneyInConverted: toDecimal(0),
+      moneyOutConverted: toDecimal(0),
       count: 0,
     });
   }
@@ -129,10 +169,22 @@ export function buildAccountBalanceReport(
     if (effTime !== null && effTime > toTime) continue; // not yet effective
     const insideWindow = fromTime !== null && effTime !== null && effTime >= fromTime;
     if (insideWindow) {
-      if (opening.greaterThanOrEqualTo(0)) accumulator.moneyIn = accumulator.moneyIn.plus(opening);
-      else accumulator.moneyOut = accumulator.moneyOut.plus(opening.abs());
+      const converted = convert(account.id, dayKey(new Date(effTime)), opening);
+      if (opening.greaterThanOrEqualTo(0)) {
+        accumulator.moneyIn = accumulator.moneyIn.plus(opening);
+        accumulator.moneyInConverted = accumulator.moneyInConverted.plus(converted);
+      } else {
+        accumulator.moneyOut = accumulator.moneyOut.plus(opening.abs());
+        accumulator.moneyOutConverted = accumulator.moneyOutConverted.plus(converted.abs());
+      }
     } else {
+      // The opening column values at the day the window opens; on an
+      // all-time window, at each lump's own effective day (the epoch's
+      // earliest rate carries back for the undated).
+      const basisDay = openingBasisDay
+        ?? (effTime !== null ? dayKey(new Date(effTime)) : '1999-01-04');
       accumulator.opening = accumulator.opening.plus(opening);
+      accumulator.openingConverted = accumulator.openingConverted.plus(convert(account.id, basisDay, opening));
     }
   }
 
@@ -147,11 +199,20 @@ export function buildAccountBalanceReport(
     const amount = toDecimal(transaction.amount);
     if (fromTime !== null && time < fromTime) {
       accumulator.opening = accumulator.opening.plus(amount);
+      accumulator.openingConverted = accumulator.openingConverted.plus(
+        convert(transaction.accountId, openingBasisDay ?? dayKey(new Date(time)), amount)
+      );
       continue;
     }
     accumulator.count += 1;
-    if (amount.greaterThanOrEqualTo(0)) accumulator.moneyIn = accumulator.moneyIn.plus(amount);
-    else accumulator.moneyOut = accumulator.moneyOut.plus(amount.abs());
+    const converted = convert(transaction.accountId, dayKey(new Date(time)), amount);
+    if (amount.greaterThanOrEqualTo(0)) {
+      accumulator.moneyIn = accumulator.moneyIn.plus(amount);
+      accumulator.moneyInConverted = accumulator.moneyInConverted.plus(converted);
+    } else {
+      accumulator.moneyOut = accumulator.moneyOut.plus(amount.abs());
+      accumulator.moneyOutConverted = accumulator.moneyOutConverted.plus(converted.abs());
+    }
   }
 
   const rows: AccountBalanceRow[] = accounts.map(account => {
@@ -159,9 +220,13 @@ export function buildAccountBalanceReport(
       opening: toDecimal(account.openingBalance ?? 0),
       moneyIn: toDecimal(0),
       moneyOut: toDecimal(0),
+      openingConverted: toDecimal(account.openingBalance ?? 0),
+      moneyInConverted: toDecimal(0),
+      moneyOutConverted: toDecimal(0),
       count: 0,
     };
     const change = accumulator.moneyIn.minus(accumulator.moneyOut);
+    const changeConverted = accumulator.moneyInConverted.minus(accumulator.moneyOutConverted);
     return {
       accountId: account.id,
       name: account.name,
@@ -172,6 +237,9 @@ export function buildAccountBalanceReport(
       moneyOut: accumulator.moneyOut.toNumber(),
       change: change.toNumber(),
       closing: accumulator.opening.plus(change).toNumber(),
+      openingConverted: accumulator.openingConverted.toNumber(),
+      changeConverted: changeConverted.toNumber(),
+      closingConverted: accumulator.openingConverted.plus(changeConverted).toNumber(),
       count: accumulator.count,
     };
   });
@@ -191,13 +259,15 @@ export function buildAccountBalanceReport(
       );
       const sum = (pick: (row: AccountBalanceRow) => number): number =>
         sorted.reduce((acc, row) => acc.plus(toDecimal(pick(row))), toDecimal(0)).toNumber();
+      // Totals sum the CONVERTED figures — the rows above them stay native
+      // in their own currencies, exactly as everywhere else in the app.
       return {
         key: label,
         label,
         rows: sorted,
-        opening: sum(row => row.opening),
-        change: sum(row => row.change),
-        closing: sum(row => row.closing),
+        opening: sum(row => row.openingConverted),
+        change: sum(row => row.changeConverted),
+        closing: sum(row => row.closingConverted),
       };
     })
     .sort((a, b) => orderOfLabel(a.label) - orderOfLabel(b.label));
@@ -207,11 +277,11 @@ export function buildAccountBalanceReport(
   let openingNetWorth = toDecimal(0);
   let netWorth = toDecimal(0);
   for (const row of rows) {
-    const closing = toDecimal(row.closing);
+    const closing = toDecimal(row.closingConverted);
     if (closing.greaterThan(0)) assets = assets.plus(closing);
     else liabilities = liabilities.plus(closing.abs());
     netWorth = netWorth.plus(closing);
-    openingNetWorth = openingNetWorth.plus(toDecimal(row.opening));
+    openingNetWorth = openingNetWorth.plus(toDecimal(row.openingConverted));
   }
 
   return {
@@ -221,6 +291,7 @@ export function buildAccountBalanceReport(
     liabilities: liabilities.toNumber(),
     netWorth: netWorth.toNumber(),
     openingNetWorth: openingNetWorth.toNumber(),
+    holdsForeign,
     change: netWorth.minus(openingNetWorth).toNumber(),
     asOf,
   };

--- a/src/utils/netWorthSeries.ts
+++ b/src/utils/netWorthSeries.ts
@@ -104,6 +104,32 @@ export interface NetWorthConversionByDate {
   unconverted: readonly string[];
 }
 
+/** 'YYYY-MM-DD' → local Date, never the ISO/UTC parse that moves a boundary. */
+const dayKeyToDate = (day: string): Date => {
+  const [y, m, d] = day.split('-').map(Number);
+  return new Date(y, m - 1, d);
+};
+
+/**
+ * A per-day factor lookup over a dated conversion, memoised by day — the
+ * walks that consume it ask for the same day once per account. Identity
+ * (always null) when no seam is passed, so callers keep one code path.
+ */
+export const dailyFactorLookup = (
+  conversionAt: ((date: Date) => NetWorthConversion | null) | undefined
+): ((accountId: string, day: string) => DecimalInstance | null) => {
+  if (!conversionAt) return () => null;
+  const byDay = new Map<string, ReadonlyMap<string, DecimalInstance> | null>();
+  return (accountId, day) => {
+    let factors = byDay.get(day);
+    if (factors === undefined) {
+      factors = conversionAt(dayKeyToDate(day))?.factors ?? null;
+      byDay.set(day, factors);
+    }
+    return factors?.get(accountId) ?? null;
+  };
+};
+
 const isDatedConversion = (
   c: NetWorthConversion | NetWorthConversionByDate
 ): c is NetWorthConversionByDate => typeof (c as NetWorthConversionByDate).at === 'function';

--- a/src/utils/portfolioPerformance.ts
+++ b/src/utils/portfolioPerformance.ts
@@ -5,7 +5,7 @@ import { expandSplitTransactions } from './transactionSplits';
 import { resolveEffectiveOpeningDates } from './openingDates';
 import { counterpartyAccountId, transferCategoryAccounts } from './portfolioSummary';
 import { dayOf } from './plWindow';
-import type { NetWorthConversion } from './netWorthSeries';
+import { dailyFactorLookup, type NetWorthConversion } from './netWorthSeries';
 
 /**
  * PORTFOLIO PERFORMANCE, the way the industry measures it — both ways.
@@ -105,31 +105,6 @@ const DAYS_PER_YEAR = toDecimal('365.25');
 /** Local day string → a comparable time (UTC midnight of that day). */
 const dayTime = (day: string): number => Date.parse(`${day}T00:00:00Z`);
 
-/** 'YYYY-MM-DD' → local Date, never the ISO/UTC parse that moves a boundary. */
-const dayToDate = (day: string): Date => {
-  const [y, m, d] = day.split('-').map(Number);
-  return new Date(y, m - 1, d);
-};
-
-/**
- * A per-day factor lookup over the dated seam, memoised by day — the walks
- * below ask for the same day once per account.
- */
-const factorLookup = (
-  conversionAt: ((date: Date) => NetWorthConversion | null) | undefined
-): ((accountId: string, day: string) => DecimalInstance | null) => {
-  if (!conversionAt) return () => null;
-  const byDay = new Map<string, ReadonlyMap<string, DecimalInstance> | null>();
-  return (accountId, day) => {
-    let factors = byDay.get(day);
-    if (factors === undefined) {
-      factors = conversionAt(dayToDate(day))?.factors ?? null;
-      byDay.set(day, factors);
-    }
-    return factors?.get(accountId) ?? null;
-  };
-};
-
 /**
  * The scope's opening-balance flows — each account's dated opening lump, the
  * same resolution the performance walk counts as money in. Exposed so the
@@ -144,7 +119,7 @@ export function scopeOpeningFlows(
   const memberIds = new Set(memberAccounts.map(a => a.id));
   const memberTransactions = transactions.filter(t => memberIds.has(t.accountId));
   const openingDates = resolveEffectiveOpeningDates([...memberAccounts], [...memberTransactions]);
-  const factorFor = factorLookup(conversionAt);
+  const factorFor = dailyFactorLookup(conversionAt);
   const flows: Array<{ accountId: string; day: string; amount: DecimalInstance }> = [];
   for (const account of memberAccounts) {
     const opening = toDecimal(account.openingBalance ?? 0);
@@ -174,7 +149,7 @@ export function scopeValueAt(
   const memberTransactions = transactions.filter(t => memberIds.has(t.accountId));
   const cutoff = dayOf(date);
   const openingDates = resolveEffectiveOpeningDates([...memberAccounts], [...memberTransactions]);
-  const factorFor = factorLookup(conversionAt);
+  const factorFor = dailyFactorLookup(conversionAt);
   // Native per account first, ONE factor at the cutoff after: a balance held
   // across a rate move changes its sterling value with no transaction, and
   // only valuation-day conversion sees that.
@@ -206,7 +181,7 @@ export function computePortfolioPerformance(input: PortfolioPerformanceInput): P
 
   const memberIds = new Set(memberAccounts.map(a => a.id));
   const memberTransactions = transactions.filter(t => memberIds.has(t.accountId));
-  const factorFor = factorLookup(input.conversionAt);
+  const factorFor = dailyFactorLookup(input.conversionAt);
 
   /**
    * Every event that moves the scope's value, PER ACCOUNT, by local day.


### PR DESCRIPTION
The audit's **P4** — the last conversion batch of the programme (owner: "please do", 23 Aug).

## The table's contract is the identity

`opening + change = closing` is what the Account Balances table asserts, so every column converts on the identity's own terms: each movement at **its own day's** ECB rate, the opening column at **the day the window opens** (each lump at its own effective day on an all-time window). The identity survives conversion — end-date valuation would break it. Rows stay native in their account's own currency; only the group and report totals wear the converted, ≈-marked figures. The per-day factor helper moves to `netWorthSeries` as the one shared implementation.

## The three reports

- **Account balances** and the **Net worth statement** — the audit's *worst manner*: a `NetWorthSummary` rendered with no provenance hint at all — flip to the registry's `'flows'` rung: the hub's basis note when the history is in force, the Phase 0 disclosure while degraded, ≈ on the statement's three figures.
- **Account distribution** is a snapshot of *now*, so it converts at **today's factors** — each balance before the shares are taken, making the footnote's "shares sum to 100% across every account" finally true of one currency. It self-describes (`'self'`) with the standard `ConvertedTotalNote`; the dashboard's distribution card converts through the same per-account factors it already held, so card and report cannot disagree.

Specs pin the identity surviving conversion and the unchanged native path. Verified live on all three surfaces.

Every figure in the tests is invented; the repo is public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)