### PR TITLE
style(dark): the six neither-category blues take their ruled families (§8)

### DIFF
--- a/src/components/LoadTestDataModal.tsx
+++ b/src/components/LoadTestDataModal.tsx
@@ -121,9 +121,12 @@ export default function LoadTestDataModal({ isOpen, onClose }: Props): React.JSX
             <p className="text-sm text-gray-700 dark:text-gray-300">
               {progress?.message ?? 'Working…'}
             </p>
+            {/* A progress fill is a MAGNITUDE: navy-400 on light, the
+                primary-action near-white on dark — the buttons' own
+                inversion, no invented blue (Design ruling, 23 Aug §8). */}
             <div className="h-2 w-full rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
               <div
-                className="h-full bg-[#1a2332] dark:bg-blue-600 transition-all duration-200"
+                className="h-full bg-navy-400 dark:bg-primary-action transition-all duration-200"
                 style={{ width: `${Math.round((progress?.fraction ?? 0) * 100)}%` }}
               />
             </div>

--- a/src/components/MsMoneyImportModal.tsx
+++ b/src/components/MsMoneyImportModal.tsx
@@ -138,7 +138,10 @@ export default function MsMoneyImportModal({ isOpen, onClose, onBackup, onExecut
           {/* ── Reading ──────────────────────────────────────────── */}
           {stage === 'reading' && (
             <div className="text-center py-10">
-              <div className="inline-block h-8 w-8 border-2 border-[#1a2332] dark:border-blue-500 border-t-transparent rounded-full animate-spin mb-4" />
+              {/* A spinner is motion, not a signal — neutral: line-strong on
+                  light, the focus-family slate on dark (Design ruling, 23 Aug
+                  §8). */}
+              <div className="inline-block h-8 w-8 border-2 border-line-strong dark:border-[#94a3b8] border-t-transparent rounded-full animate-spin mb-4" />
               <p className="text-gray-600 dark:text-gray-400">Reading {fileName}…</p>
             </div>
           )}
@@ -226,7 +229,7 @@ export default function MsMoneyImportModal({ isOpen, onClose, onBackup, onExecut
             <div className="py-8">
               <p className="text-center text-gray-700 dark:text-gray-300 mb-4">{progress.message}</p>
               <div className="h-2 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
-                <div className="h-full bg-[#1a2332] dark:bg-blue-600 transition-[width] duration-300"
+                <div className="h-full bg-navy-400 dark:bg-primary-action transition-[width] duration-300"
                   style={{ width: `${Math.round(progress.fraction * 100)}%` }} />
               </div>
               <p className="text-center text-xs text-gray-500 dark:text-gray-400 mt-3">

--- a/src/components/common/ImportProgress.tsx
+++ b/src/components/common/ImportProgress.tsx
@@ -76,11 +76,13 @@ export default function ImportProgress({
       >
         {percent === null ? (
           // Alive, but claiming nothing. Stilled for anyone who has asked the
-          // system for less motion.
-          <div className="h-full w-full bg-[#1a2332]/30 dark:bg-blue-500/30 animate-pulse motion-reduce:animate-none" />
+          // system for less motion. Magnitude colours (Design ruling, 23 Aug
+          // §8): navy-400 light, primary-action dark — the determinate fill's
+          // own pair, washed to 30% while the size is still unknown.
+          <div className="h-full w-full bg-navy-400/30 dark:bg-primary-action/30 animate-pulse motion-reduce:animate-none" />
         ) : (
           <div
-            className="h-full bg-[#1a2332] dark:bg-blue-500 transition-all"
+            className="h-full bg-navy-400 dark:bg-primary-action transition-all"
             style={{ width: `${percent}%` }}
           />
         )}

--- a/src/components/ui/ToggleSwitch.tsx
+++ b/src/components/ui/ToggleSwitch.tsx
@@ -43,7 +43,13 @@ const ToggleSwitch = forwardRef<HTMLButtonElement, ToggleSwitchProps>(function T
         aria-hidden="true"
         className={`relative inline-block h-6 w-11 shrink-0 rounded-full transition-colors duration-200 ease-in-out
           ${checked
-            ? 'bg-[#1a2332] dark:bg-blue-600'
+            // ON is SELECTED, so it takes the selected-state family (Design
+            // ruling, 23 Aug §8): navy-900 on light, the focus/selected slate
+            // on dark. NOT the chosen segment's #2d3a4d fill — measured, that
+            // is ~1.15:1 against a gray-800 panel, and a toggle whose ON
+            // state is invisible fails its one job. #94a3b8 reads 5.7:1
+            // against the panel and ~2.2:1 apart from the OFF gray.
+            ? 'bg-[#1a2332] dark:bg-[#94a3b8]'
             : 'bg-gray-300 dark:bg-gray-600'}
           ${disabled ? 'opacity-40' : ''}`}
       >

--- a/src/pages/EnhancedImport.tsx
+++ b/src/pages/EnhancedImport.tsx
@@ -127,7 +127,10 @@ export default function EnhancedImport(): React.JSX.Element {
         {/* Microsoft Money — the first-class total-migration flow, front and centre */}
         <button
           onClick={() => setShowMsMoneyImport(true)}
-          className="w-full mb-6 text-left rounded-2xl border border-[#1a2332]/15 dark:border-blue-500/30 bg-[#1a2332]/[0.03] dark:bg-blue-500/10 hover:bg-[#1a2332]/[0.06] dark:hover:bg-blue-500/20 transition-colors p-5 flex items-center gap-4"
+          // No tinted wash: a wash behind a call to action is decoration
+          // under P2 — the hairline and the icon's primary fill say it
+          // (Design ruling, 23 Aug §8).
+          className="w-full mb-6 text-left rounded-2xl border border-line dark:border-gray-700 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors p-5 flex items-center gap-4"
         >
           <span className="shrink-0 grid place-items-center h-12 w-12 rounded-xl bg-primary-action text-on-primary-action">
             <DatabaseIcon size={24} />

--- a/src/pages/settings/DataManagement.tsx
+++ b/src/pages/settings/DataManagement.tsx
@@ -531,7 +531,10 @@ function LinkCard({ to, icon: Icon, title, description }: {
   return (
     <Link
       to={to}
-      className="w-full text-left rounded-xl border border-[#1a2332]/15 dark:border-blue-500/30 bg-[#1a2332]/[0.03] dark:bg-blue-500/10 hover:bg-[#1a2332]/[0.06] dark:hover:bg-blue-500/20 transition-colors p-4 flex items-center gap-3"
+      // No tinted wash: a wash behind a call to action is decoration under
+      // P2 — the hairline and the icon's primary fill say it (Design
+      // ruling, 23 Aug §8).
+      className="w-full text-left rounded-xl border border-line dark:border-gray-700 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors p-4 flex items-center gap-3"
     >
       <span className="shrink-0 grid place-items-center h-10 w-10 rounded-lg bg-primary-action text-on-primary-action">
         <Icon size={20} />


### PR DESCRIPTION
## Design ruling, 23 Aug §8

> A blue that exists only so something is visible on dark is a missing
> token, not a colour choice.

Applied to all six:

| Site | Was (dark) | Now |
|---|---|---|
| LoadTestDataModal progress fill | `dark:bg-blue-600` | `bg-navy-400 dark:bg-primary-action` |
| MsMoneyImportModal progress fill | `dark:bg-blue-600` | same pair |
| ImportProgress fill + 30% indeterminate track | `dark:bg-blue-500(/30)` | same pair (/30) |
| ToggleSwitch ON track | `dark:bg-blue-600` | `bg-[#1a2332] dark:bg-[#94a3b8]` (selected family) |
| MsMoneyImportModal spinner border | `dark:border-blue-500` | `border-line-strong dark:border-[#94a3b8]` |
| EnhancedImport + DataManagement CTA washes | tinted blue washes | **deleted** — hairline card + the icon's existing primary fill |

**One deliberate departure for Design's eye**: the ruling says the toggle
takes the selected-state answer "same as a chosen segment" — but the chosen
segment's dark FILL is `#2d3a4d`, which measures ~1.15:1 against a gray-800
panel. A toggle whose ON state is invisible fails its one job, so the ON
track takes the ruling's stated *slate* (`#94a3b8`, 5.7:1 against the
panel, ~2.2:1 apart from the OFF gray) rather than the segment's navy-700.

## Verification
- `grep` confirms no stock `dark:bg-blue-*` / `dark:border-blue-*` remains in src
- Live in the pane (dark): Money banner computes the neutral card surface
  (`rgb(31,41,55)` / border `rgb(55,65,81)`) with the primary icon square;
  a toggle's ON track computes `rgb(148,163,184)`
- tsc -b clean, lint zero, husky full gate on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)