### PR TITLE
feat(categorisation): suggestions by account, confirm stops shouting, and the review count says "new"

### DIFF
--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -2925,8 +2925,16 @@ function AccountsList() {
                 the step you are on, the alternative in a plain control. */}
             {(reviewTotal > 0 || reconcileAccountCount > 0) && (() => {
               const nextJob: 'review' | 'reconcile' = reviewTotal > 0 ? 'review' : 'reconcile';
+              // "NEW", because this count answers a different question from
+              // Categorisation's (owner, 24 Aug — he compared 29 here with 30
+              // there and reasonably expected them to agree). This is "arrived
+              // and nobody has looked at it since", over OPEN accounts;
+              // Categorisation counts "has no category" and "the category was
+              // guessed", over every account including closed ones. Three
+              // populations, overlapping, none a subset of another — so the
+              // word has to carry the difference.
               const label = nextJob === 'review'
-                ? `Review ${reviewTotal} transaction${reviewTotal === 1 ? '' : 's'}`
+                ? `Review ${reviewTotal} new transaction${reviewTotal === 1 ? '' : 's'}`
                 : `Reconcile ${reconcileAccountCount} account${reconcileAccountCount === 1 ? '' : 's'}`;
               const wearsAmber = feedsNeedingAttention === 0 && !isFocused;
               const other: 'review' | 'reconcile' = focusMode === 'review' ? 'reconcile' : 'review';

--- a/src/pages/Categorisation.tsx
+++ b/src/pages/Categorisation.tsx
@@ -4,7 +4,9 @@ import { useCurrencyDecimal } from '../hooks/useCurrencyDecimal';
 import { computeIncomeExpense } from '../utils/incomeExpense';
 import { expandSplitTransactions, type SplitExpandedTransaction } from '../utils/transactionSplits';
 import { groupUncategorisedByAccount } from '../utils/uncategorisedByAccount';
-import { groupSuggestedByCategory } from '../utils/categoryProvenance';
+import { groupSuggestedByCategory, groupSuggestedByAccount } from '../utils/categoryProvenance';
+import { preferences } from '../services/preferencesService';
+import { DEPTH_LEVEL_1 } from '../styles/depthShading';
 import { useAccountNames } from '../hooks/useAccountNames';
 import { useToast } from '../contexts/ToastContext';
 import TransferSweepModal from '../components/TransferSweepModal';
@@ -13,6 +15,9 @@ import ReportDrillModal, { type ReportDrillTarget } from '../components/reports/
 import { ArrowRightLeftIcon, TagIcon, ListIcon, CheckCircleIcon, ChevronRightIcon } from '../components/icons';
 import EmptyState from '../components/EmptyState';
 import type { Transaction } from '../types';
+
+/** Which of the two suggested views the reader last chose. */
+const SUGGESTED_VIEW_KEY = 'categorisationSuggestedView';
 
 /**
  * Categorisation — the counterpart to Reconciliation.
@@ -40,7 +45,7 @@ export default function Categorisation(): React.JSX.Element {
   const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
   const [showTransferSweep, setShowTransferSweep] = useState(false);
   const [showBulkCategorize, setShowBulkCategorize] = useState(false);
-  /** Which category group is mid-confirm, so its button can say so. */
+  /** Which group button is mid-confirm, so it alone can say so. */
   const [confirmingCategoryId, setConfirmingCategoryId] = useState<string | null>(null);
 
   // Split parents become one row per line, so a half-filed split still shows
@@ -81,11 +86,38 @@ export default function Categorisation(): React.JSX.Element {
     [suggestedGroups]
   );
 
+  /**
+   * The same suggestions seen BY ACCOUNT (owner, 24 Aug), each account's own
+   * category groups beneath it — the shape the unfiled list above already
+   * uses, and the one that answers "what has this card been guessing at?".
+   * The category view stays the default: a guess is judged against its
+   * category first, and an account is how you narrow it.
+   *
+   * Persisted, because it is a way of working rather than a one-off look.
+   */
+  const [suggestedView, setSuggestedView] = useState<'category' | 'account'>(
+    () => (preferences.getItem(SUGGESTED_VIEW_KEY) === 'account' ? 'account' : 'category')
+  );
+  const chooseSuggestedView = (view: 'category' | 'account'): void => {
+    setSuggestedView(view);
+    preferences.setItem(SUGGESTED_VIEW_KEY, view);
+  };
+
+  const suggestedByAccount = useMemo(
+    () => groupSuggestedByAccount(transactions, accountName),
+    [transactions, accountName]
+  );
+
   const categoryLabel = (categoryId: string): string =>
     categories.find(c => c.id === categoryId)?.name ?? 'Unknown category';
 
-  const confirmGroup = async (categoryId: string, groupRows: Transaction[]): Promise<void> => {
-    setConfirmingCategoryId(categoryId);
+  const confirmGroup = async (
+    categoryId: string,
+    groupRows: Transaction[],
+    /** Which BUTTON is busy — the account view has one per account+category. */
+    busyKey: string = categoryId
+  ): Promise<void> => {
+    setConfirmingCategoryId(busyKey);
     try {
       const confirmed = await confirmTransactionCategories(groupRows.map(row => row.id));
       showSuccess(
@@ -233,43 +265,74 @@ export default function Categorisation(): React.JSX.Element {
           honestly be judged at a glance. */}
       {suggestedCount > 0 && (
         <div>
-          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
-            Suggested categories ({suggestedCount.toLocaleString()})
-          </h2>
+          <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
+            <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+              Suggested categories ({suggestedCount.toLocaleString()})
+            </h2>
+            {/* The same segmented idiom the period picker uses. */}
+            <div className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-0.5">
+              {([['category', 'By category'], ['account', 'By account']] as const).map(([view, label]) => (
+                <button
+                  key={view}
+                  type="button"
+                  onClick={() => chooseSuggestedView(view)}
+                  aria-pressed={suggestedView === view}
+                  className={`px-3 py-1 text-sm font-medium rounded-md transition-colors whitespace-nowrap ${
+                    suggestedView === view
+                      ? 'bg-[#1a2332] dark:bg-[#2d3a4d] text-white'
+                      : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
           <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
             The app filled these in from what you have filed before. They already count in your
             reports — confirming just records that you have checked them.
           </p>
           <div className="flex flex-col gap-2">
-            {suggestedGroups.map(({ categoryId, rows: groupRows }) => (
-              <div
-                key={categoryId}
-                className="w-full bg-white dark:bg-gray-800 rounded-xl border-2 border-amber-200 dark:border-amber-700/60 p-4 flex items-center gap-3"
-              >
-                <div className="p-2 bg-amber-100 dark:bg-amber-900/30 rounded-lg flex-shrink-0">
-                  <TagIcon size={20} className="text-amber-700 dark:text-amber-400" />
-                </div>
-                <button
-                  type="button"
-                  onClick={() => openSuggestedDrill(categoryId, groupRows)}
-                  className="font-medium text-gray-900 dark:text-white truncate min-w-0 flex-1 text-left hover:underline"
-                  title="Look through these transactions before deciding"
-                >
-                  {categoryLabel(categoryId)}
-                  <span className="ml-2 text-sm font-normal text-gray-500 dark:text-gray-400">
-                    {groupRows.length.toLocaleString()} transaction{groupRows.length === 1 ? '' : 's'}
-                  </span>
-                </button>
-                <button
-                  type="button"
-                  onClick={() => void confirmGroup(categoryId, groupRows)}
-                  disabled={confirmingCategoryId !== null}
-                  className="px-4 h-[42px] inline-flex items-center justify-center text-sm font-medium bg-amber-600 text-white rounded-xl hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap flex-shrink-0"
-                >
-                  {confirmingCategoryId === categoryId ? 'Confirming…' : 'Confirm these'}
-                </button>
-              </div>
-            ))}
+            {suggestedView === 'category'
+              ? suggestedGroups.map(({ categoryId, rows: groupRows }) => (
+                  <SuggestedGroupRow
+                    key={categoryId}
+                    label={categoryLabel(categoryId)}
+                    rows={groupRows}
+                    busy={confirmingCategoryId !== null}
+                    confirming={confirmingCategoryId === categoryId}
+                    onOpen={() => openSuggestedDrill(categoryId, groupRows)}
+                    onConfirm={() => void confirmGroup(categoryId, groupRows)}
+                  />
+                ))
+              : suggestedByAccount.map(({ accountId, rows: accountRows, categories: accountCategories }) => (
+                  <div key={accountId} className="flex flex-col gap-2">
+                    {/* The account heads its own categories — the depth ladder's
+                        top step, as everywhere a section heads its rows. */}
+                    <div className={`flex items-baseline justify-between gap-3 rounded px-2 py-2 ${DEPTH_LEVEL_1}`}>
+                      <span className="text-sm font-bold text-gray-900 dark:text-white truncate">
+                        {accountName(accountId)}
+                      </span>
+                      <span className="text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                        {accountRows.length.toLocaleString()} suggested
+                      </span>
+                    </div>
+                    {accountCategories.map(({ categoryId, rows: groupRows }) => (
+                      <SuggestedGroupRow
+                        key={`${accountId}-${categoryId}`}
+                        label={categoryLabel(categoryId)}
+                        rows={groupRows}
+                        indent
+                        busy={confirmingCategoryId !== null}
+                        confirming={confirmingCategoryId === `${accountId}-${categoryId}`}
+                        onOpen={() => openSuggestedDrill(categoryId, groupRows)}
+                        // Confirms THIS ACCOUNT's rows for that category, not
+                        // every account's: the view is the scope.
+                        onConfirm={() => void confirmGroup(categoryId, groupRows, `${accountId}-${categoryId}`)}
+                      />
+                    ))}
+                  </div>
+                ))}
           </div>
         </div>
       )}
@@ -304,5 +367,66 @@ function ActionCard({
       </span>
       <span className="text-sm text-gray-500 dark:text-gray-400">{body}</span>
     </button>
+  );
+}
+
+/**
+ * One suggested group — a guessed category, its size, and the way to agree
+ * with it.
+ *
+ * NEUTRAL, not amber (Design ruling, 24 Aug §1a). Seven amber buttons in a
+ * column was the most amber the app had ever shown at once, and under
+ * Ruling A amber is "this one, next" — singular. These are not next actions
+ * in that sense either: the panel above them says the rows already count in
+ * the reports and confirming only records that they were checked, which
+ * makes this optional bookkeeping. A quiet outline is what optional
+ * bookkeeping looks like.
+ */
+function SuggestedGroupRow({
+  label,
+  rows,
+  indent = false,
+  busy,
+  confirming,
+  onOpen,
+  onConfirm,
+}: {
+  label: string;
+  rows: readonly Transaction[];
+  indent?: boolean;
+  busy: boolean;
+  confirming: boolean;
+  onOpen: () => void;
+  onConfirm: () => void;
+}): React.JSX.Element {
+  return (
+    <div
+      className={`w-full bg-white dark:bg-gray-800 rounded-xl border border-line dark:border-gray-700 p-4 flex items-center gap-3 ${
+        indent ? 'ml-4' : ''
+      }`}
+    >
+      <div className="p-2 bg-gray-100 dark:bg-gray-700/50 rounded-lg flex-shrink-0">
+        <TagIcon size={20} className="text-gray-500 dark:text-gray-400" />
+      </div>
+      <button
+        type="button"
+        onClick={onOpen}
+        className="font-medium text-gray-900 dark:text-white truncate min-w-0 flex-1 text-left hover:underline"
+        title="Look through these transactions before deciding"
+      >
+        {label}
+        <span className="ml-2 text-sm font-normal text-gray-500 dark:text-gray-400">
+          {rows.length.toLocaleString()} transaction{rows.length === 1 ? '' : 's'}
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={onConfirm}
+        disabled={busy}
+        className="px-4 h-[42px] inline-flex items-center justify-center text-sm font-medium rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap flex-shrink-0"
+      >
+        {confirming ? 'Confirming…' : 'Confirm these'}
+      </button>
+    </div>
   );
 }

--- a/src/pages/__tests__/Categorisation.suggested.test.tsx
+++ b/src/pages/__tests__/Categorisation.suggested.test.tsx
@@ -157,4 +157,83 @@ describe('Categorisation — suggested categories', () => {
     expect(screen.queryByRole('button', { name: /confirm all/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /confirm everything/i })).not.toBeInTheDocument();
   });
+
+  describe('the two views — by category, and by account (owner, 24 Aug)', () => {
+    const second: Account = {
+      id: 'acct-2',
+      name: 'Second Account',
+      type: 'current',
+      balance: 0,
+      currency: 'GBP',
+      lastUpdated: new Date('2026-01-01')
+    };
+    const at = (id: string, accountId: string, category: string): Transaction => ({
+      ...txn(id, category, false),
+      accountId
+    }) as Transaction;
+
+    const givenTwoAccounts = (): void => {
+      __setAppContextValue({
+        accounts: [account, second],
+        categories,
+        transactionSplits: [],
+        transactions: [
+          at('a', 'acct-1', 'det-groceries'),
+          at('b', 'acct-1', 'det-groceries'),
+          at('c', 'acct-1', 'det-dining'),
+          at('d', 'acct-2', 'det-groceries')
+        ],
+        confirmTransactionCategories
+      });
+    };
+
+    it('opens on the category view, where a guess is judged against its category', () => {
+      givenTwoAccounts();
+      renderPage();
+      expect(screen.getByRole('button', { name: 'By category' })).toHaveAttribute('aria-pressed', 'true');
+      // Groceries across BOTH accounts is one group of three here.
+      expect(screen.getByText('3 transactions')).toBeInTheDocument();
+      expect(screen.queryByText('Everyday Account')).toBeNull();
+    });
+
+    it('shows each account with its own category groups when asked', () => {
+      givenTwoAccounts();
+      renderPage();
+      fireEvent.click(screen.getByRole('button', { name: 'By account' }));
+
+      expect(screen.getByText('Everyday Account')).toBeInTheDocument();
+      expect(screen.getByText('Second Account')).toBeInTheDocument();
+      // Worst account first, and its own split: 2 groceries + 1 dining.
+      expect(screen.getByText('3 suggested')).toBeInTheDocument();
+      expect(screen.getByText('1 suggested')).toBeInTheDocument();
+      // Groceries is no longer ONE group of three — it is per account.
+      expect(screen.queryByText('3 transactions')).toBeNull();
+    });
+
+    it('confirms only the account it was asked about', async () => {
+      givenTwoAccounts();
+      renderPage();
+      fireEvent.click(screen.getByRole('button', { name: 'By account' }));
+
+      const confirms = screen.getAllByRole('button', { name: 'Confirm these' });
+      fireEvent.click(confirms[0]);
+
+      await waitFor(() => expect(confirmTransactionCategories).toHaveBeenCalled());
+      // The first group is Everyday Account's groceries — two rows, not the
+      // three that share the category across both accounts.
+      expect(confirmTransactionCategories).toHaveBeenCalledWith(['a', 'b']);
+    });
+
+    it('confirming is optional bookkeeping, so no button on this page wears amber', () => {
+      givenTwoAccounts();
+      const { container } = renderPage();
+      // Design's ruling, 24 Aug §1a: seven amber buttons in a column was the
+      // most amber the app had ever shown at once, and amber is "this one,
+      // next" — singular.
+      for (const button of screen.getAllByRole('button', { name: 'Confirm these' })) {
+        expect(button.className).not.toMatch(/amber/);
+      }
+      expect(container.querySelectorAll('[class*="amber"]')).toHaveLength(0);
+    });
+  });
 });

--- a/src/utils/__tests__/categoryProvenance.test.ts
+++ b/src/utils/__tests__/categoryProvenance.test.ts
@@ -6,6 +6,7 @@ import {
   isConfirmableSuggestion,
   suggestedRows,
   groupSuggestedByCategory,
+  groupSuggestedByAccount,
   type CategoryProvenanceRow,
   type ConfirmableCategoryRow,
 } from '../categoryProvenance';
@@ -141,5 +142,58 @@ describe('groupSuggestedByCategory', () => {
 
   it('returns nothing when nothing was guessed', () => {
     expect(groupSuggestedByCategory([row('cat-a', true), row('')])).toEqual([]);
+  });
+});
+
+describe('groupSuggestedByAccount — the same guesses, by where they landed', () => {
+  // Every figure and name below is invented; the repo is public.
+  const name = (id: string): string => ({ 'acc-1': 'Test Card', 'acc-2': 'Test Current' }[id] ?? id);
+  const row = (id: string, accountId: string, category: string) => ({
+    id,
+    accountId,
+    category,
+    // The marker the app actually reads: a guess is a category the user has
+    // not confirmed (see isCategorySuggested).
+    categoryConfirmed: false as const,
+    type: 'expense' as const,
+  });
+
+  it('gathers each account’s suggestions, biggest account first, with its own category groups', () => {
+    const groups = groupSuggestedByAccount(
+      [
+        row('a', 'acc-1', 'cat-food'),
+        row('b', 'acc-1', 'cat-food'),
+        row('c', 'acc-1', 'cat-fuel'),
+        row('d', 'acc-2', 'cat-food'),
+      ],
+      name
+    );
+    expect(groups.map(g => g.accountId)).toEqual(['acc-1', 'acc-2']);
+    expect(groups[0].rows).toHaveLength(3);
+    // Within an account, the same "biggest group first" rule as the category view.
+    expect(groups[0].categories.map(c => [c.categoryId, c.rows.length])).toEqual([
+      ['cat-food', 2],
+      ['cat-fuel', 1],
+    ]);
+    expect(groups[1].categories).toEqual([{ categoryId: 'cat-food', rows: [groups[1].rows[0]] }]);
+  });
+
+  it('leaves out rows nobody guessed at — the two views hold the same population', () => {
+    const confirmed = {
+      id: 'x', accountId: 'acc-1', category: 'cat-food',
+      categoryConfirmed: true as const, type: 'expense' as const,
+    };
+    const groups = groupSuggestedByAccount([confirmed, row('a', 'acc-1', 'cat-food')], name);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].rows.map(r => r.id)).toEqual(['a']);
+  });
+
+  it('breaks a tie on account NAME, so the list cannot reorder under your thumb', () => {
+    const groups = groupSuggestedByAccount(
+      [row('a', 'acc-2', 'cat-food'), row('b', 'acc-1', 'cat-food')],
+      name
+    );
+    // "Test Card" before "Test Current" — one row each.
+    expect(groups.map(g => g.accountId)).toEqual(['acc-1', 'acc-2']);
   });
 });

--- a/src/utils/categoryProvenance.ts
+++ b/src/utils/categoryProvenance.ts
@@ -131,3 +131,51 @@ export function groupSuggestedByCategory<T extends CategoryProvenanceRow>(
   return Array.from(byCategory, ([categoryId, groupRows]) => ({ categoryId, rows: groupRows }))
     .sort((a, b) => b.rows.length - a.rows.length || a.categoryId.localeCompare(b.categoryId));
 }
+
+/** One account's suggestions, gathered by the category guessed for them. */
+export interface SuggestedAccountGroup<T> {
+  accountId: string;
+  /** Every suggested row in this account, across its categories. */
+  rows: T[];
+  /** Those rows by guessed category, biggest group first. */
+  categories: SuggestedCategoryGroup<T>[];
+}
+
+/**
+ * Suggested rows gathered by ACCOUNT, each account's category groups beneath
+ * it (owner, 24 Aug: "view the suggested ones by account, and then the list
+ * of suggested categories below each").
+ *
+ * Why both views exist. A guess is judged against its CATEGORY first — "are
+ * these forty really groceries?" — which is why that stays the default. But
+ * a guess also has a provenance the category view hides: one card's import
+ * can produce a run of suggestions that a glance at the account would settle
+ * in one go. Same rows, same confirm, different question.
+ *
+ * Worst first, ties broken by account NAME rather than by arrival order, for
+ * the reason groupUncategorisedByAccount states: a list that reorders itself
+ * under your thumb is how you tap the wrong row.
+ */
+export function groupSuggestedByAccount<T extends CategoryProvenanceRow & { accountId: string }>(
+  rows: readonly T[],
+  accountName: (accountId: string) => string
+): SuggestedAccountGroup<T>[] {
+  const byAccount = new Map<string, T[]>();
+  for (const row of suggestedRows(rows)) {
+    const existing = byAccount.get(row.accountId);
+    if (existing) existing.push(row);
+    else byAccount.set(row.accountId, [row]);
+  }
+
+  return Array.from(byAccount, ([accountId, accountRows]) => ({
+    accountId,
+    rows: accountRows,
+    // The same grouping the category view uses, so a category means the same
+    // thing on both — one implementation, no second sort to drift.
+    categories: groupSuggestedByCategory(accountRows),
+  })).sort(
+    (a, b) =>
+      b.rows.length - a.rows.length ||
+      accountName(a.accountId).localeCompare(accountName(b.accountId))
+  );
+}


### PR DESCRIPTION
## The owner's count question (his item 1) — investigated

29 on Accounts vs 12 + 18 = 30 on Categorisation. **Neither is wrong**;
they answer different questions over different scopes:

| Surface | Question | Scope |
|---|---|---|
| Accounts "Review 29" | `needsReview` — arrived from an import, nobody has saved it since | **open accounts only** |
| Categorisation "12" | has no category at all | every account, **including the 111 closed** |
| Categorisation "18" | the category was guessed and not confirmed | every account, including closed |

Three overlapping populations, none a subset of another — an imported row
with a good category is in the 29 and neither of the others; a suggested
row already saved is in the 18 and not the 29. The near-match is
coincidence. The control now reads **"Review 29 new transactions"** so the
word carries the difference.

## The owner's item 2 — suggestions by account

A `By category` / `By account` toggle (persisted). The account view heads
each account with its own category groups beneath, matching the unfiled
list above. Category stays the default. **Confirming inside an account
confirms that account's rows only** — the view is the scope; spec-pinned.
`groupSuggestedByAccount` reuses `groupSuggestedByCategory` per account, so
a category means the same thing in both views by construction.

## Design §1a — seven amber buttons

Neutral cards, quiet-outline buttons, neutral icon. The panel's own words
("they already count in your reports — confirming just records that you
have checked them") make this optional bookkeeping, not a next action.
**Nothing on the page wears amber now**, asserted by test.

## Verification
- categoryProvenance 19/19 (3 new: per-account grouping with inner
  category groups, non-suggestions excluded, name tie-break)
- Categorisation.suggested 8/8 (4 new: default view, account view,
  scoped confirm, no-amber)
- Lint zero; tsc -b clean; husky full gate on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)