### PR TITLE
The Plan P&L and the Calendar convert — the long tail's two real pages

### DIFF
--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -13,6 +13,9 @@ import { detectRecurring } from '../utils/recurringDetection';
 import { projectRecurringSchedule } from '../utils/recurringSchedule';
 import { dismissedKeys, recurringAnswerKey } from '../utils/suggestionDismissals';
 import { computeIncomeExpense, buildCategoryKindLookup, classifyFlow } from '../utils/incomeExpense';
+import { useFlowConvert } from '../hooks/useFlowConvert';
+import { useNetWorthConversion } from '../hooks/useNetWorthConversion';
+import { dailyFactorLookup } from '../utils/netWorthSeries';
 import { Modal, ModalBody } from '../components/common/Modal';
 import EditTransactionModal from '../components/EditTransactionModal';
 import type { Transaction } from '../types';
@@ -55,6 +58,12 @@ function CalendarView() {
     if (suggestionDismissalsStatus === 'idle') void refreshSuggestionDismissals();
   }, [suggestionDismissalsStatus, refreshSuggestionDismissals]);
   const { formatCurrency } = useCurrencyDecimal();
+  // The seams (the long tail's conversion, 23 Aug): day tiles convert each
+  // movement at its own day's rate; the running balance values each day's
+  // per-account natives at that day's rate. Native while the history is
+  // absent — the page's disclosure then stands.
+  const convert = useFlowConvert(accounts);
+  const { conversionAt, historical: flowsHistorical } = useNetWorthConversion(accounts, { range: { from: null, to: null } });
   const navigate = useNavigate();
   const location = useLocation();
   const [currentDate, setCurrentDate] = useState(new Date());
@@ -62,12 +71,6 @@ function CalendarView() {
   const year = currentDate.getFullYear();
   const month = currentDate.getMonth();
 
-  // Calculate total balance across all accounts
-  const totalOpeningBalance = useMemo(() => {
-    return accounts.reduce((sum, acc) => {
-      return sum + (acc.openingBalance ?? 0);
-    }, 0);
-  }, [accounts]);
 
   // Build calendar grid data
   const calendarData = useMemo(() => {
@@ -93,36 +96,44 @@ function CalendarView() {
       const dateKey = toDateKey(t.date);
       const existing = txByDate.get(dateKey) || { income: 0, expense: 0, count: 0 };
       existing.count++;
+      // Each movement at its own day's rate (native when no factor).
+      const factor = convert?.(t) ?? null;
+      const amount = factor !== null ? toDecimal(t.amount).times(factor) : toDecimal(t.amount);
       if (t.amount >= 0) {
-        existing.income = toDecimal(existing.income).plus(toDecimal(t.amount)).toNumber();
+        existing.income = toDecimal(existing.income).plus(amount).toNumber();
       } else {
-        existing.expense = toDecimal(existing.expense).plus(toDecimal(t.amount).abs()).toNumber();
+        existing.expense = toDecimal(existing.expense).plus(amount.abs()).toNumber();
       }
       txByDate.set(dateKey, existing);
     });
 
-    // Compute running balance day by day
-    // Sort all transactions chronologically
+    // The running balance, per-account and Decimal (float `+` retired with
+    // the native summing): natives accumulate chronologically, and each
+    // rendered day values every account's native at THAT day's own rate —
+    // a held foreign balance changes its sterling value with no transaction,
+    // and only day-of valuation sees it.
     const allSorted = [...transactions].sort((a, b) =>
       new Date(a.date).getTime() - new Date(b.date).getTime()
     );
-    const balanceByDate = new Map<string, number>();
-    let runningBal = totalOpeningBalance;
-    allSorted.forEach(t => {
-      runningBal += t.amount;
-      balanceByDate.set(toDateKey(t.date), runningBal);
-    });
-
-    // Fill in balances for dates with no transactions (carry forward)
-    const startOfMonth = new Date(year, month, 1);
-
-    // Find the last known balance before the month starts
-    let lastKnownBalance = totalOpeningBalance;
-    allSorted.forEach(t => {
-      if (new Date(t.date) < startOfMonth) {
-        lastKnownBalance = balanceByDate.get(toDateKey(t.date)) ?? lastKnownBalance;
+    const factorFor = dailyFactorLookup(conversionAt ?? undefined);
+    const natives = new Map<string, ReturnType<typeof toDecimal>>();
+    accounts.forEach(acc => natives.set(acc.id, toDecimal(acc.openingBalance ?? 0)));
+    const valueOn = (dateKey: string): number => {
+      let total = toDecimal(0);
+      for (const [accountId, native] of natives) {
+        const factor = factorFor(accountId, dateKey);
+        total = total.plus(factor ? native.times(factor) : native);
       }
-    });
+      return total.toNumber();
+    };
+    const startOfMonth = new Date(year, month, 1);
+    let cursor = 0;
+    // Everything before the month advances the natives silently.
+    while (cursor < allSorted.length && new Date(allSorted[cursor].date) < startOfMonth) {
+      const t = allSorted[cursor];
+      natives.set(t.accountId, (natives.get(t.accountId) ?? toDecimal(0)).plus(toDecimal(t.amount)));
+      cursor++;
+    }
 
     // Build grid: fill previous month days, current month, next month
     const days: DayData[] = [];
@@ -143,15 +154,19 @@ function CalendarView() {
     }
 
     // Current month days
-    let currentBalance = lastKnownBalance;
     for (let d = 1; d <= daysInMonth; d++) {
       const date = new Date(year, month, d);
       const dateKey = `${year}-${String(month + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
       const dayTx = txByDate.get(dateKey);
 
-      if (balanceByDate.has(dateKey)) {
-        currentBalance = balanceByDate.get(dateKey)!;
+      // Advance natives through this day, then value AT this day.
+      const endOfDay = new Date(year, month, d, 23, 59, 59, 999);
+      while (cursor < allSorted.length && new Date(allSorted[cursor].date) <= endOfDay) {
+        const t = allSorted[cursor];
+        natives.set(t.accountId, (natives.get(t.accountId) ?? toDecimal(0)).plus(toDecimal(t.amount)));
+        cursor++;
       }
+      const currentBalance = valueOn(dateKey);
 
       days.push({
         date,
@@ -182,7 +197,7 @@ function CalendarView() {
     }
 
     return days;
-  }, [transactions, year, month, totalOpeningBalance]);
+  }, [transactions, year, month, accounts, convert, conversionAt]);
 
   /**
    * THE FORWARD HALF (Design handover 17 Aug, §1 and §8 step 3): what is
@@ -307,7 +322,7 @@ function CalendarView() {
    * a movement count over the same window.
    */
   const windowSummary = useMemo(() => {
-    const flows = computeIncomeExpense(transactions, transactionSplits, categories, visibleWindow);
+    const flows = computeIncomeExpense(transactions, transactionSplits, categories, { ...visibleWindow, convert });
     const count = transactions.filter(t => {
       const time = new Date(t.date).getTime();
       return time >= visibleWindow.from.getTime() && time <= visibleWindow.to.getTime();
@@ -317,7 +332,7 @@ function CalendarView() {
       totalExpense: flows.expenses.toNumber(),
       totalTransactions: count,
     };
-  }, [transactions, transactionSplits, categories, visibleWindow]);
+  }, [transactions, transactionSplits, categories, visibleWindow, convert]);
 
   /**
    * THE WEEK, BY CATEGORY, split income from expenditure (owner, 18 Aug:
@@ -333,7 +348,7 @@ function CalendarView() {
 
   const weekBreakdown = useMemo(() => {
     if (view !== 'week') return null;
-    const flows = computeIncomeExpense(transactions, transactionSplits, categories, visibleWindow);
+    const flows = computeIncomeExpense(transactions, transactionSplits, categories, { ...visibleWindow, convert });
     const label = labeller;
     const grouped = (rows: typeof flows.incomeRows): Array<{ label: string; total: number }> => {
       const totals = new Map<string, ReturnType<typeof toDecimal>>();
@@ -351,7 +366,7 @@ function CalendarView() {
       uncategorizedIn: flows.uncategorizedIn.toNumber(),
       uncategorizedOut: flows.uncategorizedOut.toNumber(),
     };
-  }, [view, transactions, transactionSplits, categories, labeller, visibleWindow]);
+  }, [view, transactions, transactionSplits, categories, labeller, visibleWindow, convert]);
 
   /**
    * THE YEAR AS TWELVE MONTHS, each with its own income and expenditure,
@@ -363,12 +378,13 @@ function CalendarView() {
     if (view !== 'year') return null;
     return Array.from({ length: 12 }, (_, m) => {
       const flows = computeIncomeExpense(transactions, transactionSplits, categories, {
+        convert,
         from: new Date(year, m, 1),
         to: new Date(year, m + 1, 0, 23, 59, 59, 999),
       });
       return { month: m, income: flows.income.toNumber(), expense: flows.expenses.toNumber() };
     });
-  }, [view, transactions, transactionSplits, categories, year]);
+  }, [view, transactions, transactionSplits, categories, year, convert]);
 
   /**
    * THE DAY, TRANSACTION BY TRANSACTION (owner, 18 Aug: "in daily view…
@@ -439,6 +455,7 @@ function CalendarView() {
       // way the list can sum to the figure that was clicked (splits expanded,
       // refunds netting, exactly as the tile counted them).
       const flows = computeIncomeExpense(transactions, transactionSplits, categories, {
+        convert,
         from: drill.from, to: drill.to,
       });
       const rows =
@@ -486,7 +503,7 @@ function CalendarView() {
         if (ra !== -1 || rb !== -1) return (ra === -1 ? -1 : ra + 1) - (rb === -1 ? -1 : rb + 1);
         return b.total - a.total;
       });
-  }, [drill, transactions, transactionSplits, categories, categoryKinds, labeller]);
+  }, [drill, transactions, transactionSplits, categories, categoryKinds, labeller, convert]);
 
   /** The real editor, over whichever row was clicked in a day or a drill. */
   const [editing, setEditing] = useState<Transaction | null>(null);
@@ -564,10 +581,19 @@ function CalendarView() {
 
   return (
     <PageWrapper title="Calendar">
-      {/* Phase 0 (the disclosure ruling, 22 Aug §2): the month figures and
-          the running balance still sum native units — said until their
-          conversion phase. Nothing for a single-currency ledger. */}
-      <MixedCurrencyDisclosure className="mb-3" />
+      {/* The ladder (the long tail's conversion, 23 Aug): with the history
+          in force each movement converts at its own day and the running
+          balance values each day at that day's rate — the line says so;
+          while it is absent the totals stay native and the Phase 0
+          disclosure stands. Nothing for a single-currency ledger. */}
+      {flowsHistorical ? (
+        <p className="mb-3 text-dense text-gray-500 dark:text-gray-400" data-testid="calendar-rates-basis">
+          ≈ Converted at each day’s ECB reference rate. Weekends and holidays carry
+          the previous business day’s rate.
+        </p>
+      ) : (
+        <MixedCurrencyDisclosure className="mb-3" />
+      )}
       {/* Month summary bar — each figure tile is a DRILL into what made it
           up, the same popup the day cells open (owner, 19 Aug: "the
           'Income' / 'Expenditure' / 'Net' should be clickable"). */}

--- a/src/pages/Forecast.tsx
+++ b/src/pages/Forecast.tsx
@@ -13,6 +13,8 @@ import { ArrowDownIcon, ArrowUpIcon, ChevronDownIcon, ChevronRightIcon } from '.
 import { WholePoundsScope, WholePoundsToggle } from '../contexts/WholePoundsContext';
 import { DEPTH_LEVEL_1, DEPTH_LEVEL_2, DEPTH_LEVEL_2_STICKY } from '../styles/depthShading';
 import { dataPort } from '@data';
+import { useFlowConvert } from '../hooks/useFlowConvert';
+import { useNetWorthConversion } from '../hooks/useNetWorthConversion';
 import type { ForecastAdjustment, Transaction } from '../types';
 
 /**
@@ -104,6 +106,10 @@ function ForecastStatement(): React.JSX.Element {
     suggestionDismissals, suggestionDismissalsStatus, refreshSuggestionDismissals,
   } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
+  // The flows seam: per-row factors at each row's own date, undefined while
+  // the ECB history is absent (the totals then stay native, disclosed).
+  const convert = useFlowConvert(accounts);
+  const { historical: flowsHistorical } = useNetWorthConversion(accounts, { range: { from: null, to: null } });
 
   const [tab, setTab] = useState<'current' | 'forecast'>('current');
 
@@ -199,6 +205,7 @@ function ForecastStatement(): React.JSX.Element {
     const sides: Record<'in' | 'out', Map<string, BuildEntry>> = { in: new Map(), out: new Map() };
     let transfers = 0;
     let revaluations = 0;
+    let holdsForeign = false;
 
     // Keyed by IDS, never wordings — two groups or categories that happened
     // to share a name must not share a figure.
@@ -218,7 +225,13 @@ function ForecastStatement(): React.JSX.Element {
       const categoryKey = categoryId ?? UNFILED_LABEL;
       const category = entry.categories.get(categoryKey)
         ?? { categoryId, label: leafLabel, total: 0, perBucket: Array.from({ length: bucketCount }, () => 0), rows: [] };
-      const magnitude = toDecimal(row.amount).abs();
+      // The flows seam (the long tail's conversion, 23 Aug): each row at
+      // its own day's rate, through the same resolver every other flows
+      // surface sums with. Native while the history is absent — the page's
+      // disclosure then stands.
+      const factor = convert?.(row) ?? null;
+      if (factor !== null) holdsForeign = true;
+      const magnitude = (factor !== null ? toDecimal(row.amount).times(factor) : toDecimal(row.amount)).abs();
       category.total = toDecimal(category.total).plus(magnitude).toNumber();
       category.perBucket[bucket] = toDecimal(category.perBucket[bucket]).plus(magnitude).toNumber();
       category.rows.push(row);
@@ -314,8 +327,9 @@ function ForecastStatement(): React.JSX.Element {
       ),
       transfers,
       revaluations,
+      holdsForeign,
     };
-  }, [transactions, plWindow, categoryKinds, categoryById, sort]);
+  }, [transactions, plWindow, categoryKinds, categoryById, sort, convert]);
 
   const average = (total: number): number =>
     toDecimal(total).dividedBy(plWindow.buckets.length).toNumber();
@@ -339,9 +353,12 @@ function ForecastStatement(): React.JSX.Element {
   const cellText = (side: 'in' | 'out', value: number): string =>
     value === 0 ? '—' : flowText(side, value);
 
+  // ≈ when a conversion is actually inside (ruling §6.3) — the same gate the
+  // basis line renders under, so mark and line always agree.
+  const approx = statement.holdsForeign ? '≈ ' : '';
   const netText = (value: number): string =>
-    value === 0 ? formatCurrency(0)
-      : value > 0 ? `+${formatCurrency(value)}` : formatCurrency(value);
+    approx + (value === 0 ? formatCurrency(0)
+      : value > 0 ? `+${formatCurrency(value)}` : formatCurrency(value));
 
   const netLabel = statement.net >= 0 ? 'Net income' : 'Net expenditure';
   const netColour = statement.net === 0 ? 'text-gray-900 dark:text-white'
@@ -683,10 +700,19 @@ function ForecastStatement(): React.JSX.Element {
        also went — what that side shows is history, so it says Actuals. */
     <PageWrapper title="Plan">
       <div className="max-w-[1400px] mx-auto space-y-6">
-        {/* Phase 0 (the disclosure ruling, 22 Aug §2): the P&L's category and
-            bucket totals still sum native units — said until their conversion
-            phase. Nothing for a single-currency ledger. */}
-        <MixedCurrencyDisclosure />
+        {/* The ladder (the long tail's conversion, 23 Aug): with the ECB
+            history in force every figure converts at its row's own day and
+            the basis is said; while it is absent the totals stay native and
+            the Phase 0 disclosure stands. Nothing for a single-currency
+            ledger. */}
+        {flowsHistorical && statement.holdsForeign ? (
+          <p className="text-dense text-gray-500 dark:text-gray-400" data-testid="forecast-rates-basis">
+            ≈ Converted at each day’s ECB reference rate. Weekends and holidays carry
+            the previous business day’s rate.
+          </p>
+        ) : (
+          !flowsHistorical && <MixedCurrencyDisclosure />
+        )}
         <div className="flex flex-wrap items-center justify-between gap-3">
           {/* The tab, chosen the way the calendar chooses its view — a
               segmented control (owner, 19 Aug: "Lets have two tabs for now",

--- a/src/utils/__tests__/currencyAggregationCensus.test.ts
+++ b/src/utils/__tests__/currencyAggregationCensus.test.ts
@@ -70,7 +70,7 @@ const LEDGER: Record<string, Partial<Record<(typeof PRIMITIVES)[number], Status>
   // ── the audit's known native sums, phase-ordered in the ruling ──
   'src/hooks/useReportDataset.ts': { computeIncomeExpense: 'converts' },
   'src/components/dashboard/ImprovedDashboard.tsx': { computeIncomeExpense: 'converts' },
-  'src/pages/Calendar.tsx': { computeIncomeExpense: 'native-known' },
+  'src/pages/Calendar.tsx': { computeIncomeExpense: 'converts' },
   'src/pages/Categorisation.tsx': { computeIncomeExpense: 'native-known' },
   'src/pages/reports/PeriodComparisonReport.tsx': { computeIncomeExpense: 'converts' },
   'src/utils/categoryHealth.ts': { computeIncomeExpense: 'native-known' },


### PR DESCRIPTION
The currency programme's long tail, continued (owner: "please do", 23 Aug).

**The Plan P&L** — one accumulation point served every category, group, bucket and net figure, so one resolver there converts the whole statement: each row at its own day's ECB rate through the same seam every other flows surface uses. Net figures wear ≈ only when a conversion is actually inside; the Phase 0 line upgrades to the §6.2 basis sentence when the history is in force.

**The Calendar** — the day tiles convert each movement at its own day, and the running-balance line (previously a cross-account **float** walk) is now per-account Decimal natives valued at *each rendered day's* rate, so a held foreign balance's sterling drift shows on the day it happened. The month tiles and both drills thread the same resolver. Same three-state ladder replaces the Phase 0 mount.

The census ledger flips Calendar to `converts`. Still native behind stated disclosures: Categorisation, categoryHealth, the exports' totals and the small services — the tail's tail. Verified live on both pages.

Every figure in the tests is invented; the repo is public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)