### PR TITLE
fix(reports): the uncategorised band is information, not an alarm

### DIFF
--- a/src/components/reports/UncategorisedReviewBand.test.tsx
+++ b/src/components/reports/UncategorisedReviewBand.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * The review band is INFORMATION, not an alarm (Design, 23 Aug §2).
+ *
+ * The first shipped draft carried five signals in one strip: an amber border
+ * and tint, a green figure, a red figure, a red-BORDERED box around the net —
+ * a piece of furniture nothing else in the app has — and an amber action link
+ * stacked above two blue ones, three routes to the same job in two colours.
+ * These specs pin the calm version: a neutral house card, the three figures
+ * in the money colours they would wear anywhere else with no box, a zero net
+ * in no colour at all, and every route in the one link colour.
+ *
+ * The flows are built the way the report pages build them
+ * (computeIncomeExpense over invented rows). Every figure below is invented;
+ * the repo is public.
+ */
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import UncategorisedReviewBand from './UncategorisedReviewBand';
+import { computeIncomeExpense } from '../../utils/incomeExpense';
+import type { Category, Transaction } from '../../types';
+
+// The three ways out open real working surfaces with their own suites; here
+// they only stand in for "a route exists".
+vi.mock('../TransferSweepModal', () => ({ default: () => null }));
+vi.mock('../BulkCategorizeModal', () => ({ default: () => null }));
+vi.mock('./ReportDrillModal', () => ({ default: () => null }));
+
+vi.mock('../../hooks/useCurrencyDecimal', () => ({
+  useCurrencyDecimal: () => ({
+    formatCurrency: (n: number) => `£${Math.abs(Number(n)).toFixed(2)}`,
+  }),
+}));
+
+const CATEGORIES: Category[] = [
+  { id: 'type-expense', name: 'Expense', type: 'expense', level: 'type', isSystem: true },
+];
+
+const txn = (over: Partial<Transaction> & { id: string }): Transaction => ({
+  date: new Date('2026-07-10'),
+  amount: -10,
+  description: 'synthetic row',
+  category: '',
+  accountId: 'acc-1',
+  type: 'expense',
+  cleared: false,
+  ...over,
+});
+
+const flowsOf = (transactions: Transaction[]) =>
+  computeIncomeExpense(transactions, [], CATEGORIES);
+
+const bandFor = (transactions: Transaction[]) => {
+  const { container } = render(
+    <UncategorisedReviewBand flows={flowsOf(transactions)} categories={CATEGORIES} />
+  );
+  return container;
+};
+
+describe('the uncategorised review band is information, not an alarm', () => {
+  const unfiled = [
+    txn({ id: 't-in', amount: 120, type: 'income' }),
+    txn({ id: 't-out', amount: -200, type: 'expense' }),
+  ];
+
+  it('wears the neutral house surface — no amber anywhere in the band', () => {
+    const container = bandFor(unfiled);
+    expect(container.innerHTML).not.toMatch(/amber/);
+  });
+
+  it('states the net in a money colour with NO box around it', () => {
+    const container = bandFor(unfiled);
+    const net = screen.getByText(/net out/);
+    expect(net.className).toContain('text-red-600');
+    // The bordered chip was furniture nothing else in the app has.
+    expect(net.className).not.toMatch(/border/);
+    expect(container.innerHTML).toContain('£120.00');
+    expect(container.innerHTML).toContain('£200.00');
+  });
+
+  it('a zero net wears no colour at all', () => {
+    bandFor([
+      txn({ id: 't-in', amount: 150, type: 'income' }),
+      txn({ id: 't-out', amount: -150, type: 'expense' }),
+    ]);
+    const zero = screen.getByText('nets to zero');
+    expect(zero.className).toContain('text-gray-500');
+    expect(zero.className).not.toMatch(/border|amber|red|green/);
+  });
+
+  it('all three routes to filing speak in the one link colour', () => {
+    bandFor(unfiled);
+    const review = screen.getByText('Click to review and categorise');
+    const sweep = screen.getByText(/match transfers automatically/);
+    const payee = screen.getByText(/categorise by payee/);
+    expect(review.className).toContain('text-blue-700');
+    for (const route of [sweep, payee]) {
+      expect(route.className).toContain('text-blue-700');
+    }
+  });
+
+  it('renders nothing at all when every row is filed', () => {
+    const { container } = render(
+      <UncategorisedReviewBand
+        flows={flowsOf([txn({ id: 't-filed', category: 'type-expense' })])}
+        categories={CATEGORIES}
+      />
+    );
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/src/components/reports/UncategorisedReviewBand.tsx
+++ b/src/components/reports/UncategorisedReviewBand.tsx
@@ -32,6 +32,15 @@ export default function UncategorisedReviewBand({
 
   return (
     <div className="space-y-2">
+      {/* NEUTRAL band, semantic figures, ONE link colour (Design, 23 Aug §2).
+          The first draft carried five signals in one strip — amber border and
+          tint, a green, a red, a red-BORDERED box around the net (a piece of
+          furniture nothing else in the app has), and an amber link over two
+          blue ones. The exclusion is information, not an alarm: the container
+          is the house card surface, the three figures keep the money colours
+          they'd have anywhere else (no box — the "net" label already sets the
+          figure apart), a zero net wears no colour at all, and all three
+          routes to the same job speak in the one link colour. */}
       <button
         type="button"
         onClick={() => setDrill({
@@ -40,9 +49,9 @@ export default function UncategorisedReviewBand({
           rows: flows.uncategorizedRows,
           total: null,
         })}
-        className="w-full flex flex-wrap items-center gap-x-4 gap-y-1 rounded-2xl border border-amber-300 dark:border-amber-600 bg-amber-50 dark:bg-amber-900/20 px-5 py-3 text-left hover:bg-amber-100 dark:hover:bg-amber-900/30 transition-colors"
+        className="w-full flex flex-wrap items-center gap-x-4 gap-y-1 rounded-2xl border border-line dark:border-gray-700 bg-white dark:bg-gray-800 px-5 py-3 text-left hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
       >
-        <span className="text-sm font-semibold text-amber-800 dark:text-amber-300">
+        <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
           {count.toLocaleString()} uncategorised transaction{count === 1 ? '' : 's'} excluded from these totals
         </span>
         {/* The money the report cannot see, in the app's money colours: in
@@ -55,29 +64,25 @@ export default function UncategorisedReviewBand({
           <span className="text-red-600 dark:text-red-400">
             {formatCurrency(flows.uncategorizedOut.toNumber())} out
           </span>
-          {/* The net wears a subtle bordered chip: it is the one figure that
-              says how far these totals could move, so it stands apart from
-              the two components it nets. */}
           {(() => {
             const net = flows.uncategorizedIn.minus(flows.uncategorizedOut);
             if (net.isZero()) {
+              // A zero asks for no attention, so it wears no colour.
               return (
-                <span className="px-2 py-0.5 rounded-md border border-amber-300 dark:border-amber-600 text-amber-700 dark:text-amber-400">
-                  nets to zero
-                </span>
+                <span className="text-gray-500 dark:text-gray-400">nets to zero</span>
               );
             }
-            const chip = net.isNegative()
-              ? 'border-red-300 dark:border-red-600/70 text-red-600 dark:text-red-400'
-              : 'border-green-300 dark:border-green-600/70 text-green-600 dark:text-green-400';
+            const tone = net.isNegative()
+              ? 'text-red-600 dark:text-red-400'
+              : 'text-green-600 dark:text-green-400';
             return (
-              <span className={`px-2 py-0.5 rounded-md border ${chip}`}>
+              <span className={tone}>
                 {formatCurrency(net.abs().toNumber())} net {net.isNegative() ? 'out' : 'in'}
               </span>
             );
           })()}
         </span>
-        <span className="ml-auto text-xs text-amber-700 dark:text-amber-400">
+        <span className="ml-auto text-xs text-blue-700 dark:text-blue-400">
           Click to review and categorise
         </span>
       </button>


### PR DESCRIPTION
## Design review 23 Aug §2

The band carried five signals in one strip: amber border and tint, a green
figure, a red figure, a **red-bordered box** around the net — a piece of
furniture nothing else in the app has — and an amber action link above two
blue ones (three routes to the same job, two colours).

## The fix (Design's suggested shape, taken whole)

- Neutral house card surface — the exclusion is information, not an alarm
- The three figures keep their money colours, **no box** — the "net" label
  already sets that figure apart
- A zero net wears no colour at all (a zero asks for no attention)
- All three routes to filing speak in the one link colour

## Verification
- `UncategorisedReviewBand.test.tsx` (new, 5/5): no amber anywhere, no
  border on the net, colourless zero, one link colour, nothing rendered
  when every row is filed. Flows built via the real `computeIncomeExpense`;
  every figure invented — the repo is public
- Lint zero; tsc -b clean; husky full gate on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)