### PR TITLE
feat(currency): custom reports join the flows seam — the last Phase 0 sentence retires

### DIFF
--- a/src/components/CustomReportViewer.tsx
+++ b/src/components/CustomReportViewer.tsx
@@ -33,6 +33,8 @@ export interface GeneratedReport {
   report: CustomReport;
   dateRange: { startDate: Date; endDate: Date };
   data: Record<string, unknown>;
+  /** True when the flows seam applied a conversion factor — the ≈ gate. */
+  holdsForeign: boolean;
 }
 
 interface ChartSeries {
@@ -101,7 +103,12 @@ export default function CustomReportViewer({
                   {key.replace(/([A-Z])/g, ' $1').replace(/^./, c => c.toUpperCase()).trim()}
                 </p>
                 <p className="text-lg font-semibold text-gray-900 dark:text-white tabular-nums">
-                  {/count|Count/.test(key) ? value.toLocaleString() : money(value)}
+                  {/count|Count/.test(key)
+                    ? value.toLocaleString()
+                    // ≈ on converted money figures — the hub's basis line
+                    // states the mechanism; the mark says which figures it
+                    // reached. Rates and counts are not money.
+                    : `${generated.holdsForeign && !/[Rr]ate/.test(key) ? '≈ ' : ''}${money(value)}`}
                 </p>
               </div>
             ))}

--- a/src/pages/CustomReports.tsx
+++ b/src/pages/CustomReports.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useApp } from '../contexts/AppContextSupabase';
 import { useNotifications } from '../contexts/NotificationContext';
 import { customReportService } from '../services/customReportService';
+import { useFlowConvert } from '../hooks/useFlowConvert';
 import CustomReportBuilder from '../components/CustomReportBuilder';
 import CustomReportViewer, { type GeneratedReport } from '../components/CustomReportViewer';
 import type { CustomReport } from '../components/CustomReportBuilder';
@@ -28,6 +29,11 @@ export default function CustomReports(): React.JSX.Element {
     customReports, saveCustomReport, deleteCustomReport
   } = useApp();
   const { addNotification } = useNotifications();
+  // The flows seam (closed here 24 Aug — the last native surface): each
+  // row's amount converts at its own day's reference rate before the
+  // aggregating generators sum it. Undefined while the history loads, when
+  // the hub's disclosure keeps saying the totals are native.
+  const flowConvert = useFlowConvert(accounts);
 
   const [showBuilder, setShowBuilder] = useState(false);
   const [editingReport, setEditingReport] = useState<CustomReport | undefined>();
@@ -122,7 +128,7 @@ export default function CustomReports(): React.JSX.Element {
         accounts,
         budgets,
         categories
-      });
+      }, flowConvert);
       
       // Show the report itself — "generated" used to mean a toast and
       // nothing to look at.

--- a/src/pages/reports/reportRegistry.ts
+++ b/src/pages/reports/reportRegistry.ts
@@ -244,6 +244,12 @@ export const REPORTS: ReportDefinition[] = [
     icon: FileTextIcon,
     // Custom reports carry their own date and account filters.
     usesPeriod: false,
+    // The LAST surface to convert (24 Aug): aggregates run through the
+    // shared flows seam — each row at its own day's rate — so the hub's
+    // note states the basis, and its degraded fallback keeps the old
+    // sentence honest while the history loads. Listed table rows stay
+    // native, as rows do everywhere.
+    currency: 'flows',
     component: lazyWithRecovery(() => import('../CustomReports')),
   },
 ];

--- a/src/services/__tests__/customReportService.convert.test.ts
+++ b/src/services/__tests__/customReportService.convert.test.ts
@@ -1,0 +1,67 @@
+/**
+ * The custom-report flows seam (24 Aug — the LAST surface still summing
+ * native units): aggregating generators receive rows already converted at
+ * each row's own day's factor; the table generator keeps the raw rows,
+ * because a listed transaction prints its own money and only aggregates
+ * convert. Every figure below is invented; the repo is public.
+ */
+import { describe, it, expect } from 'vitest';
+import { customReportService } from '../customReportService';
+import { toDecimal } from '../../utils/decimal';
+import type { FlowFactorResolver } from '../../utils/incomeExpense';
+import type { Account, Category, Transaction } from '../../types';
+import type { CustomReport } from '../../components/CustomReportBuilder';
+
+const ACCOUNTS: Account[] = [
+  { id: 'acc-gbp', name: 'Test Sterling', type: 'current', balance: 0, currency: 'GBP', lastUpdated: new Date(2026, 6, 1), openingBalance: 0 },
+  { id: 'acc-usd', name: 'Test Dollar', type: 'savings', balance: 0, currency: 'USD', lastUpdated: new Date(2026, 6, 1), openingBalance: 0 },
+];
+
+const CATEGORIES: Category[] = [
+  { id: 'type-income', name: 'Income', type: 'income', level: 'type', isSystem: true },
+  { id: 'cat-pay', name: 'Pay', type: 'income', level: 'detail', parentId: 'type-income' },
+];
+
+const TRANSACTIONS: Transaction[] = [
+  { id: 't-gbp', date: new Date(2026, 6, 10), amount: 100, description: 'synthetic', category: 'cat-pay', accountId: 'acc-gbp', type: 'income', cleared: false },
+  { id: 't-usd', date: new Date(2026, 6, 12), amount: 200, description: 'synthetic', category: 'cat-pay', accountId: 'acc-usd', type: 'income', cleared: false },
+];
+
+const REPORT: CustomReport = {
+  id: 'r-1',
+  name: 'Synthetic report',
+  description: '',
+  components: [
+    { id: 'c-stats', type: 'summary-stats', config: {}, width: 'full' },
+    { id: 'c-table', type: 'table', config: {}, width: 'full' },
+  ],
+  filters: { dateRange: 'custom', customStartDate: '2026-07-01', customEndDate: '2026-07-31' },
+  createdAt: new Date(2026, 6, 1),
+  updatedAt: new Date(2026, 6, 1),
+};
+
+/** Dollars at 0.8 to the display unit; sterling needs no factor. */
+const convert: FlowFactorResolver = row =>
+  row.accountId === 'acc-usd' ? toDecimal(0.8) : null;
+
+const dataset = { transactions: TRANSACTIONS, accounts: ACCOUNTS, budgets: [], categories: CATEGORIES };
+
+describe('the custom-report flows seam', () => {
+  it('aggregates convert at each row’s own factor; listed table rows stay native', async () => {
+    const generated = await customReportService.generateReportData(REPORT, dataset, convert);
+    const stats = generated.data['c-stats'] as { income: number };
+    // 100 native + 200 × 0.8 — never 100 + 200.
+    expect(stats.income).toBe(260);
+    const table = generated.data['c-table'] as Array<{ amount: number }>;
+    // The dollar row prints its own 200 — rows are native everywhere.
+    expect(table.map(r => r.amount).sort((a, b) => a - b)).toEqual([100, 200]);
+    expect(generated.holdsForeign).toBe(true);
+  });
+
+  it('without the seam everything sums native and says so', async () => {
+    const generated = await customReportService.generateReportData(REPORT, dataset);
+    const stats = generated.data['c-stats'] as { income: number };
+    expect(stats.income).toBe(300);
+    expect(generated.holdsForeign).toBe(false);
+  });
+});

--- a/src/services/customReportService.ts
+++ b/src/services/customReportService.ts
@@ -54,7 +54,8 @@ import type {
   Transaction
 } from '../types';
 import Decimal from 'decimal.js';
-import { buildCategoryKindLookup, classifyFlow, type FlowKind } from '../utils/incomeExpense';
+import { toDecimal } from '../utils/decimal';
+import { buildCategoryKindLookup, classifyFlow, type FlowKind, type FlowFactorResolver } from '../utils/incomeExpense';
 import { startOfMonth, endOfMonth, startOfQuarter, endOfQuarter, startOfYear, endOfYear, subMonths, parseISO, format } from 'date-fns';
 
 type StorageLike = Pick<Storage, 'getItem' | 'setItem'>;
@@ -457,11 +458,24 @@ export class CustomReportService {
       accounts: Account[];
       budgets: Budget[];
       categories: Category[];
-    }
+    },
+    /**
+     * The flows seam (the disclosure ruling's ladder, closed here 24 Aug —
+     * this was the LAST surface still summing native units): each row's
+     * amount converts at its own day's reference rate before any aggregating
+     * generator sees it, so stats, charts, breakdowns and comparisons all
+     * convert through the one resolver every report uses. The TABLE
+     * component keeps the raw rows — a listed transaction prints its own
+     * money, only aggregates convert. Omitted, everything sums native and
+     * the page's Phase 0 disclosure stays true.
+     */
+    convert?: FlowFactorResolver
   ): Promise<{
     report: CustomReport;
     dateRange: { startDate: Date; endDate: Date };
     data: Record<string, unknown>;
+    /** True when any conversion factor was applied — the ≈ gate. */
+    holdsForeign: boolean;
   }> {
     // Apply date filters
     const { startDate, endDate } = this.getDateRange(report.filters.dateRange, {
@@ -496,14 +510,28 @@ export class CustomReportService {
       );
     }
 
+    // The seam: aggregating generators receive rows whose amounts are
+    // already in the display currency, each at its own day's factor. The
+    // table generator receives the RAW rows below — listed money stays
+    // native.
+    let holdsForeign = false;
+    const aggregable = convert
+      ? filteredTransactions.map(t => {
+          const factor = convert(t);
+          if (factor === null) return t;
+          holdsForeign = true;
+          return { ...t, amount: toDecimal(t.amount).times(factor).toNumber() };
+        })
+      : filteredTransactions;
+
     // Generate component data
     const componentData: Record<string, unknown> = {};
-    
+
     for (const component of report.components) {
       componentData[component.id] = await this.generateComponentData(
         component,
         {
-          transactions: filteredTransactions,
+          transactions: component.type === 'table' ? filteredTransactions : aggregable,
           accounts: data.accounts,
           budgets: data.budgets,
           categories: data.categories,
@@ -515,7 +543,8 @@ export class CustomReportService {
     return {
       report,
       dateRange: { startDate, endDate },
-      data: componentData
+      data: componentData,
+      holdsForeign
     };
   }
 


### PR DESCRIPTION
## Design review 24 Aug (thirteen captures) §1

The sentence was **true** — customReportService summed native in every
generator, making it the last honest Phase 0 note in the app. Resolution
per the ladder: convert, and the mount goes in the same stroke.

- `generateReportData` gains the shared `FlowFactorResolver`: each row's
  amount converts at its own day's rate **before** any aggregating
  generator sees it — stats, line, pie, bar, category breakdown, date
  comparison, all through one cut
- The **table** component keeps raw rows: listed money stays native, only
  aggregates convert (house canon)
- Registry: custom-reports → `'flows'` — the hub states the basis, and its
  degraded fallback keeps the old sentence honest while history loads
- Summary-stat money figures wear ≈ when a factor was applied

## Verification
- New spec: dollar rows aggregate at their factor while their table rows
  stay native; the no-seam path stays identical and `holdsForeign` says so
- Live (demo): the page shows the ≈ basis line; **no Phase 0 sentence
  remains anywhere in the app**
- Census 3/3, lint zero, tsc -b clean, husky full gate on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)