### PR TITLE
fix(reports): the ring stands down when the fold would dominate it

### DIFF
--- a/src/pages/reports/SpendingByCategoryReport.tsx
+++ b/src/pages/reports/SpendingByCategoryReport.tsx
@@ -113,6 +113,21 @@ export default function SpendingByCategoryReport({ picker, focus }: ReportViewPr
   // up to the period's total.
   const netted = flows.expenses.greaterThan(0) && !listedTotal.equals(flows.expenses);
 
+  /**
+   * When the fold outweighs the largest named slice, the ring is the wrong
+   * instrument (Design ruling, 24 Aug §2): the spend simply isn't
+   * concentrated, so a top-4-plus-remainder ring is one enormous quiet wedge
+   * and four slivers — and quietest-step placement assumes the fold is the
+   * TAIL. Say the shape of the data instead and let the table do the work
+   * it already does well. Same rule as "one point is not a time series",
+   * one dimension over.
+   */
+  const fold = pieData.find(d => !d.categoryId);
+  const largestNamed = pieData.find(d => d.categoryId);
+  const spreadNote = fold && largestNamed && fold.value > largestNamed.value
+    ? { count: totals.length, name: largestNamed.name, share: shareOf(largestNamed.value) }
+    : null;
+
   return (
     <div className="max-w-[1400px] mx-auto space-y-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
@@ -140,10 +155,16 @@ export default function SpendingByCategoryReport({ picker, focus }: ReportViewPr
           </span>
         </div>
         <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
-          {PERIOD_LABELS[picker.period]} — click a slice for the transactions behind it.
+          {PERIOD_LABELS[picker.period]}{spreadNote ? '' : ' — click a slice for the transactions behind it.'}
         </p>
         {pieData.length === 0 ? (
           <p className="text-center py-16 text-gray-400">No categorised spending in this period</p>
+        ) : spreadNote ? (
+          <p className="text-body text-gray-600 dark:text-gray-300" data-testid="spending-spread-note">
+            Spending is spread across {spreadNote.count.toLocaleString()} categories — the
+            largest, {spreadNote.name}, is {spreadNote.share} of the total. Every category
+            is ranked in the table below.
+          </p>
         ) : (
           <div className="h-80" ref={chartRef}>
             <ResponsiveContainer width="100%" height="100%">

--- a/src/pages/reports/__tests__/SpendingByCategoryReport.test.tsx
+++ b/src/pages/reports/__tests__/SpendingByCategoryReport.test.tsx
@@ -192,3 +192,50 @@ describe('SpendingByCategoryReport — the accounts the spending is read over', 
     expect(screen.getAllByText('No categorised spending in this period').length).toBeGreaterThan(0);
   });
 });
+
+describe('the ring stands down when the fold would dominate it (Design, 24 Aug §2)', () => {
+  // Seven near-equal categories: the cap would show four and fold three, and
+  // the fold would outweigh the largest named slice — spread, not
+  // concentrated. Every figure is invented; the repo is public.
+  const SPREAD_CATEGORIES: Category[] = [
+    { id: 'type-expense', name: 'Expense', type: 'expense', level: 'type', isSystem: true },
+    ...Array.from({ length: 7 }, (_, i) => ({
+      id: `cat-s${i}`,
+      name: `Synthetic Category ${i}`,
+      type: 'expense' as const,
+      level: 'detail' as const,
+      parentId: 'type-expense',
+    })),
+  ];
+  const spreadTxns: Transaction[] = Array.from({ length: 7 }, (_, i) =>
+    txn({ id: `s${i}`, amount: -10, category: `cat-s${i}` })
+  );
+
+  beforeEach(() => {
+    localStorage.clear();
+    useMarch2026();
+  });
+  afterEach(() => __resetAppContextValue());
+
+  it('says the shape of the data instead of drawing one enormous quiet wedge', () => {
+    __setAppContextValue({ accounts: ACCOUNTS, categories: SPREAD_CATEGORIES, transactions: spreadTxns, transactionSplits: [] });
+    renderReport();
+    const note = screen.getByTestId('spending-spread-note');
+    expect(note.textContent).toContain('spread across 7 categories');
+    expect(note.textContent).toContain('14.3%');
+    expect(document.querySelector('.recharts-responsive-container')).toBeNull();
+    // The subtitle stops promising slices that are not there.
+    expect(screen.queryByText(/click a slice/)).toBeNull();
+  });
+
+  it('keeps the ring for genuinely concentrated spending', () => {
+    const concentrated = [
+      txn({ id: 'big', amount: -100, category: 'cat-s0' }),
+      ...Array.from({ length: 6 }, (_, i) => txn({ id: `small${i}`, amount: -5, category: `cat-s${i + 1}` })),
+    ];
+    __setAppContextValue({ accounts: ACCOUNTS, categories: SPREAD_CATEGORIES, transactions: concentrated, transactionSplits: [] });
+    renderReport();
+    expect(screen.queryByTestId('spending-spread-note')).toBeNull();
+    expect(document.querySelector('.recharts-responsive-container')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Design ruling, 24 Aug §2

> When the remainder exceeds the largest named slice, the ring is the wrong
> instrument.

The owner's all-time spending has its top category at 7.4% with sixty more
behind it — the capped ring drew one enormous quiet wedge and four
slivers, and quietest-step placement assumes the fold is the *tail*.

Now: when the fold outweighs the largest named slice, the report renders
**"Spending is spread across N categories — the largest, X, is Y% of the
total. Every category is ranked in the table below."** in place of the
ring, and the subtitle stops promising slices that aren't there.
Concentrated spending keeps its ring exactly as before.

## Verification
- Live (demo, a genuinely spread window): the sentence renders, no ring
- Specs 8/8: the spread case (sentence, no chart, no "click a slice"
  promise) and the concentrated case (ring stays)
- Lint zero; tsc -b clean; husky full gate on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)