### PR TITLE
fix(dashboard,reports): the stale Phase 0 note, the missing ≈, and ties count as dominance

### DIFF
--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -762,10 +762,14 @@ export function ImprovedDashboard() {
         data-testid="dashboard-grid"
         aria-label="Net worth, assets and liabilities"
       >
+        {/* The ≈ on the trio itself (Design, 24 Aug §3): the Accounts page
+            marks the identical figure on the identical basis, and the note
+            under this card already says it converted. provenance is null
+            exactly when nothing converted — the same gate. */}
         <NetWorthSummary
-          netWorth={formatCurrencyWithSymbol(spansCurrencies ? convertedNetWorth.netWorth : metrics.netWorth)}
-          assets={formatCurrencyWithSymbol(spansCurrencies ? convertedNetWorth.assets : metrics.totalAssets)}
-          liabilities={formatCurrencyWithSymbol(spansCurrencies ? convertedNetWorth.liabilities : metrics.totalLiabilities)}
+          netWorth={`${spansCurrencies && convertedNetWorth.provenance ? '≈ ' : ''}${formatCurrencyWithSymbol(spansCurrencies ? convertedNetWorth.netWorth : metrics.netWorth)}`}
+          assets={`${spansCurrencies && convertedNetWorth.provenance ? '≈ ' : ''}${formatCurrencyWithSymbol(spansCurrencies ? convertedNetWorth.assets : metrics.totalAssets)}`}
+          liabilities={`${spansCurrencies && convertedNetWorth.provenance ? '≈ ' : ''}${formatCurrencyWithSymbol(spansCurrencies ? convertedNetWorth.liabilities : metrics.totalLiabilities)}`}
           onSelect={figure => setBreakdownView(figure)}
           provenance={spansCurrencies ? convertedNetWorth.provenance : null}
           unconverted={spansCurrencies ? convertedNetWorth.unconverted : []}
@@ -805,10 +809,13 @@ export function ImprovedDashboard() {
           />
         </div>
 
-        {/* Phase 0 (the disclosure ruling, 22 Aug §2): the two figures below
-            still sum native units — said until their conversion phase.
-            Nothing for a single-currency ledger. */}
-        <MixedCurrencyDisclosure className="mb-3" />
+        {/* The Phase 0 disclosure now mounts ONLY while the flows seam is
+            degraded (no rate history yet): the figures below convert through
+            the same per-date resolver the reports use, and this note
+            survived that conversion commit — a converted card telling the
+            reader it was unconverted, 200px under a header claiming the
+            opposite (Design, 24 Aug §2). Converted figures wear ≈ instead. */}
+        {flowConvert === undefined && <MixedCurrencyDisclosure className="mb-3" />}
         {/* ─ NO TINTED GROUND (Claude Design §2, and §2.5 before it) ────────
             These were `bg-green-50` and `bg-red-50` side by side. The figures
             are already green and red; the tint said the same thing a second
@@ -870,7 +877,7 @@ export function ImprovedDashboard() {
                 ? 'text-gray-900 dark:text-white'
                 : 'text-green-600 dark:text-green-400'
             }`}>
-              {formatCurrencyWithSymbol(performance.income)}
+              {performance.holdsForeign ? '≈ ' : ''}{formatCurrencyWithSymbol(performance.income)}
               {/* Through the SHARED zero rule now. This pair got "no direction
                   at zero" right first (16 Aug) — and then Budget's cards were
                   found re-deriving it wrong, the fourth copy in one pass. The
@@ -890,7 +897,7 @@ export function ImprovedDashboard() {
                 ? 'text-gray-900 dark:text-white'
                 : 'text-red-600 dark:text-red-400'
             }`}>
-              {formatCurrencyWithSymbol(performance.expenses)}
+              {performance.holdsForeign ? '≈ ' : ''}{formatCurrencyWithSymbol(performance.expenses)}
               <TrendArrow value={performance.expenses} direction="down" size={20} />
             </p>
           </button>

--- a/src/pages/reports/AccountDistributionReport.tsx
+++ b/src/pages/reports/AccountDistributionReport.tsx
@@ -87,6 +87,20 @@ export default function AccountDistributionReport(): React.JSX.Element {
         : `${formatDecimal(entry.share, 1)}%`
       : '—';
 
+  /**
+   * When the fold matches or outweighs the largest named slice, the ring is
+   * the wrong instrument (Design ruling, 24 Aug §2 and §4): a ring whose
+   * biggest wedge is "the other N accounts" tells the reader less than a
+   * sentence would, and quietest-step placement assumes the fold is the
+   * tail. Ties count as dominance — a fold as big as the biggest account is
+   * already not a tail.
+   */
+  const remainderWedge = distribution.wedges.find(w => w.id === ACCOUNT_DISTRIBUTION_REMAINDER_ID);
+  const largestWedge = distribution.wedges.find(w => w.id !== ACCOUNT_DISTRIBUTION_REMAINDER_ID);
+  const spreadNote = remainderWedge && largestWedge && remainderWedge.value >= largestWedge.value
+    ? { count: distribution.entries.length, name: largestWedge.name, share: shareOf(largestWedge) }
+    : null;
+
   const headCell = 'px-4 py-2 text-dense font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400';
 
   return (
@@ -140,14 +154,24 @@ export default function AccountDistributionReport(): React.JSX.Element {
             must come back to that number, "otherwise it looks like a useless
             report"). */}
         <p className="text-body text-gray-500 dark:text-gray-400 mb-4">
-          {distribution.foldedCount > 0
-            ? `The ${distribution.slices.length - 1} largest accounts in credit, with every other account netted into one slice — together, your net worth`
-            : 'Every account, drawn to its balance — together, your net worth'}
-          {' '}— the same slices the Dashboard shows. Every account is listed below.
-          Click a slice for its transactions.
+          {spreadNote
+            ? 'Current balances, as shares of your net worth.'
+            : <>
+                {distribution.foldedCount > 0
+                  ? `The ${distribution.slices.length - 1} largest accounts in credit, with every other account netted into one slice — together, your net worth`
+                  : 'Every account, drawn to its balance — together, your net worth'}
+                {' '}— the same slices the Dashboard shows. Every account is listed below.
+                Click a slice for its transactions.
+              </>}
         </p>
         {distribution.wedges.length === 0 ? (
           <p className="text-center py-16 text-gray-400">No account is in credit</p>
+        ) : spreadNote ? (
+          <p className="text-body text-gray-600 dark:text-gray-300" data-testid="distribution-spread-note">
+            Your money is spread across {spreadNote.count.toLocaleString()} accounts — the
+            largest, {spreadNote.name}, holds {spreadNote.share} of your net worth. Every
+            account is listed below.
+          </p>
         ) : (
           <div className="h-80">
             <ResponsiveContainer width="100%" height="100%">

--- a/src/pages/reports/SpendingByCategoryReport.tsx
+++ b/src/pages/reports/SpendingByCategoryReport.tsx
@@ -124,7 +124,9 @@ export default function SpendingByCategoryReport({ picker, focus }: ReportViewPr
    */
   const fold = pieData.find(d => !d.categoryId);
   const largestNamed = pieData.find(d => d.categoryId);
-  const spreadNote = fold && largestNamed && fold.value > largestNamed.value
+  // >= — ties count as dominance (Design, 24 Aug §4): a fold as big as the
+  // biggest category is already not a tail.
+  const spreadNote = fold && largestNamed && fold.value >= largestNamed.value
     ? { count: totals.length, name: largestNamed.name, share: shareOf(largestNamed.value) }
     : null;
 


### PR DESCRIPTION
## Design review 24 Aug §2–§4

- **§2**: the Income and Expenses card's Phase 0 note was a **stale mount**
  — the card already converts through the flows seam (ruling C), so the
  note was a converted card claiming to be unconverted, 200px under a
  header claiming the opposite. It now mounts only while the seam is
  genuinely degraded, and the card's figures wear ≈ when converted.
- **§3**: the dashboard trio wears ≈ on the same provenance gate the
  Accounts trio uses.
- **§4**: ties count as dominance — the spending stand-down moves to `>=`,
  and **Account Distribution takes the same rule**: fold ≥ largest named
  account → the ring gives way to "Your money is spread across N accounts —
  the largest, X, holds Y% of your net worth."

## Verification
- Live (demo dashboard): no Phase 0 sentence on the page; trio and both
  flow figures wear ≈
- Spending report suite 8/8 green (the rule's both states pinned there);
  dashboard period-pin suite green; lint zero; tsc -b clean; husky full
  gate on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)