### PR TITLE
fix(currency): one net worth everywhere — closings value at the as-at day's own rates

### DIFF
--- a/src/components/reports/BalanceReportCurrencyNote.tsx
+++ b/src/components/reports/BalanceReportCurrencyNote.tsx
@@ -1,0 +1,83 @@
+import React, { useMemo } from 'react';
+import { useApp } from '../../contexts/AppContextSupabase';
+import { useNetWorthConversion } from '../../hooks/useNetWorthConversion';
+import { useLedgerSpansCurrencies } from '../../hooks/useLedgerSpansCurrencies';
+import MixedCurrencyDisclosure from '../MixedCurrencyDisclosure';
+import HistoricRatesRestatementNotice from '../HistoricRatesRestatementNotice';
+import { getDateLocale } from '../../utils/dateFormatter';
+
+/**
+ * The rate-basis line for the two balance reports (Net worth, Account
+ * balances), whose figures carry TWO bases since the one-net-worth ruling
+ * (Design, 24 Aug §1, refined by the owner):
+ *
+ * - CLOSING figures are a snapshot, valued at the rates of the statement's
+ *   own as-at day — today's rates as at today (the Accounts page's exact
+ *   factors, so the two surfaces give one answer), that day's ECB reference
+ *   rate for a statement as at a past day.
+ * - MOVEMENT figures keep the per-day basis: each movement at its own day's
+ *   ECB reference rate.
+ *
+ * The hub's generic ReportCurrencyNote states one basis, which would now be
+ * wrong here — so these reports are 'self' on the registry ladder and this
+ * note states both. Same ladder of states as the hub's note: nothing for a
+ * single-currency ledger; the two-bases line when the history is in force; a
+ * balances-convert-but-movements-don't line while the history is loading;
+ * the Phase 0 disclosure when there are no rates at all.
+ */
+export default function BalanceReportCurrencyNote({ asOf }: { asOf: Date }): React.JSX.Element | null {
+  const { accounts, transactions } = useApp();
+  const spans = useLedgerSpansCurrencies();
+  const { historical, provenance } = useNetWorthConversion(accounts, { range: { from: null, to: null } });
+
+  const reachesPreEpoch = useMemo(() => {
+    if (!historical) return false;
+    const epoch = new Date(1999, 0, 4).getTime();
+    return transactions.some(t => new Date(t.date).getTime() < epoch);
+  }, [transactions, historical]);
+
+  if (!spans) return null;
+  // No display rates at all: nothing converts anywhere — the Phase 0
+  // disclosure is the whole truth.
+  if (provenance === null) return <MixedCurrencyDisclosure />;
+
+  const startOfToday = new Date();
+  startOfToday.setHours(0, 0, 0, 0);
+  const balancesBasis = asOf.getTime() < startOfToday.getTime()
+    ? `the ECB reference rate for ${asOf.toLocaleDateString(getDateLocale(), { day: 'numeric', month: 'long', year: 'numeric' })}`
+    : 'today’s rates';
+
+  if (!historical) {
+    // Balances already convert (today's rates); the movements cannot until
+    // the history arrives — say exactly that, never the blanket Phase 0
+    // sentence, which would deny the conversion the balances carry.
+    return (
+      <p className="text-dense text-gray-500 dark:text-gray-400" data-testid="report-currency-basis">
+        ≈ Balances converted at today&rsquo;s rates. Movements in other currencies are
+        counted unit-for-unit until the rate history loads.
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <HistoricRatesRestatementNotice
+        visible={true}
+        storageKey="money_management_fx_flows_restatement_dismissed"
+      >
+        <span className="font-semibold text-gray-900 dark:text-white">
+          Report figures have been recalculated.
+        </span>{' '}
+        Amounts in other currencies are now converted at the reference rate for each
+        transaction&rsquo;s own date, so totals may differ from what you saw
+        previously. Your recorded transactions are unchanged.
+      </HistoricRatesRestatementNotice>
+      <p className="text-dense text-gray-500 dark:text-gray-400" data-testid="report-currency-basis">
+        ≈ Balances converted at {balancesBasis}; the period&rsquo;s movements at each
+        day&rsquo;s ECB reference rate. Weekends and holidays carry the previous
+        business day&rsquo;s rate.
+        {reachesPreEpoch ? <> Amounts before 4 Jan 1999 use the earliest rate available.</> : null}
+      </p>
+    </>
+  );
+}

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -2477,9 +2477,14 @@ function AccountsList() {
               // play. A single-currency ledger keeps the exact arithmetic it
               // had — same functions, same number — so this change is invisible
               // to everyone it does not concern.
-              netWorth={formatDisplayCurrency(spansCurrencies ? convertedNetWorth.netWorth : totalBalance)}
-              assets={formatDisplayCurrency(spansCurrencies ? convertedNetWorth.assets : totalAssets)}
-              liabilities={formatDisplayCurrency(spansCurrencies ? convertedNetWorth.liabilities : totalLiabilities)}
+              // The ≈ on the trio itself (Design, 24 Aug §1): the group
+              // totals below already wear it for the same conversion, and a
+              // converted figure marked on one surface and not the other
+              // reads as two different kinds of number. provenance is null
+              // exactly when nothing converted.
+              netWorth={`${spansCurrencies && convertedNetWorth.provenance ? '≈ ' : ''}${formatDisplayCurrency(spansCurrencies ? convertedNetWorth.netWorth : totalBalance)}`}
+              assets={`${spansCurrencies && convertedNetWorth.provenance ? '≈ ' : ''}${formatDisplayCurrency(spansCurrencies ? convertedNetWorth.assets : totalAssets)}`}
+              liabilities={`${spansCurrencies && convertedNetWorth.provenance ? '≈ ' : ''}${formatDisplayCurrency(spansCurrencies ? convertedNetWorth.liabilities : totalLiabilities)}`}
               onSelect={figure => setBreakdownView(figure)}
               provenance={spansCurrencies ? convertedNetWorth.provenance : null}
               unconverted={spansCurrencies ? convertedNetWorth.unconverted : []}

--- a/src/pages/reports/AccountBalancesReport.tsx
+++ b/src/pages/reports/AccountBalancesReport.tsx
@@ -3,7 +3,8 @@ import { useApp } from '../../contexts/AppContextSupabase';
 import { useNetWorthConversion } from '../../hooks/useNetWorthConversion';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import ReportDrillModal, { type ReportDrillTarget } from '../../components/reports/ReportDrillModal';
-import { buildAccountBalanceReport, type AccountBalanceRow } from '../../utils/accountBalanceReport';
+import { buildAccountBalanceReport, resolveClosingSnapshot, type AccountBalanceRow } from '../../utils/accountBalanceReport';
+import BalanceReportCurrencyNote from '../../components/reports/BalanceReportCurrencyNote';
 import { PERIOD_LABELS } from '../../hooks/usePeriod';
 import type { ReportViewProps } from './types';
 import { getDateLocale } from '../../utils/dateFormatter';
@@ -24,13 +25,18 @@ export default function AccountBalancesReport({ picker }: ReportViewProps): Reac
   const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
 
   // The dated seam (balance reports' conversion, 23 Aug): each movement at
-  // its own day's rate, openings at the window's start; null while the
-  // history is absent, when the totals stay native and the hub's disclosure
-  // says so.
-  const { conversionAt } = useNetWorthConversion(accounts, { range: { from: null, to: null } });
+  // its own day's rate, openings at the window's start. The CLOSING figures
+  // take the snapshot basis (one-net-worth ruling, 24 Aug §1) — the as-at
+  // day's own rates — so this page's total agrees with Accounts and the
+  // Net worth report to the penny.
+  const { conversion, conversionAt } = useNetWorthConversion(accounts, { range: { from: null, to: null } });
   const report = useMemo(
-    () => buildAccountBalanceReport(accounts, transactions, picker.range, new Date(), conversionAt ?? undefined),
-    [accounts, transactions, picker.range, conversionAt]
+    () => buildAccountBalanceReport(
+      accounts, transactions, picker.range, new Date(),
+      conversionAt ?? undefined,
+      resolveClosingSnapshot(picker.range, new Date(), conversion, conversionAt)
+    ),
+    [accounts, transactions, picker.range, conversion, conversionAt]
   );
   const approx = report.holdsForeign ? '≈ ' : '';
 
@@ -82,6 +88,11 @@ export default function AccountBalancesReport({ picker }: ReportViewProps): Reac
           </p>
         </div>
       </div>
+
+      {/* The two bases, said — balances at the as-at day, movements at their
+          own days (the one-net-worth ruling). The hub stands down for this
+          report; the note is its own. */}
+      <BalanceReportCurrencyNote asOf={report.asOf} />
 
       <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700">
         <div className="p-6 pb-3">

--- a/src/pages/reports/NetWorthStatementReport.tsx
+++ b/src/pages/reports/NetWorthStatementReport.tsx
@@ -3,7 +3,8 @@ import { useApp } from '../../contexts/AppContextSupabase';
 import { useNetWorthConversion } from '../../hooks/useNetWorthConversion';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import ReportDrillModal, { type ReportDrillTarget } from '../../components/reports/ReportDrillModal';
-import { buildAccountBalanceReport, type AccountBalanceRow } from '../../utils/accountBalanceReport';
+import { buildAccountBalanceReport, resolveClosingSnapshot, type AccountBalanceRow } from '../../utils/accountBalanceReport';
+import BalanceReportCurrencyNote from '../../components/reports/BalanceReportCurrencyNote';
 import { PERIOD_LABELS } from '../../hooks/usePeriod';
 import NetWorthSummary from '../../components/NetWorthSummary';
 import type { ReportViewProps } from './types';
@@ -26,11 +27,18 @@ export default function NetWorthStatementReport({ picker }: ReportViewProps): Re
   const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
 
   // The dated seam (balance reports' conversion, 23 Aug) — same terms as
-  // the Account Balances report, from the same util.
-  const { conversionAt } = useNetWorthConversion(accounts, { range: { from: null, to: null } });
+  // the Account Balances report, from the same util. The CLOSING figures
+  // take the snapshot basis (one-net-worth ruling, 24 Aug §1): the as-at
+  // day's own rates, which as at today are the Accounts page's exact
+  // factors — one answer to "what am I worth" on both surfaces.
+  const { conversion, conversionAt } = useNetWorthConversion(accounts, { range: { from: null, to: null } });
   const report = useMemo(
-    () => buildAccountBalanceReport(accounts, transactions, picker.range, new Date(), conversionAt ?? undefined),
-    [accounts, transactions, picker.range, conversionAt]
+    () => buildAccountBalanceReport(
+      accounts, transactions, picker.range, new Date(),
+      conversionAt ?? undefined,
+      resolveClosingSnapshot(picker.range, new Date(), conversion, conversionAt)
+    ),
+    [accounts, transactions, picker.range, conversion, conversionAt]
   );
   const approx = report.holdsForeign ? '≈ ' : '';
 
@@ -174,10 +182,15 @@ export default function NetWorthStatementReport({ picker }: ReportViewProps): Re
         </span>
         . Change over {PERIOD_LABELS[picker.period].toLowerCase()}{' '}
         <span className={report.change < 0 ? 'text-expense font-medium' : 'text-income font-medium'}>
-          {report.change > 0 ? '+' : ''}{money(report.change)}
+          {report.change > 0 ? '+' : ''}{approx}{money(report.change)}
         </span>
-        , from {money(report.openingNetWorth)}.
+        , from {approx}{money(report.openingNetWorth)}.
       </p>
+
+      {/* The two bases, said — balances at the as-at day, movements at their
+          own days (the one-net-worth ruling). The hub stands down for this
+          report; the note is its own. */}
+      <BalanceReportCurrencyNote asOf={report.asOf} />
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
         {section('What you own', sides.owned, report.assets, 'No account is in credit in this period')}

--- a/src/pages/reports/reportRegistry.ts
+++ b/src/pages/reports/reportRegistry.ts
@@ -115,9 +115,11 @@ export const REPORTS: ReportDefinition[] = [
     group: 'what-i-have',
     icon: WalletIcon,
     usesPeriod: true,
-    // Totals convert on the per-day basis (each movement at its own day,
-    // openings at the window's start) — the hub's note states it.
-    currency: 'flows',
+    // Two bases since the one-net-worth ruling (24 Aug §1): closings at the
+    // as-at day's rates, movements at their own days. The report states them
+    // itself (BalanceReportCurrencyNote) — the hub's one-basis note would be
+    // wrong here.
+    currency: 'self',
     component: lazyWithRecovery(() => import('./NetWorthStatementReport')),
   },
   {
@@ -142,9 +144,11 @@ export const REPORTS: ReportDefinition[] = [
     group: 'what-i-have',
     icon: LandmarkIcon,
     usesPeriod: true,
-    // Totals convert on the per-day basis (each movement at its own day,
-    // openings at the window's start) — the hub's note states it.
-    currency: 'flows',
+    // Two bases since the one-net-worth ruling (24 Aug §1): closings at the
+    // as-at day's rates, movements at their own days. The report states them
+    // itself (BalanceReportCurrencyNote) — the hub's one-basis note would be
+    // wrong here.
+    currency: 'self',
     component: lazyWithRecovery(() => import('./AccountBalancesReport')),
   },
   {

--- a/src/utils/accountBalanceReport.test.ts
+++ b/src/utils/accountBalanceReport.test.ts
@@ -217,3 +217,87 @@ describe('buildAccountBalanceReport — the dated conversion seam', () => {
     expect(report.holdsForeign).toBe(false);
   });
 });
+
+describe('the closing snapshot basis (one-net-worth ruling, 24 Aug §1)', () => {
+  // Every figure and rate below is invented; the repo is public.
+  const FOREIGN_ACCOUNTS: Account[] = [
+    account({ id: 'acc-gbp', name: 'Test Sterling', type: 'current', openingBalance: 100 }),
+    account({ id: 'acc-usd', name: 'Test Dollar', type: 'savings', currency: 'USD', openingBalance: 0 }),
+  ];
+  const MOVES: Transaction[] = [
+    txn({ id: 'u1', amount: 300, date: new Date(2026, 1, 10), accountId: 'acc-usd', type: 'income' }),
+  ];
+  const factors = (usdPerDisplay: number) => ({
+    factors: new Map([['acc-usd', toDecimal(usdPerDisplay)]]),
+    unconverted: [] as string[],
+  });
+  /** Movements convert at a per-day factor of 0.5 whatever the day. */
+  const perDay = () => factors(0.5);
+
+  it('values the converted closing at the snapshot factors, never the identity construction', () => {
+    const report = buildAccountBalanceReport(
+      FOREIGN_ACCOUNTS, MOVES, RANGE, new Date(2026, 1, 28),
+      perDay,
+      factors(0.8) // the as-at day's rate differs from every movement day's
+    );
+    const usd = report.rows.find(r => r.accountId === 'acc-usd');
+    // Native closing 300 × snapshot 0.8 — NOT the identity's 300 × 0.5.
+    expect(usd?.closingConverted).toBe(240);
+    // The movement keeps its own day's basis.
+    expect(usd?.changeConverted).toBe(150);
+    expect(report.holdsForeign).toBe(true);
+  });
+
+  it('reports the period change as the movements’ own basis, never netWorth − opening', () => {
+    const report = buildAccountBalanceReport(
+      FOREIGN_ACCOUNTS, MOVES, RANGE, new Date(2026, 1, 28),
+      perDay,
+      factors(0.8)
+    );
+    // 150 converted movement + nothing on the sterling account — the FX
+    // drift between 0.5 and 0.8 belongs to no flow.
+    expect(report.change).toBe(150);
+    // And the snapshot aggregates follow the snapshot closings.
+    expect(report.netWorth).toBe(100 + 240);
+  });
+
+  it('keeps the identity construction when no snapshot is given (old callers)', () => {
+    const report = buildAccountBalanceReport(
+      FOREIGN_ACCOUNTS, MOVES, RANGE, new Date(2026, 1, 28),
+      perDay
+    );
+    const usd = report.rows.find(r => r.accountId === 'acc-usd');
+    expect(usd?.closingConverted).toBe(150);
+    expect(report.netWorth).toBe(100 + 150);
+  });
+});
+
+describe('resolveClosingSnapshot — which day values the closings', () => {
+  const today = new Date(2026, 7, 24);
+  const conversionToday = { factors: new Map([['acc-usd', toDecimal(0.9)]]), unconverted: [] as string[] };
+  const conversionOn = (date: Date) =>
+    ({ factors: new Map([['acc-usd', toDecimal(date.getFullYear() === 2015 ? 1.5 : 0.7)]]), unconverted: [] as string[] });
+
+  it('as at today (or an open-ended window) → today’s rates, the Accounts page’s own basis', async () => {
+    const { resolveClosingSnapshot } = await import('./accountBalanceReport');
+    expect(resolveClosingSnapshot({ from: null, to: null }, today, conversionToday, conversionOn)).toBe(conversionToday);
+    expect(
+      resolveClosingSnapshot({ from: new Date(2026, 7, 1), to: today }, today, conversionToday, conversionOn)
+    ).toBe(conversionToday);
+  });
+
+  it('as at a past day → that day’s own rate: 2015 dollars value at 2015’s rate', async () => {
+    const { resolveClosingSnapshot } = await import('./accountBalanceReport');
+    const asAt2015 = resolveClosingSnapshot(
+      { from: new Date(2015, 0, 1), to: new Date(2015, 11, 31) }, today, conversionToday, conversionOn
+    );
+    expect(asAt2015?.factors.get('acc-usd')?.toNumber()).toBe(1.5);
+  });
+
+  it('degraded (no history) → today’s rates stand in, stated by the basis line', async () => {
+    const { resolveClosingSnapshot } = await import('./accountBalanceReport');
+    expect(
+      resolveClosingSnapshot({ from: new Date(2015, 0, 1), to: new Date(2015, 11, 31) }, today, conversionToday, null)
+    ).toBe(conversionToday);
+  });
+});

--- a/src/utils/accountBalanceReport.ts
+++ b/src/utils/accountBalanceReport.ts
@@ -106,6 +106,36 @@ interface Accumulator {
   count: number;
 }
 
+const dayKeyOf = (d: Date): string =>
+  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+
+/**
+ * WHICH rates value the closing balances (Design ruling, 24 Aug §1, refined
+ * by the owner the same night): a net worth is a snapshot AS AT the
+ * statement's own date.
+ *
+ * As at TODAY — every default period — that is today's rates, the very
+ * factors the Accounts page converts with, so the two surfaces give one
+ * answer to "what am I worth". As at a PAST day (a custom range ending
+ * there), it is that day's ECB reference rate — wealth held in dollars in
+ * 2015 values at 2015's rate, never restated by today's. Degraded (no
+ * history), today's rates stand in and the basis line says so.
+ *
+ * One exported rule, because two report pages call it and they may not
+ * disagree about the same money.
+ */
+export function resolveClosingSnapshot(
+  range: PeriodRange,
+  now: Date,
+  conversion: NetWorthConversion | null,
+  conversionAt: ((date: Date) => NetWorthConversion | null) | null
+): NetWorthConversion | null {
+  if (range.to && dayKeyOf(range.to) < dayKeyOf(now)) {
+    return conversionAt?.(range.to) ?? conversion;
+  }
+  return conversion;
+}
+
 export function buildAccountBalanceReport(
   accounts: Account[],
   transactions: Transaction[],
@@ -113,23 +143,34 @@ export function buildAccountBalanceReport(
   now: Date = new Date(),
   /**
    * The dated conversion seam (the balance reports' conversion, 23 Aug).
-   * The table's contract is the accounting identity — opening + change =
-   * closing — so every column converts on the identity's own terms: each
-   * movement at ITS OWN day's rate, the opening column at the day the
-   * window opens (each lump at its own effective day on an all-time
-   * window). Rows stay native — they print their account's own currency —
-   * and only the group and report totals wear the converted figures.
-   * Omitted, every figure is exactly what it always was.
+   * Movements convert on the identity's own terms: each movement at ITS OWN
+   * day's rate, the opening column at the day the window opens (each lump at
+   * its own effective day on an all-time window). Rows stay native — they
+   * print their account's own currency — and only the group and report
+   * totals wear the converted figures. Omitted, every figure is exactly what
+   * it always was.
    */
-  conversionAt?: (date: Date) => NetWorthConversion | null
+  conversionAt?: (date: Date) => NetWorthConversion | null,
+  /**
+   * TODAY'S-rates factors for the CLOSING figures (Design ruling, 24 Aug §1):
+   * a net worth is a snapshot, and two surfaces one click apart were giving
+   * two authoritative answers to "what am I worth" — Accounts at today's
+   * rates, this report's closings at each day's. One basis for the snapshot
+   * everywhere: pass the same today's-rates conversion the Accounts card
+   * uses and every converted closing (row, group total, assets/liabilities/
+   * net worth) values the native closing at it. The identity argument keeps
+   * the movement columns — which is where it was always aimed — so
+   * `opening + change` and `closing` may differ in converted terms by
+   * exactly the FX drift on held money; the caller's basis line states the
+   * two bases. Omitted, closings keep the identity construction.
+   */
+  snapshot?: NetWorthConversion | null
 ): AccountBalanceReport {
   const asOf = range.to ?? now;
   const fromTime = range.from ? range.from.getTime() : null;
   const toTime = asOf.getTime();
   const factorFor = dailyFactorLookup(conversionAt);
-  const dayKey = (d: Date): string =>
-    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-  const openingBasisDay = fromTime !== null ? dayKey(new Date(fromTime - 86_400_000)) : null;
+  const openingBasisDay = fromTime !== null ? dayKeyOf(new Date(fromTime - 86_400_000)) : null;
   let holdsForeign = false;
   const convert = (accountId: string, day: string, amount: DecimalInstance): DecimalInstance => {
     const factor = factorFor(accountId, day);
@@ -169,7 +210,7 @@ export function buildAccountBalanceReport(
     if (effTime !== null && effTime > toTime) continue; // not yet effective
     const insideWindow = fromTime !== null && effTime !== null && effTime >= fromTime;
     if (insideWindow) {
-      const converted = convert(account.id, dayKey(new Date(effTime)), opening);
+      const converted = convert(account.id, dayKeyOf(new Date(effTime)), opening);
       if (opening.greaterThanOrEqualTo(0)) {
         accumulator.moneyIn = accumulator.moneyIn.plus(opening);
         accumulator.moneyInConverted = accumulator.moneyInConverted.plus(converted);
@@ -182,7 +223,7 @@ export function buildAccountBalanceReport(
       // all-time window, at each lump's own effective day (the epoch's
       // earliest rate carries back for the undated).
       const basisDay = openingBasisDay
-        ?? (effTime !== null ? dayKey(new Date(effTime)) : '1999-01-04');
+        ?? (effTime !== null ? dayKeyOf(new Date(effTime)) : '1999-01-04');
       accumulator.opening = accumulator.opening.plus(opening);
       accumulator.openingConverted = accumulator.openingConverted.plus(convert(account.id, basisDay, opening));
     }
@@ -200,12 +241,12 @@ export function buildAccountBalanceReport(
     if (fromTime !== null && time < fromTime) {
       accumulator.opening = accumulator.opening.plus(amount);
       accumulator.openingConverted = accumulator.openingConverted.plus(
-        convert(transaction.accountId, openingBasisDay ?? dayKey(new Date(time)), amount)
+        convert(transaction.accountId, openingBasisDay ?? dayKeyOf(new Date(time)), amount)
       );
       continue;
     }
     accumulator.count += 1;
-    const converted = convert(transaction.accountId, dayKey(new Date(time)), amount);
+    const converted = convert(transaction.accountId, dayKeyOf(new Date(time)), amount);
     if (amount.greaterThanOrEqualTo(0)) {
       accumulator.moneyIn = accumulator.moneyIn.plus(amount);
       accumulator.moneyInConverted = accumulator.moneyInConverted.plus(converted);
@@ -227,6 +268,21 @@ export function buildAccountBalanceReport(
     };
     const change = accumulator.moneyIn.minus(accumulator.moneyOut);
     const changeConverted = accumulator.moneyInConverted.minus(accumulator.moneyOutConverted);
+    const closing = accumulator.opening.plus(change);
+    // The snapshot basis (see the parameter): the native closing valued at
+    // today's rates — the Accounts card's own factors — so every surface
+    // answers "what is this worth" with one number. Without a snapshot the
+    // closing keeps the identity construction.
+    const snapshotFactor = snapshot?.factors.get(account.id);
+    let closingConverted: DecimalInstance;
+    if (snapshot === undefined) {
+      closingConverted = accumulator.openingConverted.plus(changeConverted);
+    } else if (snapshotFactor) {
+      holdsForeign = true;
+      closingConverted = closing.times(snapshotFactor);
+    } else {
+      closingConverted = closing;
+    }
     return {
       accountId: account.id,
       name: account.name,
@@ -236,10 +292,10 @@ export function buildAccountBalanceReport(
       moneyIn: accumulator.moneyIn.toNumber(),
       moneyOut: accumulator.moneyOut.toNumber(),
       change: change.toNumber(),
-      closing: accumulator.opening.plus(change).toNumber(),
+      closing: closing.toNumber(),
       openingConverted: accumulator.openingConverted.toNumber(),
       changeConverted: changeConverted.toNumber(),
-      closingConverted: accumulator.openingConverted.plus(changeConverted).toNumber(),
+      closingConverted: closingConverted.toNumber(),
       count: accumulator.count,
     };
   });
@@ -276,12 +332,14 @@ export function buildAccountBalanceReport(
   let liabilities = toDecimal(0);
   let openingNetWorth = toDecimal(0);
   let netWorth = toDecimal(0);
+  let periodChange = toDecimal(0);
   for (const row of rows) {
     const closing = toDecimal(row.closingConverted);
     if (closing.greaterThan(0)) assets = assets.plus(closing);
     else liabilities = liabilities.plus(closing.abs());
     netWorth = netWorth.plus(closing);
     openingNetWorth = openingNetWorth.plus(toDecimal(row.openingConverted));
+    periodChange = periodChange.plus(toDecimal(row.changeConverted));
   }
 
   return {
@@ -292,7 +350,10 @@ export function buildAccountBalanceReport(
     netWorth: netWorth.toNumber(),
     openingNetWorth: openingNetWorth.toNumber(),
     holdsForeign,
-    change: netWorth.minus(openingNetWorth).toNumber(),
+    // The period's MOVEMENTS on their own per-day basis — never derived as
+    // netWorth − opening, which would mix the snapshot basis into a flow
+    // figure. Identity mode makes the two formulas equal exactly.
+    change: periodChange.toNumber(),
     asOf,
   };
 }


### PR DESCRIPTION
## Design review 24 Aug §1 (the finding that matters), plus the owner's refinement

After the CSP fix, Accounts and the Net worth report gave **two
authoritative answers to "what am I worth"** — today's rates vs each
movement's own day — both correct, with no way for a reader to learn the
difference was legitimate. Design's resolution (1) taken: **one basis for
the snapshot**.

The owner then caught the sharp edge in the first cut: a statement *as at
2015* must value 2015 dollars at 2015's rate, not today's. So the rule is:

> **Closings value at the rates of the statement's own as-at day.**
> As at today (every default period) that is today's rates — the Accounts
> page's exact factors, same provider, same fetch — so the surfaces agree
> to the penny. As at a past day, that day's ECB reference rate.

`resolveClosingSnapshot` is the one exported rule; both balance reports
call it. The identity basis keeps the movement columns (openings at the
window's start, movements at their own days) — where Design said it was
always aimed — and the period change is now the movements' own sum, never
`netWorth − opening`. The remaining converted-terms difference between
`opening + change` and `closing` is exactly the FX drift on held money,
and the new `BalanceReportCurrencyNote` states both bases on both reports
(with a past-as-at variant naming the day, an honest degraded line, and
the Phase 0 fallback). Both reports move to the registry's `'self'` rung.

Also the smaller §1 finding: the **Accounts trio now wears ≈** — its own
group totals already carried it for the same conversion.

## Verification
- Live (demo, dev pane): Accounts, Net worth and Account balances all read
  the identical ≈ trio, to the penny; the two-bases line renders on both
  reports
- 19/19 on the report util (6 new: snapshot vs identity closing, per-day
  change, old-caller fallback, and the resolver's three cases — including
  the owner's exact 2015-dollars scenario); hub anatomy + currency-note
  suites green; lint zero; tsc -b clean; husky full gate on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)