### PR TITLE
fix(settings): the invisible note, the dollar glyph, and two mechanism panels in alert dress

### DIFF
--- a/src/components/BudgetAlertSettings.tsx
+++ b/src/components/BudgetAlertSettings.tsx
@@ -77,22 +77,27 @@ export default function BudgetAlertSettings() {
         {/* Alert Types */}
         <div className={`transition-opacity ${budgetAlertsEnabled ? 'opacity-100' : 'opacity-50'}`}>
           <h3 className="font-medium text-gray-900 dark:text-white mb-3">Alert Types</h3>
+          {/* NEUTRAL rows (Design, 24 Aug §7): these describe what the app
+              WILL DO at the thresholds — a mechanism, not a condition — and
+              were wearing the alert colours as decoration. The colours
+              belong to the alerts themselves; the Example panel below shows
+              what those look like. */}
           <div className="space-y-3">
-            <div className="flex items-start gap-3 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg">
-              <AlertCircleIcon size={20} className="text-yellow-600 dark:text-yellow-400 mt-0.5" />
+            <div className="flex items-start gap-3 p-3 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+              <AlertCircleIcon size={20} className="text-gray-500 dark:text-gray-400 mt-0.5" />
               <div>
-                <p className="font-medium text-yellow-800 dark:text-yellow-200">Warning Alert</p>
-                <p className="text-sm text-yellow-700 dark:text-yellow-300">
+                <p className="font-medium text-gray-900 dark:text-white">Warning Alert</p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
                   Triggered when spending reaches {alertThreshold}% of budget
                 </p>
               </div>
             </div>
-            
-            <div className="flex items-start gap-3 p-3 bg-red-50 dark:bg-red-900/20 rounded-lg">
-              <AlertCircleIcon size={20} className="text-red-600 dark:text-red-400 mt-0.5" />
+
+            <div className="flex items-start gap-3 p-3 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+              <AlertCircleIcon size={20} className="text-gray-500 dark:text-gray-400 mt-0.5" />
               <div>
-                <p className="font-medium text-red-800 dark:text-red-200">Danger Alert</p>
-                <p className="text-sm text-red-700 dark:text-red-300">
+                <p className="font-medium text-gray-900 dark:text-white">Danger Alert</p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
                   Triggered when spending exceeds 100% of budget
                 </p>
               </div>

--- a/src/components/LargeTransactionAlertSettings.tsx
+++ b/src/components/LargeTransactionAlertSettings.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNotifications } from '../contexts/NotificationContext';
-import { AlertCircleIcon, DollarSignIcon } from './icons';
+import { AlertCircleIcon } from './icons';
 import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import MoneyInput from './common/MoneyInput';
 import { parseMoneyInput } from '../utils/decimal';
@@ -46,8 +46,11 @@ export default function LargeTransactionAlertSettings() {
           </p>
           
           <div className="space-y-4">
+            {/* No dollar glyph (Design, 24 Aug §6): the field's chips and
+                the figure beside it already print the app's own currency,
+                and a $ icon beside £ values was one field wearing two
+                symbols. The icon said nothing the formatted value doesn't. */}
             <div className="flex items-center gap-4">
-              <DollarSignIcon size={20} className="text-gray-500" />
               <MoneyInput
                 aria-label="Large transaction alert threshold"
                 value={largeTransactionThreshold}

--- a/src/pages/settings/AppSettings.tsx
+++ b/src/pages/settings/AppSettings.tsx
@@ -248,8 +248,13 @@ export default function AppSettings() {
           ))}
         </div>
 
-        <div className="mt-6 p-4 bg-theme-accent dark:bg-gray-800/50 rounded-2xl">
-          <p className="text-body text-theme-heading dark:text-gray-300">
+        {/* The neutral house panel, NOT bg-theme-accent: that class carries
+            !important in index.css, so it beat dark:bg-gray-800/50 and left
+            light-grey text on a near-white ground — invisible in dark mode
+            (Design, 24 Aug §6; the index.css specificity-trap family). This
+            was its only remaining use. */}
+        <div className="mt-6 p-4 bg-gray-50 dark:bg-gray-800/50 rounded-2xl">
+          <p className="text-body text-gray-700 dark:text-gray-300">
             <strong>Note:</strong> Hidden pages will not appear in the sidebar navigation but can still be accessed if you have a direct link.
           </p>
         </div>


### PR DESCRIPTION
## Design review 24 Aug (thirteen captures) §6–§7

- **§6a**: the Page Visibility note was light-grey text on a near-white
  panel in dark — `bg-theme-accent` carries `!important` in index.css and
  beat the `dark:` utility (the documented specificity-trap family). Now
  the neutral house panel; that was the class's last use
- **§6b**: the Large Transaction threshold field showed a `$` icon beside
  £-formatted chips and value — the glyph goes; the formatted figures
  already name the currency
- **§7**: the Warning/Danger Alert rows describe a mechanism, not announce
  a condition — neutral now; the `EXAMPLE` specimen keeps showing what the
  real alerts look like

## Verification
- Lint zero; tsc -b clean; husky full gate on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)