### PR TITLE
fix(charts): tooltip item text wears the surface's own colour — a series colour is never text

### DIFF
--- a/src/components/CustomReportViewer.tsx
+++ b/src/components/CustomReportViewer.tsx
@@ -15,7 +15,7 @@ import {
   Legend,
 } from 'recharts';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
-import { capSeriesWithRemainder, categoricalColor, useCategoricalRamp } from './charts/chartColors';
+import { capSeriesWithRemainder, categoricalColor, useCategoricalRamp, useChartTooltipStyle, useChartTooltipItemStyle } from './charts/chartColors';
 import { formatDecimal } from '../utils/decimal-format';
 import type { CustomReport, ReportComponent } from './CustomReportBuilder';
 import { getDateLocale } from '../utils/dateFormatter';
@@ -69,6 +69,11 @@ export default function CustomReportViewer({
   // sit at the top of this file put an emerald and a red in a CATEGORICAL
   // list, inches from figures where those two hues mean income and expense.
   const ramp = useCategoricalRamp();
+  // The house tooltip surface — these three charts were the last still
+  // showing recharts' bare white box (glaring on a dark card), with item
+  // rows in whatever colour each series happened to be.
+  const chartTooltipStyle = useChartTooltipStyle();
+  const chartTooltipItemStyle = useChartTooltipItemStyle();
 
   const money = (v: number | string): string =>
     formatCurrency(typeof v === 'number' ? v : Number(v));
@@ -117,7 +122,7 @@ export default function CustomReportViewer({
                   <CartesianGrid strokeDasharray="3 3" stroke="rgba(107, 114, 128, 0.2)" />
                   <XAxis dataKey="label" tick={{ fill: '#6B7280', fontSize: 11 }} minTickGap={24} />
                   <YAxis tick={{ fill: '#6B7280', fontSize: 11 }} tickFormatter={compactTick} width={56} />
-                  <Tooltip formatter={money} />
+                  <Tooltip formatter={money} contentStyle={chartTooltipStyle} itemStyle={chartTooltipItemStyle} separator=": " />
                   <Legend />
                   {series.datasets.map((ds, i) => (
                     <Line
@@ -136,7 +141,7 @@ export default function CustomReportViewer({
                   <CartesianGrid strokeDasharray="3 3" stroke="rgba(107, 114, 128, 0.2)" />
                   <XAxis dataKey="label" tick={{ fill: '#6B7280', fontSize: 11 }} minTickGap={24} />
                   <YAxis tick={{ fill: '#6B7280', fontSize: 11 }} tickFormatter={compactTick} width={56} />
-                  <Tooltip formatter={money} />
+                  <Tooltip formatter={money} contentStyle={chartTooltipStyle} itemStyle={chartTooltipItemStyle} separator=": " />
                   <Legend />
                   {series.datasets.map((ds, i) => (
                     <Bar
@@ -177,7 +182,7 @@ export default function CustomReportViewer({
                       <Cell key={row.name} fill={categoricalColor(ramp, i)} />
                     ))}
                   </Pie>
-                  <Tooltip formatter={money} />
+                  <Tooltip formatter={money} contentStyle={chartTooltipStyle} itemStyle={chartTooltipItemStyle} separator=": " />
                 </RechartsPieChart>
               </ResponsiveContainer>
             </div>

--- a/src/components/charts/DashboardCharts.tsx
+++ b/src/components/charts/DashboardCharts.tsx
@@ -21,7 +21,7 @@ import {
   Cell
 } from 'recharts';
 import { formatDecimal } from '../../utils/decimal-format';
-import { categoricalColor, useCategoricalRamp, useChartTooltipStyle } from './chartColors';
+import { categoricalColor, useCategoricalRamp, useChartTooltipStyle, useChartTooltipItemStyle } from './chartColors';
 
 export { ResponsiveContainer };
 
@@ -85,6 +85,7 @@ export function BarChart({
   const ramp = useCategoricalRamp();
   const barFill = fill ?? ramp[0];
   const tooltipStyle = useChartTooltipStyle();
+  const tooltipItemStyle = useChartTooltipItemStyle();
   const formatValue = formatter ?? defaultTickFormatter;
   const summary = buildChartSummary(
     ariaLabel,
@@ -103,6 +104,7 @@ export function BarChart({
       />
       <Tooltip
         contentStyle={contentStyle ?? tooltipStyle}
+        itemStyle={tooltipItemStyle}
         separator=": "
         formatter={(value: number | string | Array<number | string>) => {
           const numeric = typeof value === 'number' ? value : Number(value);
@@ -151,6 +153,7 @@ export function PieChart<T extends PieDatum>({
   // 17 Aug §2.6). `separator` likewise: " : " with spaces is a library
   // default, not the house format.
   const tooltipStyle = useChartTooltipStyle();
+  const tooltipItemStyle = useChartTooltipItemStyle();
 
   // Recharts wants index-signature rows; keep the original datum reachable by
   // index so onClick hands back the caller's own object, not a copy.
@@ -185,6 +188,7 @@ export function PieChart<T extends PieDatum>({
       </Pie>
       <Tooltip
         contentStyle={contentStyle ?? tooltipStyle}
+        itemStyle={tooltipItemStyle}
         separator=": "
         formatter={(value: number | string | Array<number | string>) => {
           const numeric = typeof value === 'number' ? value : Number(value);

--- a/src/components/charts/__tests__/tooltipItemLegibility.test.ts
+++ b/src/components/charts/__tests__/tooltipItemLegibility.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Recharts colours each tooltip ITEM ROW with its series' own colour — it
+ * promotes a series colour to TEXT. Series colours are graphics colours,
+ * built for WCAG's 3:1 graphical-object bar, not the 4.5:1 text bar: on the
+ * dark tooltip bubble the semantic pair measures 4.34 and 3.36, and the
+ * ramp's dark-ground steps are mid navies that all but vanish there (the
+ * owner's category-donut hover, 23 Aug, was unreadable in dark mode).
+ *
+ * The rule (chartColors.useChartTooltipItemStyle): item text wears the
+ * tooltip surface's OWN text colour, every chart, no exceptions — a tooltip
+ * row already NAMES its series, and "colour groups the series, the label
+ * identifies it" is the standing house rule.
+ *
+ * Two clauses, both measured rather than remembered:
+ *  1. CENSUS — every recharts <Tooltip in src passes itemStyle, so the next
+ *     chart cannot silently reintroduce series-coloured text.
+ *  2. CONTRAST — the pinned item colour clears 4.5:1 on its own bubble in
+ *     both themes, so the pin itself can never regress.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import { ColorContrastChecker } from '../../../utils/color-contrast-checker';
+import { TOOLTIP_SURFACE } from '../chartColors';
+
+const SRC = resolve(process.cwd(), 'src');
+
+function tsxFilesUnder(dir: string): string[] {
+  return readdirSync(dir).flatMap(entry => {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      if (entry === 'node_modules' || entry === '__tests__') return [];
+      return tsxFilesUnder(path);
+    }
+    return entry.endsWith('.tsx') ? [path] : [];
+  });
+}
+
+interface TooltipSite {
+  file: string;
+  line: number;
+  /** The <Tooltip …> opening tag, through its closing angle bracket. */
+  tag: string;
+}
+
+/** Every recharts <Tooltip opening tag in src, with enough of the tag to inspect. */
+function rechartsTooltipSites(): TooltipSite[] {
+  const sites: TooltipSite[] = [];
+  for (const path of tsxFilesUnder(SRC)) {
+    const content = readFileSync(path, 'utf8');
+    if (!/from ['"]recharts['"]/.test(content)) continue;
+    let index = content.indexOf('<Tooltip');
+    while (index !== -1) {
+      // The character after must end the identifier — "<TooltipCard" is not
+      // recharts' Tooltip.
+      const next = content[index + '<Tooltip'.length];
+      if (next === undefined || /[\s/>]/.test(next)) {
+        // The tag runs to its self-closing `/>` — a bare `>` is not the end,
+        // because attribute values hold arrow functions (`formatter={v => …}`)
+        // whose `=>` would cut the tag off before later attributes.
+        const close = content.indexOf('/>', index);
+        sites.push({
+          file: relative(process.cwd(), path),
+          line: content.slice(0, index).split('\n').length,
+          tag: content.slice(index, close === -1 ? undefined : close + 2),
+        });
+      }
+      index = content.indexOf('<Tooltip', index + 1);
+    }
+  }
+  return sites;
+}
+
+describe('every recharts tooltip pins its item text (census)', () => {
+  const sites = rechartsTooltipSites();
+
+  it('the census sees the charts it exists for', () => {
+    // A refactor that moved every chart out of src/ would leave the clauses
+    // below vacuously green — this line makes that impossible to miss.
+    expect(sites.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('every <Tooltip passes itemStyle — series colours are never text', () => {
+    const bare = sites.filter(site => !site.tag.includes('itemStyle'));
+    expect(
+      bare.map(site => `${site.file}:${site.line}`),
+      'these tooltips let recharts colour item text with the series colour'
+    ).toEqual([]);
+  });
+
+  it('every <Tooltip passes contentStyle — no bare white recharts box', () => {
+    const bare = sites.filter(site => !site.tag.includes('contentStyle'));
+    expect(
+      bare.map(site => `${site.file}:${site.line}`),
+      'these tooltips render recharts’ unthemed white card'
+    ).toEqual([]);
+  });
+});
+
+describe('the pinned item colour is legible on its own bubble (measured)', () => {
+  for (const ground of ['light', 'dark'] as const) {
+    it(`${ground}: item text clears the 4.5:1 text bar on the ${ground} bubble`, () => {
+      const surface = TOOLTIP_SURFACE[ground];
+      const ratio = ColorContrastChecker.getContrastRatio(surface.color, surface.backgroundColor);
+      expect(ratio).toBeGreaterThanOrEqual(4.5);
+    });
+  }
+});

--- a/src/components/charts/chartColors.ts
+++ b/src/components/charts/chartColors.ts
@@ -233,26 +233,45 @@ export function useCategoricalRamp(): readonly string[] {
  * figure in a tooltip is money, so `tabular-nums` applies here the same as
  * everywhere else money is printed (P5).
  */
+export const TOOLTIP_SURFACE = {
+  dark: {
+    backgroundColor: '#1f2937', // gray-800
+    border: '1px solid #4b5563', // gray-600
+    color: '#f9fafb',
+  },
+  light: {
+    backgroundColor: '#ffffff',
+    border: '1px solid #e5e7eb', // gray-200 hairline
+    color: '#111827',
+  },
+} as const;
+
 export function useChartTooltipStyle(): React.CSSProperties {
-  const dark = useIsDarkGround();
-  const shared: React.CSSProperties = {
+  const surface = TOOLTIP_SURFACE[useIsDarkGround() ? 'dark' : 'light'];
+  return {
     borderRadius: '8px',
     fontSize: '0.75rem',
     fontVariantNumeric: 'tabular-nums',
+    ...surface,
   };
-  return dark
-    ? {
-        ...shared,
-        backgroundColor: '#1f2937', // gray-800
-        border: '1px solid #4b5563', // gray-600
-        color: '#f9fafb',
-      }
-    : {
-        ...shared,
-        backgroundColor: '#ffffff',
-        border: '1px solid #e5e7eb', // gray-200 hairline
-        color: '#111827',
-      };
+}
+
+/**
+ * Recharts colours each tooltip ITEM ROW with its series' own colour — which
+ * promotes a series colour to TEXT. Series colours are built for the 3:1
+ * graphics bar, not the 4.5:1 text bar: the semantic pair's own table above
+ * measures 4.34 and 3.36 on the dark bubble, and the ramp's dark-ground steps
+ * are mid navies that all but vanish on it (the owner's category-donut hover,
+ * 23 Aug, was unreadable). The house rule already covers this — "colour
+ * groups the series, the label identifies it" — and every tooltip row NAMES
+ * its series, so the colour was carrying nothing the name doesn't.
+ *
+ * Item text therefore wears the tooltip surface's own text colour, every
+ * chart, no exceptions — including the decomposition chart, whose rows are
+ * named too. tooltipItemLegibility.test.ts holds every <Tooltip> to this.
+ */
+export function useChartTooltipItemStyle(): React.CSSProperties {
+  return { color: TOOLTIP_SURFACE[useIsDarkGround() ? 'dark' : 'light'].color };
 }
 
 /**

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -13,7 +13,7 @@ import {
 } from 'recharts';
 import { useApp } from '../../../contexts/AppContextSupabase';
 import { useCurrencyDecimal } from '../../../hooks/useCurrencyDecimal';
-import { categoricalColor, MAX_CATEGORICAL_SERIES, useCategoricalRamp, SEMANTIC_SERIES, useChartTooltipStyle } from '../../charts/chartColors';
+import { categoricalColor, MAX_CATEGORICAL_SERIES, useCategoricalRamp, SEMANTIC_SERIES, useChartTooltipStyle, useChartTooltipItemStyle } from '../../charts/chartColors';
 import { singlePointDot } from '../../charts/singlePointDots';
 import { buildMonthlyTrend } from '../../../utils/monthlyTrend';
 import { buildNetWorthSnapshots, netWorthAxisTicks, netWorthPointToken, netWorthValueAxis } from '../../../utils/netWorthSeries';
@@ -85,6 +85,7 @@ export function NetWorthWidget({ picker, pin }: {
   // Recharts' default tooltip is black-on-white whatever the page's mode —
   // the themed style is the difference between a label and a glare in dark.
   const chartTooltipStyle = useChartTooltipStyle();
+  const chartTooltipItemStyle = useChartTooltipItemStyle();
 
   /*
    * THE LINE HAS TO SURVIVE THE GROUND IT IS DRAWN ON.
@@ -192,7 +193,7 @@ export function NetWorthWidget({ picker, pin }: {
               tick={{ fill: '#6B7280', fontSize: 10 }} tickFormatter={compactTick} width={44}
               {...netWorthValueAxis(snapshots.map(s => s.netWorth))}
             />
-            <Tooltip contentStyle={chartTooltipStyle} separator=": " formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
+            <Tooltip contentStyle={chartTooltipStyle} itemStyle={chartTooltipItemStyle} separator=": " formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
             <Line type="monotone" dataKey="netWorth" name="Net Worth" stroke={lineStroke} strokeWidth={2} dot={singlePointDot(snapshots, lineStroke)} isAnimationActive={false} />
           </LineChart>
         </ResponsiveContainer>
@@ -217,6 +218,7 @@ export function IncomeExpenseTrendWidget({ picker, pin }: {
   // Recharts' default tooltip is black-on-white whatever the page's mode —
   // the themed style is the difference between a label and a glare in dark.
   const chartTooltipStyle = useChartTooltipStyle();
+  const chartTooltipItemStyle = useChartTooltipItemStyle();
   const { range } = picker;
 
   const data = useMemo(() => {
@@ -279,7 +281,7 @@ export function IncomeExpenseTrendWidget({ picker, pin }: {
             <CartesianGrid strokeDasharray="3 3" stroke="rgba(107, 114, 128, 0.2)" />
             <XAxis dataKey="month" tick={{ fill: '#6B7280', fontSize: 10 }} minTickGap={32} />
             <YAxis tick={{ fill: '#6B7280', fontSize: 10 }} tickFormatter={compactTick} width={44} />
-            <Tooltip contentStyle={chartTooltipStyle} separator=": " formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
+            <Tooltip contentStyle={chartTooltipStyle} itemStyle={chartTooltipItemStyle} separator=": " formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
             <Line type="monotone" dataKey="income" name="Income" stroke={SEMANTIC_SERIES.income} strokeWidth={2} dot={singlePointDot(data, SEMANTIC_SERIES.income)} isAnimationActive={false} />
             <Line type="monotone" dataKey="expenses" name="Expenses" stroke={SEMANTIC_SERIES.expense} strokeWidth={2} dot={singlePointDot(data, SEMANTIC_SERIES.expense)} isAnimationActive={false} />
           </LineChart>
@@ -305,6 +307,7 @@ export function ExpenseCategoriesWidget({ picker, pin }: {
   // Recharts' default tooltip is black-on-white whatever the page's mode —
   // the themed style is the difference between a label and a glare in dark.
   const chartTooltipStyle = useChartTooltipStyle();
+  const chartTooltipItemStyle = useChartTooltipItemStyle();
   const { range } = picker;
   // The shared ramp — see charts/chartColors. The copy that used to live in
   // this file was byte-identical to three others and drifted from a fourth.
@@ -407,7 +410,7 @@ export function ExpenseCategoriesWidget({ picker, pin }: {
                     <Cell key={entry.name} fill={categoricalColor(ramp, index)} />
                   ))}
                 </Pie>
-                <Tooltip contentStyle={chartTooltipStyle} separator=": " formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
+                <Tooltip contentStyle={chartTooltipStyle} itemStyle={chartTooltipItemStyle} separator=": " formatter={(v: number | string) => formatCurrency(typeof v === 'number' ? v : Number(v))} />
               </RechartsPieChart>
             </ResponsiveContainer>
           </div>

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -55,7 +55,7 @@ import { buildHoldingAllocation } from '../utils/holdingAllocation';
 import { dataPort } from '@data';
 import type { InvestmentHolding } from '@data';
 import { fetchQuotes } from '../services/stockPriceService';
-import { capSeriesWithRemainder, categoricalColor, useCategoricalRamp, useChartTooltipStyle } from '../components/charts/chartColors';
+import { capSeriesWithRemainder, categoricalColor, useCategoricalRamp, useChartTooltipStyle, useChartTooltipItemStyle } from '../components/charts/chartColors';
 import { resolvePeriod } from '../hooks/usePeriod';
 import DatePicker from '../components/common/DatePicker';
 
@@ -826,6 +826,7 @@ function InvestmentsView() {
   // twin — positions seven and eight had drifted to a cyan and a lime.
   const ramp = useCategoricalRamp();
   const chartTooltipStyle = useChartTooltipStyle();
+  const chartTooltipItemStyle = useChartTooltipItemStyle();
 
   /*
    * NO INVESTMENT ACCOUNTS — but the WATCHLIST still opens.
@@ -1596,7 +1597,7 @@ function InvestmentsView() {
               />
               <Tooltip
                 formatter={(value) => formatCurrency(toDecimal(Number(value)))}
-                contentStyle={chartTooltipStyle} separator=": "
+                contentStyle={chartTooltipStyle} itemStyle={chartTooltipItemStyle} separator=": "
               />
               <Line 
                 type="monotone" 

--- a/src/pages/NetWorthReport.tsx
+++ b/src/pages/NetWorthReport.tsx
@@ -28,7 +28,7 @@ import { useNetWorthConversion } from '../hooks/useNetWorthConversion';
 import { useArrivalAction } from '../hooks/useArrivalFocus';
 import { resolveEffectiveOpeningDates } from '../utils/openingDates';
 import { TrendingUpIcon, ChevronRightIcon } from '../components/icons';
-import { useDecompositionSeries, useChartTooltipStyle } from '../components/charts/chartColors';
+import { useDecompositionSeries, useChartTooltipStyle, useChartTooltipItemStyle } from '../components/charts/chartColors';
 import type { DecompositionSeries } from '../components/charts/chartColors';
 import PeriodBar from '../components/PeriodBar';
 import { sectionTypeForAccount, ACCOUNT_SECTION_DEFINITIONS, OTHER_SECTION_DEFINITION } from '../utils/accountGrouping';
@@ -130,6 +130,7 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
   // can flip the ground under a mounted chart. The series does the same, and
   // for the same measured reason: the light navies are 1.08:1 on a dark card.
   const chartTooltipStyle = useChartTooltipStyle();
+  const chartTooltipItemStyle = useChartTooltipItemStyle();
   const decomposition = useDecompositionSeries();
   const navigate = useNavigate();
   const location = useLocation();
@@ -652,7 +653,7 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
                     on three other report pages. */}
                 <Tooltip
                   formatter={(value: number | string) => formatCurrency(typeof value === 'number' ? value : Number(value))}
-                  contentStyle={chartTooltipStyle} separator=": "
+                  contentStyle={chartTooltipStyle} itemStyle={chartTooltipItemStyle} separator=": "
                 />
                 {/* A legend distinguishes series; with one line there is
                     nothing to distinguish and the card title already names it

--- a/src/pages/reports/IncomeSpendingOverTimeReport.tsx
+++ b/src/pages/reports/IncomeSpendingOverTimeReport.tsx
@@ -20,7 +20,7 @@ import ReportCumulativeToggle from '../../components/reports/ReportCumulativeTog
 import UncategorisedReviewBand from '../../components/reports/UncategorisedReviewBand';
 import { buildMonthlyTrend } from '../../utils/monthlyTrend';
 import { toCumulativeTrend } from '../../utils/cumulativeSeries';
-import { SEMANTIC_SERIES, useChartTooltipStyle } from '../../components/charts/chartColors';
+import { SEMANTIC_SERIES, useChartTooltipStyle, useChartTooltipItemStyle } from '../../components/charts/chartColors';
 import { singlePointDot } from '../../components/charts/singlePointDots';
 import { toDecimal } from '../../utils/decimal';
 import { formatDecimal } from '../../utils/decimal-format';
@@ -61,6 +61,7 @@ export default function IncomeSpendingOverTimeReport({ picker, focus }: ReportVi
   const { formatCurrency } = useCurrencyDecimal();
   // Recharts' default tooltip is black-on-white whatever the mode.
   const chartTooltipStyle = useChartTooltipStyle();
+  const chartTooltipItemStyle = useChartTooltipItemStyle();
   const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
   const chartRef = useRef<HTMLDivElement>(null);
   // Lines or bars — same data, same drill-in; the choice is persisted.
@@ -218,7 +219,7 @@ export default function IncomeSpendingOverTimeReport({ picker, focus }: ReportVi
                 <XAxis dataKey="month" tick={{ fill: '#6B7280', fontSize: 12 }} minTickGap={24} />
                 <YAxis tick={{ fill: '#6B7280', fontSize: 12 }} tickFormatter={compactTick} width={70} />
                 <Tooltip
-                  contentStyle={chartTooltipStyle} separator=": "
+                  contentStyle={chartTooltipStyle} itemStyle={chartTooltipItemStyle} separator=": "
                   formatter={(value: number | string) =>
                     formatCurrency(typeof value === 'number' ? value : Number(value))
                   }

--- a/src/pages/reports/PeriodComparisonReport.tsx
+++ b/src/pages/reports/PeriodComparisonReport.tsx
@@ -7,7 +7,7 @@ import ReportAccountMultiSelect from '../../components/reports/ReportAccountMult
 import ReportDrillModal, { type ReportDrillTarget } from '../../components/reports/ReportDrillModal';
 import ReportExportBar from '../../components/reports/ReportExportBar';
 import UncategorisedReviewBand from '../../components/reports/UncategorisedReviewBand';
-import { SEMANTIC_SERIES, useChartTooltipStyle } from '../../components/charts/chartColors';
+import { SEMANTIC_SERIES, useChartTooltipStyle, useChartTooltipItemStyle } from '../../components/charts/chartColors';
 import { computeIncomeExpense } from '../../utils/incomeExpense';
 import {
   buildPeriodComparison,
@@ -62,6 +62,7 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
   const { formatCurrency } = useCurrencyDecimal();
   // Recharts' default tooltip is black-on-white whatever the mode.
   const chartTooltipStyle = useChartTooltipStyle();
+  const chartTooltipItemStyle = useChartTooltipItemStyle();
   const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
   const chartRef = useRef<HTMLDivElement>(null);
   const [basis, setBasis] = useState<ComparisonBasis>(() =>
@@ -356,7 +357,7 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
                       interval={0}
                     />
                     <Tooltip
-                  contentStyle={chartTooltipStyle} separator=": "
+                  contentStyle={chartTooltipStyle} itemStyle={chartTooltipItemStyle} separator=": "
                       formatter={(value: number | string) =>
                         formatCurrency(typeof value === 'number' ? value : Number(value))
                       }

--- a/src/pages/reports/SpendingByCategoryReport.tsx
+++ b/src/pages/reports/SpendingByCategoryReport.tsx
@@ -13,7 +13,7 @@ import { formatDecimal } from '../../utils/decimal-format';
 import { ARRIVAL_ROW_CLASS, useArrivalRowFocus } from '../../hooks/useArrivalFocus';
 import { PERIOD_LABELS } from '../../hooks/usePeriod';
 import type { ReportViewProps } from './types';
-import { categoricalColor, useCategoricalRamp, useChartTooltipStyle } from '../../components/charts/chartColors';
+import { categoricalColor, useCategoricalRamp, useChartTooltipStyle, useChartTooltipItemStyle } from '../../components/charts/chartColors';
 
 /**
  * "Spending by category" — where the money went, ranked.
@@ -43,6 +43,7 @@ export default function SpendingByCategoryReport({ picker, focus }: ReportViewPr
   const { formatCurrency } = useCurrencyDecimal();
   // Recharts' default tooltip is black-on-white whatever the mode.
   const chartTooltipStyle = useChartTooltipStyle();
+  const chartTooltipItemStyle = useChartTooltipItemStyle();
   const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
   const chartRef = useRef<HTMLDivElement>(null);
 
@@ -145,7 +146,7 @@ export default function SpendingByCategoryReport({ picker, focus }: ReportViewPr
                   ))}
                 </Pie>
                 <Tooltip
-                  contentStyle={chartTooltipStyle} separator=": "
+                  contentStyle={chartTooltipStyle} itemStyle={chartTooltipItemStyle} separator=": "
                   formatter={(value: number | string) =>
                     formatCurrency(typeof value === 'number' ? value : Number(value))
                   }

--- a/src/pages/reports/SpendingByPayeeReport.tsx
+++ b/src/pages/reports/SpendingByPayeeReport.tsx
@@ -12,7 +12,7 @@ import { formatDecimal } from '../../utils/decimal-format';
 import { PERIOD_LABELS } from '../../hooks/usePeriod';
 import type { ReportViewProps } from './types';
 import { preferences } from '../../services/preferencesService';
-import { categoricalColor, useCategoricalRamp, useChartTooltipStyle } from '../../components/charts/chartColors';
+import { categoricalColor, useCategoricalRamp, useChartTooltipStyle, useChartTooltipItemStyle } from '../../components/charts/chartColors';
 import { getDateLocale } from '../../utils/dateFormatter';
 
 /**
@@ -42,6 +42,7 @@ export default function SpendingByPayeeReport({ picker }: ReportViewProps): Reac
   const { formatCurrency } = useCurrencyDecimal();
   // Recharts' default tooltip is black-on-white whatever the mode.
   const chartTooltipStyle = useChartTooltipStyle();
+  const chartTooltipItemStyle = useChartTooltipItemStyle();
   const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
   const chartRef = useRef<HTMLDivElement>(null);
   const [side, setSide] = useState<'expense' | 'income'>(() =>
@@ -160,7 +161,7 @@ export default function SpendingByPayeeReport({ picker }: ReportViewProps): Reac
                   interval={0}
                 />
                 <Tooltip
-                  contentStyle={chartTooltipStyle} separator=": "
+                  contentStyle={chartTooltipStyle} itemStyle={chartTooltipItemStyle} separator=": "
                   formatter={(value: number | string) =>
                     formatCurrency(typeof value === 'number' ? value : Number(value))
                   }


### PR DESCRIPTION
## The defect (owner's dark-mode screenshot, 23 Aug)

The category donut's hover tooltip rendered its item row in the slice's own
colour — recharts' default promotes every series colour to TEXT. On the dark
bubble the ramp's mid-navy steps are barely legible; the semantic pair's own
measured table in chartColors.ts reads 4.34 and 3.36 there, under the 4.5:1
text bar those colours were never built for. The house rule already covers
it: colour groups the series, the label identifies it — and every tooltip
row names its series, so the colour carried nothing.

## The fix

- `chartColors.ts`: `TOOLTIP_SURFACE` shared constant; `useChartTooltipStyle`
  and the new `useChartTooltipItemStyle` both read it, so bubble and item
  text cannot drift apart
- every recharts `<Tooltip>` in src now passes `itemStyle` (14 sites across
  9 files) — including CustomReportViewer's three, which still rendered
  recharts' bare unthemed white box with no `contentStyle` at all
- uniform, no exceptions: the decomposition chart's rows are named too

## The guard

`tooltipItemLegibility.test.ts`:
- **census** — every `<Tooltip` in a recharts-importing file must pass
  `itemStyle` AND `contentStyle`; fails listing `file:line`. Probe-proven
  (stripping one site fails by name). The census also caught two sites my
  first sweep missed — the tag scanner originally cut off at a formatter's
  `=>` — and asserts it sees ≥10 sites so it can never go vacuously green
- **measured** — the pinned item colour clears 4.5:1 on its own bubble,
  both themes

## Verification
- Spec 5/5; probe shown above
- Live in the pane (dark, spending-by-category donut): item text computes
  `rgb(249,250,251)` on bubble `rgb(31,41,55)`
- Husky full gate on commit: build:check, lint, test:unit, coverage
  78.42% / 82.68% over the 75/80 floors

🤖 Generated with [Claude Code](https://claude.com/claude-code)