### PR TITLE
polish(charts,calendar): 16px legend swatches, and TODAY sheds the last stock blue

### DIFF
--- a/src/components/CustomReportViewer.tsx
+++ b/src/components/CustomReportViewer.tsx
@@ -190,7 +190,9 @@ export default function CustomReportViewer({
             <ul className="w-44 space-y-1">
               {rows.map((row, i) => (
                 <li key={row.name} className="flex items-center gap-2 text-xs">
-                  <span className="w-2.5 h-2.5 rounded-sm flex-shrink-0" style={{ backgroundColor: categoricalColor(ramp, i) }} />
+                  {/* 16px swatch (Design §11): neighbouring ramp slates read
+                      as one tone smaller. */}
+                  <span className="w-4 h-4 rounded-sm flex-shrink-0" style={{ backgroundColor: categoricalColor(ramp, i) }} />
                   <span className="flex-1 min-w-0 truncate text-gray-600 dark:text-gray-300">{row.name}</span>
                   <span className="tabular-nums text-gray-900 dark:text-white">{money(row.value)}</span>
                 </li>

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -1055,8 +1055,10 @@ export function ImprovedDashboard() {
                               : navigate(preserveDemoParam(`/accounts/${d.id}`, location.search))}
                             className="w-full flex items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors text-left"
                           >
+                            {/* 16px swatch (Design §11): neighbouring ramp
+                                slates read as one tone at 12px. */}
                             <span
-                              className="w-3 h-3 rounded-sm flex-shrink-0"
+                              className="w-4 h-4 rounded-sm flex-shrink-0"
                               style={{ backgroundColor: categoricalColor(chartRamp, i) }}
                               aria-hidden="true"
                             />

--- a/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
+++ b/src/components/dashboard/reportWidgets/DashboardReportWidgets.tsx
@@ -443,7 +443,9 @@ export function ExpenseCategoriesWidget({ picker, pin }: {
                   title={`${d.name} — open the full report on this category`}
                   className="w-full flex items-center gap-2 rounded-lg px-2 py-1.5 text-left hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
                 >
-                  <span className="w-3 h-3 rounded-sm flex-shrink-0" style={{ backgroundColor: categoricalColor(ramp, i) }} aria-hidden="true" />
+                  {/* 16px swatch (Design §11): the ramp's neighbouring slates
+                      read as one tone at 12px. */}
+                  <span className="w-4 h-4 rounded-sm flex-shrink-0" style={{ backgroundColor: categoricalColor(ramp, i) }} aria-hidden="true" />
                   <span className="flex-1 min-w-0 truncate text-sm text-gray-700 dark:text-gray-300">{d.name}</span>
                   {/* The figure takes what it needs and the name yields — a
                       truncated CATEGORY is still readable, a truncated amount

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -840,7 +840,10 @@ function CalendarView() {
               <div className="mb-1">
                 <span className={`text-sm font-medium ${
                   day.isToday
-                    ? 'bg-blue-600 text-white w-6 h-6 rounded-full flex items-center justify-center text-xs'
+                    // TODAY wears the primary-action pair, not a stock blue —
+                    // the last blue fill outside links (Design, 24 Aug §4):
+                    // navy circle in light, the near-white inversion in dark.
+                    ? 'bg-primary-action text-on-primary-action w-6 h-6 rounded-full flex items-center justify-center text-xs'
                     : day.isCurrentMonth
                       ? 'text-gray-900 dark:text-gray-200'
                       : 'text-gray-400 dark:text-gray-600'

--- a/src/pages/reports/SpendingByCategoryReport.tsx
+++ b/src/pages/reports/SpendingByCategoryReport.tsx
@@ -180,7 +180,10 @@ export default function SpendingByCategoryReport({ picker, focus }: ReportViewPr
                     categories" above the real ones. A constant sorter keeps
                     payload order: rank order, the fold last — the same order
                     the ring is painted in. */}
-                <Legend layout="vertical" align="right" verticalAlign="middle" formatter={legendText} itemSorter={() => 0} />
+                {/* iconSize 16: the ramp's neighbours need a swatch big
+                    enough to tell apart — at recharts' default the named
+                    slates read as two tones (Design §11, landed 24 Aug). */}
+                <Legend layout="vertical" align="right" verticalAlign="middle" formatter={legendText} itemSorter={() => 0} iconSize={16} />
               </RechartsPieChart>
             </ResponsiveContainer>
           </div>


### PR DESCRIPTION
## Design 24 Aug §3 + §4

- **§3 (the §11 swatch ruling, landed)**: at ~12px the ramp's neighbouring
  slates read as one tone. The spending donut's recharts legend takes
  `iconSize={16}`; the three HTML legends (dashboard Expense Categories,
  account-distribution list, custom-report pie) move to 16px squares.
- **§4**: the calendar's TODAY circle — the last stock blue fill outside
  links — wears the `primary-action` pair: navy in light, the near-white
  inversion in dark.

## Verification
- Live (dark): today's cell computes `rgb(241,243,247)` circle with
  `rgb(26,35,50)` text
- Lint zero; tsc -b clean; husky full gate on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)