### PR TITLE
fix(reports): the spending donut folds past five, and legend labels are words again

### DIFF
--- a/src/components/CustomReportViewer.tsx
+++ b/src/components/CustomReportViewer.tsx
@@ -16,6 +16,7 @@ import {
 } from 'recharts';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { capSeriesWithRemainder, categoricalColor, useCategoricalRamp, useChartTooltipStyle, useChartTooltipItemStyle } from './charts/chartColors';
+import { legendText } from './charts/ChartLegendText';
 import { formatDecimal } from '../utils/decimal-format';
 import type { CustomReport, ReportComponent } from './CustomReportBuilder';
 import { getDateLocale } from '../utils/dateFormatter';
@@ -123,7 +124,7 @@ export default function CustomReportViewer({
                   <XAxis dataKey="label" tick={{ fill: '#6B7280', fontSize: 11 }} minTickGap={24} />
                   <YAxis tick={{ fill: '#6B7280', fontSize: 11 }} tickFormatter={compactTick} width={56} />
                   <Tooltip formatter={money} contentStyle={chartTooltipStyle} itemStyle={chartTooltipItemStyle} separator=": " />
-                  <Legend />
+                  <Legend formatter={legendText} />
                   {series.datasets.map((ds, i) => (
                     <Line
                       key={ds.label}
@@ -142,7 +143,7 @@ export default function CustomReportViewer({
                   <XAxis dataKey="label" tick={{ fill: '#6B7280', fontSize: 11 }} minTickGap={24} />
                   <YAxis tick={{ fill: '#6B7280', fontSize: 11 }} tickFormatter={compactTick} width={56} />
                   <Tooltip formatter={money} contentStyle={chartTooltipStyle} itemStyle={chartTooltipItemStyle} separator=": " />
-                  <Legend />
+                  <Legend formatter={legendText} />
                   {series.datasets.map((ds, i) => (
                     <Bar
                       key={ds.label}

--- a/src/components/charts/ChartLegendText.tsx
+++ b/src/components/charts/ChartLegendText.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import type { LegendProps } from 'recharts';
+
+/**
+ * Legend label text in the page's own text colour.
+ *
+ * Recharts' default legend colours each LABEL with its series colour — the
+ * same promotion of a graphics colour to text that the tooltips had (see
+ * useChartTooltipItemStyle). On the spending donut it read as "two labels in
+ * a lighter blue than the other six", which a reader parses as links or as
+ * emphasis; on light ground the ramp's lightest step is barely legible as
+ * words at all. The swatch is the graphic and keeps the series colour — the
+ * words identify, and identification is body text.
+ *
+ * Passed to recharts as `<Legend formatter={legendText} />`.
+ * tooltipItemLegibility.test.ts holds every <Legend to this (formatter or
+ * a fully custom `content`, which draws its own neutral text).
+ */
+export const legendText: NonNullable<LegendProps['formatter']> = (value) => (
+  <span className="text-xs text-gray-600 dark:text-gray-300">{String(value)}</span>
+);

--- a/src/components/charts/__tests__/categoricalRamp.test.ts
+++ b/src/components/charts/__tests__/categoricalRamp.test.ts
@@ -24,7 +24,7 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { ColorContrastChecker } from '../../../utils/color-contrast-checker';
-import { CATEGORICAL_AXIS, categoricalColor, categoricalRamp } from '../chartColors';
+import { CATEGORICAL_AXIS, MAX_CATEGORICAL_SERIES, capSeriesWithRemainder, categoricalColor, categoricalRamp } from '../chartColors';
 
 const AA_GRAPHICS = 3.0;
 const SURFACES_LIGHT = ['#ffffff', '#f8f9fb'] as const;
@@ -171,5 +171,40 @@ describe('the categorical ramp is the only chart palette', () => {
       const found = withoutComments(read(path)).match(PALETTE_SHAPE) ?? [];
       expect(found, `${path} declares a palette of its own: ${found.join(' ')}`).toEqual([]);
     }
+  });
+});
+
+describe('capSeriesWithRemainder — the fold a capped chart answers clicks with', () => {
+  // Every figure below is invented; the repo is public.
+  const items = [
+    { id: 'a', total: 500 },
+    { id: 'b', total: 400 },
+    { id: 'c', total: 300 },
+    { id: 'd', total: 200 },
+    { id: 'e', total: 100 },
+    { id: 'f', total: 50 },
+    { id: 'g', total: 25 },
+  ];
+  const cap = (list: typeof items) =>
+    capSeriesWithRemainder(list, i => i.total, i => i.id, count => `${count} smaller`);
+
+  it('folds everything past the ceiling into one named remainder', () => {
+    const rows = cap(items);
+    expect(rows.length).toBe(MAX_CATEGORICAL_SERIES);
+    expect(rows[rows.length - 1]).toMatchObject({ name: '3 smaller', value: 175 });
+  });
+
+  it('carries the caller’s own datum on every real slice, and none on the fold', () => {
+    const rows = cap(items);
+    // The `source` is what lets a capped ring still answer a click (drill by
+    // id) — and its absence is how a caller tells the fold from a slice.
+    expect(rows.slice(0, -1).map(r => r.source?.id)).toEqual(['a', 'b', 'c', 'd']);
+    expect(rows[rows.length - 1].source).toBeUndefined();
+  });
+
+  it('leaves an uncapped series whole, every slice with its source', () => {
+    const rows = cap(items.slice(0, 3));
+    expect(rows.map(r => r.name)).toEqual(['a', 'b', 'c']);
+    expect(rows.every(r => r.source !== undefined)).toBe(true);
   });
 });

--- a/src/components/charts/__tests__/tooltipItemLegibility.test.ts
+++ b/src/components/charts/__tests__/tooltipItemLegibility.test.ts
@@ -97,6 +97,35 @@ describe('every recharts tooltip pins its item text (census)', () => {
   });
 });
 
+describe('every recharts legend neutralises its label text (census)', () => {
+  // Recharts' default legend colours each LABEL with its series colour — the
+  // same promotion of a graphics colour to text the tooltip items had. Two of
+  // the spending donut's labels read as a second, lighter kind of text
+  // (Design, 23 Aug §3). A legend must either pass `formatter={legendText}`
+  // (ChartLegendText — neutral words, series-coloured swatch) or draw its own
+  // `content`, which owns its text colour outright.
+  it('every <Legend passes formatter or content', () => {
+    const sites: string[] = [];
+    for (const path of tsxFilesUnder(SRC)) {
+      const content = readFileSync(path, 'utf8');
+      if (!/from ['"]recharts['"]/.test(content)) continue;
+      let index = content.indexOf('<Legend');
+      while (index !== -1) {
+        const next = content[index + '<Legend'.length];
+        if (next === undefined || /[\s/>]/.test(next)) {
+          const close = content.indexOf('/>', index);
+          const tag = content.slice(index, close === -1 ? undefined : close + 2);
+          if (!tag.includes('formatter') && !tag.includes('content')) {
+            sites.push(`${relative(process.cwd(), path)}:${content.slice(0, index).split('\n').length}`);
+          }
+        }
+        index = content.indexOf('<Legend', index + 1);
+      }
+    }
+    expect(sites, 'these legends let recharts colour label text with the series colour').toEqual([]);
+  });
+});
+
 describe('the pinned item colour is legible on its own bubble (measured)', () => {
   for (const ground of ['light', 'dark'] as const) {
     it(`${ground}: item text clears the 4.5:1 text bar on the ${ground} bubble`, () => {

--- a/src/components/charts/chartColors.ts
+++ b/src/components/charts/chartColors.ts
@@ -151,8 +151,12 @@ export function capSeriesWithRemainder<T>(
   value: (item: T) => number,
   name: (item: T) => string,
   remainderLabel: (count: number) => string
-): Array<{ name: string; value: number }> {
-  const all = items.map((item) => ({ name: name(item), value: value(item) }));
+): Array<{ name: string; value: number; source?: T }> {
+  // `source` carries the caller's own datum on every REAL slice, so a capped
+  // chart can still answer a click (drill by id, open the account) — the
+  // remainder has no single source and carries none, which is also how a
+  // caller tells the fold apart from a slice.
+  const all = items.map((item) => ({ name: name(item), value: value(item), source: item }));
   if (all.length <= MAX_CATEGORICAL_SERIES) return all;
 
   const shown = all.slice(0, MAX_CATEGORICAL_SERIES - 1);

--- a/src/pages/reports/IncomeSpendingOverTimeReport.tsx
+++ b/src/pages/reports/IncomeSpendingOverTimeReport.tsx
@@ -21,6 +21,7 @@ import UncategorisedReviewBand from '../../components/reports/UncategorisedRevie
 import { buildMonthlyTrend } from '../../utils/monthlyTrend';
 import { toCumulativeTrend } from '../../utils/cumulativeSeries';
 import { SEMANTIC_SERIES, useChartTooltipStyle, useChartTooltipItemStyle } from '../../components/charts/chartColors';
+import { legendText } from '../../components/charts/ChartLegendText';
 import { singlePointDot } from '../../components/charts/singlePointDots';
 import { toDecimal } from '../../utils/decimal';
 import { formatDecimal } from '../../utils/decimal-format';
@@ -224,7 +225,7 @@ export default function IncomeSpendingOverTimeReport({ picker, focus }: ReportVi
                     formatCurrency(typeof value === 'number' ? value : Number(value))
                   }
                 />
-                <Legend />
+                <Legend formatter={legendText} />
                 {chartType === 'bar' ? (
                   <Bar dataKey="income" name={incomeSeriesName} fill={SEMANTIC_SERIES.income} radius={[3, 3, 0, 0]} cursor="pointer" isAnimationActive={false} onClick={handlePointClick('income')} />
                 ) : (

--- a/src/pages/reports/SpendingByCategoryReport.tsx
+++ b/src/pages/reports/SpendingByCategoryReport.tsx
@@ -13,7 +13,8 @@ import { formatDecimal } from '../../utils/decimal-format';
 import { ARRIVAL_ROW_CLASS, useArrivalRowFocus } from '../../hooks/useArrivalFocus';
 import { PERIOD_LABELS } from '../../hooks/usePeriod';
 import type { ReportViewProps } from './types';
-import { categoricalColor, useCategoricalRamp, useChartTooltipStyle, useChartTooltipItemStyle } from '../../components/charts/chartColors';
+import { capSeriesWithRemainder, categoricalColor, useCategoricalRamp, useChartTooltipStyle, useChartTooltipItemStyle } from '../../components/charts/chartColors';
+import { legendText } from '../../components/charts/ChartLegendText';
 
 /**
  * "Spending by category" — where the money went, ranked.
@@ -25,14 +26,11 @@ import { categoricalColor, useCategoricalRamp, useChartTooltipStyle, useChartToo
  * through to the transactions behind it.
  */
 
-/** Slices beyond this become hard to tell apart; the table still lists all. */
-const PIE_SLICES = 8;
-
 export default function SpendingByCategoryReport({ picker, focus }: ReportViewProps): React.JSX.Element {
-  // The shared ramp. Note it is five long per theme against PIE_SLICES of
-  // eight, so the last three slices repeat a colour — the stated cost of a
-  // single-hue ramp. The legend and tooltip name every slice, which is what
-  // actually identifies it.
+  // The shared ramp — five per theme, and the ring draws exactly five slices
+  // (capSeriesWithRemainder), so no slice ever repeats a colour. This chart
+  // used to draw eight with no remainder: a CLOSED ring showing roughly half
+  // the period's total, with three colours repeated (Design, 23 Aug §3).
   const ramp = useCategoricalRamp();
   const selection = useReportAccountSelection();
   // A slice clicked on the Dashboard's Expense Categories card names a
@@ -69,9 +67,16 @@ export default function SpendingByCategoryReport({ picker, focus }: ReportViewPr
 
   // The datum field is `categoryId`, NOT `key`: recharts spreads datum fields
   // onto React elements and a `key` field collides with React's reserved prop,
-  // silently breaking sector rendering.
+  // silently breaking sector rendering. The remainder slice has no categoryId
+  // — clicking it drills into the folded categories together (see below).
   const pieData = useMemo(
-    () => totals.slice(0, PIE_SLICES).map(({ key, name, value }) => ({ categoryId: key, name, value })),
+    () =>
+      capSeriesWithRemainder(
+        totals,
+        entry => entry.value,
+        entry => entry.name,
+        count => `${count} smaller categories`
+      ).map(({ name, value, source }) => ({ categoryId: source?.key, name, value })),
     [totals]
   );
 
@@ -80,6 +85,22 @@ export default function SpendingByCategoryReport({ picker, focus }: ReportViewPr
       title: `${name} — ${PERIOD_LABELS[picker.period]}`,
       bucket: 'expense',
       rows: flows.expenseRows.filter(t => t.category === categoryId),
+      total: value,
+    });
+  };
+
+  // The remainder is still a slice of real money, so it still answers a click
+  // ("click a slice for the transactions behind it" is the card's promise):
+  // the drill holds every FOLDED category's rows together — the categories in
+  // `totals` beyond the shown four, not every unshown row (a category netted
+  // to zero by refunds is listed nowhere and belongs behind no slice).
+  const drillIntoRemainder = (name: string, value: number): void => {
+    const shown = new Set(pieData.map(d => d.categoryId).filter(Boolean));
+    const folded = new Set(totals.map(t => t.key).filter(key => !shown.has(key)));
+    setDrill({
+      title: `${name} — ${PERIOD_LABELS[picker.period]}`,
+      bucket: 'expense',
+      rows: flows.expenseRows.filter(t => folded.has(t.category)),
       total: value,
     });
   };
@@ -138,11 +159,14 @@ export default function SpendingByCategoryReport({ picker, focus }: ReportViewPr
                   cursor="pointer"
                   onClick={(entry) => {
                     const datum = ((entry as { payload?: typeof pieData[number] })?.payload ?? entry) as typeof pieData[number];
-                    if (datum?.categoryId) drillIntoCategory(datum.categoryId, datum.name, datum.value);
+                    if (!datum) return;
+                    if (datum.categoryId) drillIntoCategory(datum.categoryId, datum.name, datum.value);
+                    else drillIntoRemainder(datum.name, datum.value);
                   }}
                 >
                   {pieData.map((entry, index) => (
-                    <Cell key={entry.categoryId} fill={categoricalColor(ramp, index)} />
+                    // The remainder has no categoryId; its label is unique.
+                    <Cell key={entry.categoryId ?? entry.name} fill={categoricalColor(ramp, index)} />
                   ))}
                 </Pie>
                 <Tooltip
@@ -151,7 +175,12 @@ export default function SpendingByCategoryReport({ picker, focus }: ReportViewPr
                     formatCurrency(typeof value === 'number' ? value : Number(value))
                   }
                 />
-                <Legend layout="vertical" align="right" verticalAlign="middle" />
+                {/* itemSorter: recharts' default ('value' — the LABEL, for a
+                    pie) alphabetises the legend, which floated "N smaller
+                    categories" above the real ones. A constant sorter keeps
+                    payload order: rank order, the fold last — the same order
+                    the ring is painted in. */}
+                <Legend layout="vertical" align="right" verticalAlign="middle" formatter={legendText} itemSorter={() => 0} />
               </RechartsPieChart>
             </ResponsiveContainer>
           </div>


### PR DESCRIPTION
## Design review 23 Aug §3

The category donut drew **eight slices with no remainder** — a closed ring
showing roughly half the period's total, with three ramp colours repeated —
while `capSeriesWithRemainder` already did this properly on Asset
Allocation. And two legend labels read as a second, lighter kind of text:
recharts' default legend colours each LABEL with its series colour, the same
promotion of a graphics colour to text the tooltips had (#398).

## The fix

- The donut draws `capSeriesWithRemainder`'s five: four ranked categories +
  **"N smaller categories"**, painted in ramp order so the fold sits at the
  ramp's quietest step (the §2.1 ruling, already pinned by test). The fold
  still answers a click — it drills the folded categories' rows together
  (exactly those in the ranked totals beyond the shown four; a category
  netted to zero by refunds is listed nowhere and belongs behind no slice)
- `capSeriesWithRemainder` now carries `source` on real slices (none on the
  fold) so a capped ring can answer clicks by id — contract-tested
- **`ChartLegendText.legendText`**: legend labels wear the page's own text
  colour; the series colour stays on the swatch. Applied to the donut, the
  income/spending chart (whose income green measured 3.38:1 on white as
  label text — its own file bans it as text), and CustomReportViewer's two
  default legends
- The donut's legend keeps payload order (`itemSorter` constant) — recharts'
  default sorts by label, which floated "9 smaller categories" to the top
- Census extended: every recharts `<Legend` must pass `formatter` or
  `content` — probe-proven to fail by name

## Verification
- 39/39 across the five affected suites; lint zero; tsc -b clean
- Live in the pane (dark, demo): five sectors; legend in rank order, fold
  last, neutral text; the fold's click opens "9 smaller categories — This
  month"; the React key warning the first draft introduced is fixed
  (`key={categoryId ?? name}`)
- Husky full gate on commit: build:check, lint, test:unit, coverage over
  floors

🤖 Generated with [Claude Code](https://claude.com/claude-code)