### PR TITLE
fix(import): a protection stops wearing a warning, and the summary says the thing both cards circled

### DIFF
--- a/src/components/OFXImportModal.test.tsx
+++ b/src/components/OFXImportModal.test.tsx
@@ -231,9 +231,16 @@ describe('OFXImportModal', () => {
   };
 
   /** A preview summary tile, found by its label rather than by its number. */
-  const summaryTile = (label: string): HTMLElement => {
-    const tile = screen.getByText(label).parentElement;
-    if (!tile) throw new Error(`no summary tile labelled "${label}"`);
+  /**
+   * The preview summary — ONE sentence since Design's 24 Aug §2 ruling
+   * ("N transactions are new — of M in this file, the other K you already
+   * have"), where two equal cards used to make the reader work out the
+   * relationship themselves. Matched on the tile's whole text.
+   */
+  const summary = (): HTMLElement => {
+    const figure = screen.getByText(/in this file (is|are) new/);
+    const tile = figure.parentElement;
+    if (!tile) throw new Error('no summary tile');
     return tile;
   };
 
@@ -412,8 +419,9 @@ describe('OFXImportModal', () => {
       });
       // The tiles are read by their label, not by hunting for a loose "2":
       // both of them say 2 here, and which is which is the whole point.
-      expect(summaryTile('In this file')).toHaveTextContent('2');
-      expect(summaryTile('Will be imported')).toHaveTextContent('2');
+      // The tile prints the figure and the sentence as siblings, so the
+      // whole-tile text reads "2transactions are new — of 2 in this file".
+      expect(summary()).toHaveTextContent(/^2of 2 transactions in this file are new/);
     });
 
     it('says when a row in the file could not be read', async () => {
@@ -787,7 +795,9 @@ describe('OFXImportModal', () => {
       fireEvent.click(importButton);
 
       expect(importButton).toHaveAttribute('data-loading', 'true');
-      expect(importButton).toHaveTextContent('Importing…');
+      // The button keeps its RESTING label while busy (Design §3): the
+      // progress row reports the state, in detail.
+      expect(importButton).toHaveTextContent('Import Transactions');
 
       // The mocked import resolves ~100ms later — wait for the async work to
       // settle inside the test (otherwise the finally-block setState fires
@@ -1385,7 +1395,9 @@ describe('OFXImportModal', () => {
       
       await waitFor(() => {
         expect(screen.getByText('0 transactions found')).toBeInTheDocument();
-        expect(screen.getAllByText('0')).toHaveLength(2); // In file info and summary sections
+        // ONE figure since the summary became a sentence (Design §2): the
+        // count of new rows, with the file's own total inside the words.
+        expect(screen.getAllByText('0')).toHaveLength(1);
       });
     });
 
@@ -1803,15 +1815,14 @@ describe('OFXImportModal', () => {
       expect(screen.getByText(/Already here as “Test Transaction” on 01\/01\/2024/)).toBeInTheDocument();
 
       expect(screen.getByRole('checkbox', { name: /Immediate Faster Payment/ })).not.toBeChecked();
-      expect(summaryTile('In this file')).toHaveTextContent('1');
-      expect(summaryTile('Will be imported')).toHaveTextContent('0');
+      expect(summary()).toHaveTextContent(/^0of 1 transaction in this file is new/);
     });
 
     it('imports it after the user says it is a separate payment', async () => {
       await openPreview();
 
       fireEvent.click(screen.getByRole('checkbox', { name: /Immediate Faster Payment/ }));
-      expect(summaryTile('Will be imported')).toHaveTextContent('1');
+      expect(summary()).toHaveTextContent(/^1of 1 transaction in this file is new/);
 
       vi.mocked(ofxImportService.importTransactions).mockResolvedValueOnce(
         createMockImportResult({
@@ -1842,11 +1853,11 @@ describe('OFXImportModal', () => {
       // the overrule must not survive into an account it was never about.
       chooseAccount(SAVINGS_ACCOUNT);
       expect(screen.queryByText(/looks like one you already have/)).not.toBeInTheDocument();
-      expect(summaryTile('Will be imported')).toHaveTextContent('1');
+      expect(summary()).toHaveTextContent(/^1of 1 transaction in this file is new/);
 
       chooseAccount(CURRENT_ACCOUNT);
       expect(screen.getByRole('checkbox', { name: /Immediate Faster Payment/ })).not.toBeChecked();
-      expect(summaryTile('Will be imported')).toHaveTextContent('0');
+      expect(summary()).toHaveTextContent(/^0of 1 transaction in this file is new/);
     });
   });
 

--- a/src/components/OFXImportModal.tsx
+++ b/src/components/OFXImportModal.tsx
@@ -823,20 +823,22 @@ export default function OFXImportModal({ isOpen, onClose, initialFile }: OFXImpo
               </fieldset>
             )}
 
-            {/* Summary */}
-            <div className="grid grid-cols-2 gap-4">
-              <div className="text-center p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
-                <p className="text-2xl font-bold text-gray-900 dark:text-white">
-                  {parseResult.statementRows.length}
-                </p>
-                <p className="text-sm text-gray-600 dark:text-gray-400">In this file</p>
-              </div>
-              <div className="text-center p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
-                <p className="text-2xl font-bold text-gray-900 dark:text-white">
-                  {willImport}
-                </p>
-                <p className="text-sm text-gray-600 dark:text-gray-400">Will be imported</p>
-              </div>
+            {/* ONE SENTENCE, not two equal cards (Design, 24 Aug §2): two
+                large neutral figures side by side made the eye read the
+                numbers before it read which was which, and left the
+                relationship between them — how many are already here — for
+                the reader to compute. The figure that matters is what is
+                about to change, and the sentence states all three facts in
+                the order they answer. */}
+            <div className="text-center p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+              <p className="text-2xl font-bold text-gray-900 dark:text-white">{willImport}</p>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                of {parseResult.statementRows.length}{' '}
+                {parseResult.statementRows.length === 1 ? 'transaction' : 'transactions'} in this
+                file {parseResult.statementRows.length === 1 ? 'is' : 'are'} new
+                {parseResult.statementRows.length - willImport > 0 &&
+                  ` — you already have the ${parseResult.statementRows.length - willImport === 1 ? 'other one' : `other ${parseResult.statementRows.length - willImport}`}`}
+              </p>
             </div>
             
             {/* What the import is doing, from the click onwards — the file's
@@ -860,9 +862,14 @@ export default function OFXImportModal({ isOpen, onClose, initialFile }: OFXImpo
               >
                 Cancel
               </button>
+              {/* The button keeps its RESTING label while busy (Design,
+                  24 Aug §3): the progress row above already says "Importing…
+                  N of M", in detail, and two labels for one state left the
+                  less informative one competing with it. Disabled plus the
+                  spinner is the busy signal. */}
               <LoadingButton
                 isLoading={isProcessing}
-                loadingText="Importing…"
+                loadingText="Import Transactions"
                 onClick={processImport}
                 disabled={!selectedAccountId && !parseResult.matchedAccount}
                 className="flex items-center gap-2 px-6 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary disabled:opacity-50"
@@ -879,8 +886,12 @@ export default function OFXImportModal({ isOpen, onClose, initialFile }: OFXImpo
           <div className="text-center">
             {importResult.status === 'imported' && (
               <>
-                <div className="inline-flex items-center justify-center w-16 h-16 bg-blue-100 dark:bg-blue-900/30 rounded-full mb-4">
-                  <CheckIcon size={32} className="text-blue-600 dark:text-blue-400" />
+                {/* A completed import is a SUCCESS, and the app has a token
+                    for that — the stock blue disc was a colour standing in
+                    for a semantic one that exists (Design, 24 Aug §4; same
+                    family as the Calendar TODAY circle). */}
+                <div className="inline-flex items-center justify-center w-16 h-16 bg-green-100 dark:bg-green-900/30 rounded-full mb-4">
+                  <CheckIcon size={32} className="text-green-700 dark:text-green-400" />
                 </div>
                 <h3 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
                   Import Successful!
@@ -902,8 +913,15 @@ export default function OFXImportModal({ isOpen, onClose, initialFile }: OFXImpo
                   </p>
                 )}
 
+                {/* NEUTRAL, not amber (Design, 24 Aug §1): this sentence is
+                    the app declaring it PROTECTED the reader from
+                    double-counting — reassurance, not a warning, and no
+                    control here ends any condition. Amber on "left out 16
+                    transactions" invites the opposite reading, that part of
+                    the statement failed to import. The tick above already
+                    does the "this succeeded" work. */}
                 {importResult.duplicates > 0 && (
-                  <p className="text-sm text-yellow-600 dark:text-yellow-400 mb-6">
+                  <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
                     Left out {importResult.duplicates}{' '}
                     {importResult.duplicates === 1 ? 'transaction' : 'transactions'} this
                     account already had, so the statement period is not recorded twice.
@@ -1039,9 +1057,12 @@ export default function OFXImportModal({ isOpen, onClose, initialFile }: OFXImpo
                 <RefreshCwIcon size={20} />
                 Import Another File
               </button>
+              {/* Done is the likely next step and wears the primary token
+                  (Design, 24 Aug §5 — dark-correct now, not a hardcoded
+                  navy); Import Another File stays the quiet one. */}
               <button
                 onClick={onClose}
-                className="px-6 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary"
+                className="px-6 py-2 bg-primary-action text-on-primary-action rounded-lg hover:bg-primary-action-hover transition-colors"
               >
                 Done
               </button>


### PR DESCRIPTION
## Design's import-flow review, 24 Aug

- **§1** the deduplication line goes neutral — it's a **protection**, not a
  warning, and amber on "left out 16 transactions" invites the reading
  that sixteen failed to import
- **§2** the two equal stat cards become one sentence in Design's own
  phrasing: *"1 of 8 transactions in this file are new — you already have
  the other 7"*
- **§3** the busy button keeps its resting label (disabled + spinner); the
  progress row is the state report
- **§4** the success tick takes the income/positive token instead of a
  stock blue disc
- **§5** Done takes the `primary-action` pair (dark-correct), Import
  Another File stays quiet

## Verification
- OFXImportModal suite 75/75 — four specs taught the new copy, one count
  assertion updated for the single figure
- Lint zero; tsc -b clean; husky full gate on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)