### PR TITLE
fix(a11y): a headline figure declares its own ink — three pages were near-black on near-black

### DIFF
--- a/src/pages/reports/AccountBalancesReport.tsx
+++ b/src/pages/reports/AccountBalancesReport.tsx
@@ -70,7 +70,7 @@ export default function AccountBalancesReport({ picker }: ReportViewProps): Reac
           <p className="text-label uppercase tracking-wider font-medium text-gray-500 dark:text-gray-400">
             Total balance
           </p>
-          <p className="text-page font-bold mt-1">{approx}{money(report.netWorth)}</p>
+          <p className="text-page font-bold mt-1 text-gray-900 dark:text-white">{approx}{money(report.netWorth)}</p>
           <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">
             As at {report.asOf.toLocaleDateString(getDateLocale(), { day: 'numeric', month: 'long', year: 'numeric' })}
           </p>

--- a/src/pages/reports/AccountDistributionReport.tsx
+++ b/src/pages/reports/AccountDistributionReport.tsx
@@ -121,7 +121,7 @@ export default function AccountDistributionReport(): React.JSX.Element {
               must be the one the Dashboard's headline shows — two totals for
               one page is the disagreement this report exists to prevent. */}
           <p className="text-label uppercase tracking-wider font-medium text-gray-500 dark:text-gray-400">Net worth</p>
-          <p className="text-page font-bold mt-1">{holdsForeign ? '≈ ' : ''}{money(distribution.netWorth.toNumber())}</p>
+          <p className="text-page font-bold mt-1 text-gray-900 dark:text-white">{holdsForeign ? '≈ ' : ''}{money(distribution.netWorth.toNumber())}</p>
           {conversion && (
             <ConvertedTotalNote
               provenance={conversion.factors.size > 0 ? ratesProvenance : null}

--- a/src/pages/reports/RecurringCommitmentsReport.tsx
+++ b/src/pages/reports/RecurringCommitmentsReport.tsx
@@ -411,7 +411,7 @@ export default function RecurringCommitmentsReport(): React.JSX.Element {
         </h2>
         {/* The page's one earned total: "how much of my year is already
             spoken for?" is a question people genuinely ask (§3). */}
-        <p className="text-page font-bold mt-1 tabular-nums">
+        <p className="text-page font-bold mt-1 tabular-nums text-gray-900 dark:text-white">
           {formatCurrency(annualTotal, displayCurrency)}
         </p>
         <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">

--- a/src/pages/settings/AuditLogs.tsx
+++ b/src/pages/settings/AuditLogs.tsx
@@ -240,7 +240,7 @@ export default function AuditLogs() {
         <div className="bg-gradient-to-r from-gray-600 to-gray-800 dark:from-gray-800 dark:to-gray-900 rounded-2xl p-6 mb-6 text-white shadow-lg">
           <div className="flex items-center justify-between">
             <div>
-              <h1 className="text-page font-bold mb-2">Audit Logs</h1>
+              <h1 className="text-page font-bold mb-2 text-gray-900 dark:text-white">Audit Logs</h1>
               <p className="text-gray-100">
                 Complete history of all system activities and changes
               </p>

--- a/src/test/a11y/headlineFiguresDeclareInk.test.ts
+++ b/src/test/a11y/headlineFiguresDeclareInk.test.ts
@@ -1,0 +1,75 @@
+/**
+ * A HEADLINE FIGURE MUST DECLARE ITS OWN INK.
+ *
+ * The owner found the same defect on three pages in one sitting — "black
+ * font" on What I'm committed to, Account balances and Account distribution
+ * (24 Aug). One cause each time: a display-size figure carrying
+ * `text-page font-bold` and NO colour class at all, so it inherited
+ * whatever the cascade offered. On light ground that lands near-black and
+ * looks deliberate; on dark ground it is near-black on near-black.
+ *
+ * Inheritance is not a colour DECISION — it is the absence of one, and a
+ * page's largest number is the last place to leave it to chance. This
+ * guard reads the source (the cheapest place to catch it: no theme, no
+ * render, no ground to simulate) and fails on any `text-page` or
+ * `text-display` element that names no ink.
+ *
+ * A file may opt out by naming a token that carries its own colour
+ * (`text-primary`, `text-income`, an amount component) — those state a
+ * decision, which is all this asks for.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+const SRC = resolve(process.cwd(), 'src');
+
+function tsxFilesUnder(dir: string): string[] {
+  return readdirSync(dir).flatMap(entry => {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      if (entry === 'node_modules' || entry === '__tests__') return [];
+      return tsxFilesUnder(path);
+    }
+    return entry.endsWith('.tsx') ? [path] : [];
+  });
+}
+
+/** Any class that states an ink colour, token or utility. */
+const NAMES_INK = /\btext-(gray|white|black|slate|zinc|neutral|red|green|blue|amber|yellow|orange|emerald|primary|secondary|tertiary|theme-heading|income|expense|on-primary-action|inherit|current)\b|\btext-\[/;
+
+/** The display sizes a figure or page title uses. */
+const HEADLINE_SIZE = /\btext-(page|display)\b/;
+
+describe('every headline figure declares its own ink', () => {
+  const offenders: string[] = [];
+
+  for (const path of tsxFilesUnder(SRC)) {
+    const content = readFileSync(path, 'utf8');
+    // Every className="..." literal in the file. A template literal with a
+    // conditional colour is left alone: it states a decision by construction.
+    for (const match of content.matchAll(/className="([^"]*)"/g)) {
+      const classes = match[1];
+      if (!HEADLINE_SIZE.test(classes)) continue;
+      if (NAMES_INK.test(classes)) continue;
+      const line = content.slice(0, match.index).split('\n').length;
+      offenders.push(`${relative(process.cwd(), path)}:${line} — ${classes}`);
+    }
+  }
+
+  it('the sweep sees the headline elements it exists for', () => {
+    // A refactor that renamed the size tokens would leave the clause below
+    // vacuously green.
+    const headlines = tsxFilesUnder(SRC)
+      .flatMap(path => [...readFileSync(path, 'utf8').matchAll(/className="([^"]*)"/g)])
+      .filter(m => HEADLINE_SIZE.test(m[1]));
+    expect(headlines.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('names no colourless display-size figure', () => {
+    expect(
+      offenders,
+      'these render at display size with no ink of their own — near-black on a dark ground'
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The owner's items 3, 4 and 5 (24 Aug) — one defect, three pages

"Black font" on **What I'm committed to**, **Account balances** and
**Account distribution**: each is a display-size figure with
`text-page font-bold` and **no colour class at all**, inheriting from the
cascade. Near-black on a dark ground.

Fixed in all four sites the sweep found (his three + Audit Logs' title).

## The guard

`headlineFiguresDeclareInk.test.ts` reads source and fails any
`text-page`/`text-display` element that names no ink — cheapest possible
catch: no theme, no render, no ground to simulate. A class that states a
decision (`text-orange-600`, a token, an amount component) passes; only
inheritance-by-default fails.

- It found a fifth site while being written (Tags' orange figure — a real
  decision, so the rule accepts it)
- Probe-proven: with the fixes stashed it fails on all three pages

## Verification
- Live (dark, demo): Account balances headline computes `rgb(255,255,255)`
- Lint zero; tsc -b clean; husky full gate on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)