### PR TITLE
style(reports): the exports go quiet, and the matrix page loses both its ambers

### DIFF
--- a/src/components/MonthlyIncomeExpenseMatrix.tsx
+++ b/src/components/MonthlyIncomeExpenseMatrix.tsx
@@ -245,7 +245,10 @@ export default function MonthlyIncomeExpenseMatrix({
       </div>
 
       {matrix.omittedMonths > 0 && (
-        <p className="px-6 pb-3 text-xs text-amber-700 dark:text-amber-400">
+        // Neutral, not amber (Design, 24 Aug §4): this is a caveat about the
+        // VIEW — consequence and remedy stated — not a condition a control
+        // ends. The page needs no amber at all.
+        <p className="px-6 pb-3 text-xs text-gray-500 dark:text-gray-400">
           This period spans {matrix.omittedMonths + months.length} months — the most recent {months.length} are shown
           as columns, and the Total column still covers all of it.
           {cumulative && ' The running total starts at the first column shown, so it stops short of the Total.'}

--- a/src/components/reports/IncomeExpenseSummaryCards.tsx
+++ b/src/components/reports/IncomeExpenseSummaryCards.tsx
@@ -111,9 +111,13 @@ export default function IncomeExpenseSummaryCards({
 
         <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 p-6">
           <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Income vs Expenditure</p>
-          <div className={`text-2xl font-bold ${
-            summary.savingsRate >= 20 ? 'text-green-700 dark:text-green-400' : 'text-yellow-700 dark:text-yellow-400'
-          }`}>
+          {/* NEUTRAL, like its three neighbours (Design, 24 Aug §3). This
+              used to be green at ≥20% and amber below — but the figure is a
+              RATIO with no bad end defined anywhere: a year a property
+              purchase lands in, spending exceeds income by design, and amber
+              asserted a judgement the app hasn't earned. No control ends the
+              condition, so under the amber test it isn't amber either. */}
+          <div className="text-2xl font-bold text-gray-900 dark:text-white">
             {isLoading ? <SkeletonText className="w-20 h-8" /> : `${formatDecimal(summary.savingsRate, 1)}%`}
           </div>
         </div>

--- a/src/components/reports/ReportExportBar.tsx
+++ b/src/components/reports/ReportExportBar.tsx
@@ -111,10 +111,15 @@ export default function ReportExportBar({
 
   return (
     <div className="flex flex-wrap gap-2">
+      {/* Two QUIET OUTLINES (Design, 24 Aug §5): Export PDF wore a solid
+          red — the expense/destructive token as furniture on a routine
+          action, the loudest thing on five report pages — and CSV a navy
+          fill beside it. The two are the same kind of action and look
+          alike; neither has earned a primary. */}
       <button
         type="button"
         onClick={exportCSV}
-        className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium bg-[#1a2332] text-white rounded-lg hover:bg-secondary transition-colors"
+        className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
       >
         <DownloadIcon size={16} />
         Export CSV
@@ -123,7 +128,7 @@ export default function ReportExportBar({
         type="button"
         onClick={exportPDF}
         disabled={isGenerating}
-        className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <PdfIcon size={16} />
         {isGenerating ? 'Generating…' : 'Export PDF'}


### PR DESCRIPTION
## Design review 24 Aug (thirteen captures) §3–§5

- **§5**: Export PDF's solid red (the destructive token as furniture, on
  five report pages) and Export CSV's navy fill both become quiet
  outlines — same kind of action, same look, no unearned primary
- **§3**: the Income vs Expenditure ratio card drops its green/amber
  judgement — a ratio with no defined bad end, neutral like its three
  neighbours
- **§4**: the 36-column truncation notice goes neutral — a caveat about
  the view, not a condition; the page now carries no amber at all

## Verification
- ReportsHub anatomy + pdfExport suites green (33/33); lint zero; tsc -b
  clean; husky full gate on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)