### PR TITLE
fix(currency): one provider for a given day — the ECB overlays today's rates

### DIFF
--- a/src/components/ConvertedTotalNote.test.tsx
+++ b/src/components/ConvertedTotalNote.test.tsx
@@ -133,4 +133,15 @@ describe('ConvertedTotalNote', () => {
       expect(screen.getByTestId('converted-total-note')).toHaveTextContent(/This total is wrong/);
     });
   });
+
+  describe('the ECB reference rate — the preferred provider (24 Aug §1)', () => {
+    it('names the day\'s reference rate, not a wall-clock time', () => {
+      // The reference rate is a DAILY figure; a clock time would overstate
+      // its freshness.
+      render(<ConvertedTotalNote provenance={{ source: 'ecb', asOf: new Date(2026, 7, 24, 9, 30) }} />);
+      const note = screen.getByTestId('converted-total-note');
+      expect(note).toHaveTextContent('Converted at today’s ECB reference rate');
+      expect(note.textContent).not.toMatch(/09|9:30/);
+    });
+  });
 });

--- a/src/components/ConvertedTotalNote.tsx
+++ b/src/components/ConvertedTotalNote.tsx
@@ -100,13 +100,20 @@ export default function ConvertedTotalNote({
     );
   }
 
-  // The quiet, everyday case: converted, at a live quote, at a stated time.
+  // The quiet, everyday case: converted at a live figure, its source named.
+  // The ECB reference rate is a DAILY figure — the one every backdated
+  // conversion in the app already uses — so its line names the day's rate
+  // rather than a wall-clock time that would overstate its freshness.
   return (
     <p
       className="mt-2 text-dense text-gray-500 dark:text-gray-400"
       data-testid="converted-total-note"
     >
-      {provenance ? `Converted at rates as of ${atTime(provenance.asOf)}` : null}
+      {provenance
+        ? provenance.source === 'ecb'
+          ? 'Converted at today’s ECB reference rate'
+          : `Converted at rates as of ${atTime(provenance.asOf)}`
+        : null}
     </p>
   );
 }

--- a/src/hooks/useConvertedNetWorth.test.ts
+++ b/src/hooks/useConvertedNetWorth.test.ts
@@ -122,7 +122,9 @@ describe('useConvertedNetWorth', () => {
 
       await waitFor(() => expect(result.current.isReady).toBe(true));
 
-      expect(result.current.provenance?.source).toBe('api');
+      // The suite's stub answers both providers, and the ECB overlay wins —
+      // the one-provider rule (Design, 24 Aug §1).
+      expect(result.current.provenance?.source).toBe('ecb');
     });
 
     it('reports the fallback when the provider cannot be reached', async () => {

--- a/src/pages/NetWorthReport.tsx
+++ b/src/pages/NetWorthReport.tsx
@@ -418,10 +418,15 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
           reader had already seen (the ruling, 22 Aug §6.4). */}
       <HistoricRatesRestatementNotice visible={historical && conversion !== null} />
       <div className="mb-6 space-y-2">
+        {/* ≈ when a conversion is in force (Design, 24 Aug §1): this page's
+            own basis line says the figures converted, and the dashboard's
+            card for the same series already wears the mark — a converted
+            figure marked on one surface and plain on the other reads as two
+            different kinds of number. */}
         <NetWorthSummary
-          netWorth={latest ? formatCurrency(latest.netWorth) : '—'}
-          assets={latest ? formatCurrency(latest.assets) : '—'}
-          liabilities={latest ? formatCurrency(latest.liabilities) : '—'}
+          netWorth={latest ? `${conversion ? '≈ ' : ''}${formatCurrency(latest.netWorth)}` : '—'}
+          assets={latest ? `${conversion ? '≈ ' : ''}${formatCurrency(latest.assets)}` : '—'}
+          liabilities={latest ? `${conversion ? '≈ ' : ''}${formatCurrency(latest.liabilities)}` : '—'}
         />
         {/* The date alone. The change figure lived here too, and again as the
             band's CHANGE tile two hundred pixels down — the same money said

--- a/src/utils/__tests__/currency-decimal.test.ts
+++ b/src/utils/__tests__/currency-decimal.test.ts
@@ -154,13 +154,13 @@ describe('currency-decimal', () => {
         json: () => Promise.resolve(mockApiResponse)
       });
 
-      // First call
+      // First call — one request per provider (api, then the ECB overlay)
       const rates1 = await getExchangeRatesFresh();
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
 
       // Second call should use cache
       const rates2 = await getExchangeRatesFresh();
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(rates2).toEqual(rates1);
     });
 
@@ -173,9 +173,9 @@ describe('currency-decimal', () => {
         json: () => Promise.resolve(mockApiResponse)
       });
 
-      // First call
+      // First call — one request per provider (api, then the ECB overlay)
       await getExchangeRatesFresh();
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
 
       // Mock time passing (1 hour + 1 minute)
       const originalDateNow = Date.now;
@@ -183,7 +183,7 @@ describe('currency-decimal', () => {
 
       // Second call should fetch again
       await getExchangeRatesFresh();
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenCalledTimes(4);
 
       vi.restoreAllMocks();
     });
@@ -327,7 +327,8 @@ describe('currency-decimal', () => {
       
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       
-      mockFetch.mockRejectedValueOnce(new Error('API error'));
+      // Both providers down (api, then the ECB overlay).
+      mockFetch.mockRejectedValueOnce(new Error('API error')).mockRejectedValueOnce(new Error('API error'));
 
       const result = await convertCurrency(100, 'GBP', 'USD');
       // Falls back to hardcoded rates: 100 * 1.27
@@ -464,7 +465,8 @@ describe('currency-decimal', () => {
       
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       
-      mockFetch.mockRejectedValueOnce(new Error('API error'));
+      // Both providers down (api, then the ECB overlay).
+      mockFetch.mockRejectedValueOnce(new Error('API error')).mockRejectedValueOnce(new Error('API error'));
 
       const amounts = [
         { amount: 100, currency: 'GBP' },
@@ -585,5 +587,53 @@ describe('formatCurrencyCompact — axis notation (owner, 21 Aug: £8m, never £
   it('whole units below a thousand; negatives keep the minus (colourless axis notation)', () => {
     expect(formatCurrencyCompact(850)).toBe('£850');
     expect(formatCurrencyCompact(-2_400_000)).toBe('-£2.4m');
+  });
+});
+
+describe('one provider for a given day — the ECB overlay (Design, 24 Aug §1)', () => {
+  // Every rate below is invented; the repo is public.
+  const apiResponse = { ok: true, json: () => Promise.resolve({ rates: { GBP: 1, USD: 1.27, XXX: 5 } }) };
+  const ecbResponse = { ok: true, json: () => Promise.resolve({ rates: { USD: 1.3 } }) };
+  const down = () => Promise.reject(new Error('down'));
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('ECB values overlay the api record wherever the ECB publishes; api keeps the breadth', async () => {
+    const { getExchangeRatesWithProvenance } = await import('../currency-decimal');
+    mockFetch.mockResolvedValueOnce(apiResponse).mockResolvedValueOnce(ecbResponse);
+    const { rates, provenance } = await getExchangeRatesWithProvenance();
+    // The major quotes the ECB — the same provider every backdated figure
+    // uses, so the chart's last point and the closing snapshot agree.
+    expect(rates.USD).toBe(1.3);
+    // A currency the ECB does not publish keeps the api's live quote.
+    expect(rates.XXX).toBe(5);
+    expect(provenance.source).toBe('ecb');
+  });
+
+  it('with the ECB unreachable, the api record stands alone and says so', async () => {
+    const { getExchangeRatesWithProvenance } = await import('../currency-decimal');
+    mockFetch.mockResolvedValueOnce(apiResponse).mockImplementationOnce(down);
+    const { rates, provenance } = await getExchangeRatesWithProvenance();
+    expect(rates.USD).toBe(1.27);
+    expect(provenance.source).toBe('api');
+  });
+
+  it('with the api unreachable, the ECB majors overlay the stored approximations', async () => {
+    const { getExchangeRatesWithProvenance } = await import('../currency-decimal');
+    mockFetch.mockImplementationOnce(down).mockResolvedValueOnce(ecbResponse);
+    const { rates, provenance } = await getExchangeRatesWithProvenance();
+    expect(rates.USD).toBe(1.3);
+    expect(provenance.source).toBe('ecb');
+  });
+
+  it('with both unreachable, the fallback says it is one', async () => {
+    const { getExchangeRatesWithProvenance } = await import('../currency-decimal');
+    mockFetch.mockImplementationOnce(down).mockImplementationOnce(down);
+    const { provenance } = await getExchangeRatesWithProvenance();
+    expect(provenance.source).toBe('fallback');
   });
 });

--- a/src/utils/__tests__/currency-provenance.test.ts
+++ b/src/utils/__tests__/currency-provenance.test.ts
@@ -87,14 +87,15 @@ describe('rates provenance', () => {
       const { getExchangeRates } = await freshModule();
       mockFetch.mockResolvedValue(okResponse());
 
+      // One request per provider (api, then the ECB overlay).
       await getExchangeRates();
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
 
-      // 30 minutes later: still inside the hour, so no second request.
+      // 30 minutes later: still inside the hour, so no further requests.
       const realNow = Date.now();
       vi.spyOn(Date, 'now').mockReturnValue(realNow + 30 * 60 * 1000);
       await getExchangeRates();
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
     it('retries a fallback after five minutes, not after an hour', async () => {
@@ -107,7 +108,8 @@ describe('rates provenance', () => {
 
       await getExchangeRates();
       expect(getRatesProvenance()?.source).toBe('fallback');
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      // Both providers were attempted before falling back.
+      expect(mockFetch).toHaveBeenCalledTimes(2);
 
       // Six minutes later the provider is reachable again.
       const realNow = Date.now();
@@ -116,7 +118,7 @@ describe('rates provenance', () => {
 
       await getExchangeRates();
 
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenCalledTimes(4);
       expect(getRatesProvenance()?.source).toBe('api');
       consoleErrorSpy.mockRestore();
     });

--- a/src/utils/currency-decimal.ts
+++ b/src/utils/currency-decimal.ts
@@ -18,6 +18,14 @@ interface ExchangeRates {
  * from a guess and a figure derived from a quote looked identical.
  */
 export type RatesSource =
+  /**
+   * Today's ECB reference rates — the SAME provider every historical figure
+   * converts at, overlaid on the api record below. Preferred (Design, 24 Aug
+   * §1): the net-worth chart's last point valued a day at the ECB while the
+   * closing snapshot valued the same day at exchangerate-api, and the two
+   * quoted £106 apart. One day, one provider.
+   */
+  | 'ecb'
   /** A live quote from the provider named in {@link RATES_PROVIDER}. */
   | 'api'
   /** The hardcoded approximations below. The provider could not be reached. */
@@ -228,24 +236,53 @@ export function formatCurrencyWhole(
 
 // Fetch exchange rates from a free API
 async function fetchExchangeRates(): Promise<{ rates: ExchangeRates; source: RatesSource }> {
+  // exchangerate-api gives BREADTH (~160 currencies); the ECB reference rates
+  // give the one authoritative figure per day for the majors — and they are
+  // the provider every backdated figure already converts at
+  // (historicalRatesService). So the ECB's latest OVERLAYS the api record
+  // wherever the ECB publishes: for any given currency, "today" and "each
+  // day" can never quote two different providers (Design, 24 Aug §1 — the
+  // chart's last point and the closing snapshot were £106 apart on the same
+  // day). The origin is already in both content security policies —
+  // connectSrcCoversFetchOrigins.test.ts guards it.
+  let rates: ExchangeRates | null = null;
+  let source: RatesSource = 'fallback';
   try {
     // Using exchangerate-api.com free tier
     const response = await fetch('https://api.exchangerate-api.com/v4/latest/GBP');
-
     if (!response.ok) {
       throw new Error('Failed to fetch exchange rates');
     }
-
     const data = await response.json();
-    return { rates: data.rates, source: 'api' };
+    rates = data.rates;
+    source = 'api';
   } catch (error) {
     currencyLogger.error('Error fetching exchange rates:', error);
+  }
+  try {
+    const response = await fetch('https://api.frankfurter.dev/v1/latest?base=GBP');
+    if (response.ok) {
+      const body = (await response.json()) as { rates?: Record<string, number> };
+      if (body.rates && Object.keys(body.rates).length > 0) {
+        // With the api down, the ECB majors overlay the stored
+        // approximations — live for the currencies the ECB covers, which is
+        // near-certainly every currency a ledger here holds.
+        rates = { ...(rates ?? { ...FALLBACK_RATES }), ...body.rates, GBP: 1 };
+        source = 'ecb';
+      }
+    }
+  } catch (error) {
+    currencyLogger.error('Error fetching ECB reference rates:', error);
+  }
 
-    // Fallback to approximate rates if API fails. The caller is TOLD it is a
-    // fallback — this is the one branch that used to be silent, and a total
-    // built on a guess that cannot say so is the thing this reports.
+  if (rates === null) {
+    // Fallback to approximate rates if both providers fail. The caller is
+    // TOLD it is a fallback — this is the one branch that used to be silent,
+    // and a total built on a guess that cannot say so is the thing this
+    // reports.
     return { rates: { ...FALLBACK_RATES }, source: 'fallback' };
   }
+  return { rates, source };
 }
 
 // Get cached or fresh exchange rates
@@ -269,7 +306,9 @@ export async function getExchangeRatesWithProvenance(): Promise<{
   // A fallback is held for minutes, a live quote for an hour: see
   // FALLBACK_CACHE_DURATION for why the two differ.
   if (ratesCache) {
-    const ttl = ratesCache.source === 'api' ? CACHE_DURATION : FALLBACK_CACHE_DURATION;
+    // A LIVE quote (ecb or api) holds for the hour; only a fallback retries
+    // sooner.
+    const ttl = ratesCache.source === 'fallback' ? FALLBACK_CACHE_DURATION : CACHE_DURATION;
     if ((now - ratesCache.timestamp) < ttl) {
       return {
         rates: ratesCache.rates,


### PR DESCRIPTION
## Design review 24 Aug §1 — the last piece of one-net-worth

The chart's last point valued today at the **ECB** while the closing
snapshot valued the same day at **exchangerate-api**: £106.69 apart on the
owner's ledger. Design's option (2) taken — one provider for "today".

**The cut is at the app's one today-rates cache** (`fetchExchangeRates`):
the ECB's `/v1/latest` reference rates overlay the exchangerate-api record
wherever the ECB publishes. For any given currency, "today" and "each day"
can never quote two different providers — and every consumer of the cache
(Accounts, dashboard trio, closing snapshots, breakdown modal, holdings)
agrees with the ECB-valued series **by construction**, no consumer changes.
exchangerate-api remains for breadth (~160 currencies) and as the stated
fallback; the stored approximations stay the announced last resort. The
origin was already in both CSPs (guarded by test since #397).

`ConvertedTotalNote` names the source: *"Converted at today's ECB reference
rate"* — no wall-clock time, since the reference rate is daily.

Also §1's smaller finding: the over-time page's own trio now wears the ≈
its basis line was already claiming.

## Verification
- Live (demo): Accounts and the over-time report read the **identical**
  ≈ trio, and the note shows the ECB wording
- currency-decimal 54/54 (4 new overlay specs: ECB wins where it
  publishes, api keeps breadth, each fallback names itself); provenance,
  ConvertedTotalNote (+ECB wording spec), useConvertedNetWorth suites
  updated for the second provider request — all green
- Lint zero; tsc -b clean; husky full gate on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)