### PR TITLE
fix(reconciliation): "All transactions ticked" — the badge says what it actually knows

### DIFF
--- a/src/components/reconciliation/ReconciliationAccountList.tsx
+++ b/src/components/reconciliation/ReconciliationAccountList.tsx
@@ -283,8 +283,20 @@ export default function ReconciliationAccountList({
                     // balance entered that column reads "—", so delegating
                     // the answer to it would leave the question unanswered on
                     // exactly the rows this page exists for.
+                    //
+                    // "ALL TRANSACTIONS TICKED", not "All reconciled"
+                    // (Design, 24 Aug §2). Both sentences were true at once
+                    // on the owner's ledger — every row ticked, and the
+                    // statement balance still £80,000 away — but a reader
+                    // takes "all reconciled" to mean THIS ACCOUNT IS DONE,
+                    // and then meets a difference in red beside it. This
+                    // badge only ever knew one of those two facts; now it
+                    // says which, and the Difference column answers whether
+                    // the account actually agrees. On the page that anchors
+                    // the app's claim to being provable, a contradiction the
+                    // reader has to resolve themselves is the costliest kind.
                     <span className="inline-flex items-center py-1 text-xs font-medium text-gray-500 dark:text-gray-400">
-                      All reconciled
+                      All transactions ticked
                     </span>
                   )}
                 </div>

--- a/src/components/reconciliation/__tests__/ReconciliationAccountList.test.tsx
+++ b/src/components/reconciliation/__tests__/ReconciliationAccountList.test.tsx
@@ -185,7 +185,7 @@ describe('ReconciliationAccountList — rows, not cards', () => {
       summaries: [{ ...summary('a5', 'Settled Account', 100, 100), unreconciledCount: 0 }],
     };
     renderGrouping(reconciled);
-    const badge = screen.getByText('All reconciled');
+    const badge = screen.getByText('All transactions ticked');
 
     // It was `bg-blue-100 text-blue-700` — the app's LINK blue, on a thing that
     // is not a link, on every unremarkable row at once.

--- a/src/pages/__tests__/Reconciliation.counts.test.tsx
+++ b/src/pages/__tests__/Reconciliation.counts.test.tsx
@@ -3,7 +3,7 @@
  *
  * The owner's book showed this page saying **2,447 unreconciled transactions
  * across all accounts** above a screen of rows that every one of them said
- * "All reconciled", Difference £0.00. Both numbers were produced correctly by
+ * "All transactions ticked", Difference £0.00. Both numbers were produced correctly by
  * their own lights; they answered different questions, and nothing in the app
  * or in its tests ever put them side by side. That is the pin bug's failure
  * mode exactly: two facts written from different sources, read back under
@@ -137,7 +137,7 @@ describe('Reconciliation — the headline decomposes into the rows', () => {
     expect(headline()).toBeNull();
     expect(badgeTotal()).toBe(0);
     expect(screen.getByText('All accounts are up to date')).toBeInTheDocument();
-    expect(screen.getByText('All reconciled')).toBeInTheDocument();
+    expect(screen.getByText('All transactions ticked')).toBeInTheDocument();
     // The exact contradiction that cost trust: a headline over a screen that
     // disagrees with it.
     expect(screen.queryByText(/unreconciled transactions across all accounts/)).not.toBeInTheDocument();

--- a/src/pages/__tests__/Reconciliation.holdingState.test.tsx
+++ b/src/pages/__tests__/Reconciliation.holdingState.test.tsx
@@ -180,7 +180,7 @@ describe('Reconciliation — marking is a holding state', () => {
     // 1. The reconciliation account list — the screen the user comes back to.
     const list = renderAccountList();
     expect(await screen.findByText('3 unreconciled')).toBeInTheDocument();
-    expect(screen.queryByText('All reconciled')).not.toBeInTheDocument();
+    expect(screen.queryByText('All transactions ticked')).not.toBeInTheDocument();
     list.unmount();
 
     // 2. The Accounts page's Unreconciled column, which is where the owner


### PR DESCRIPTION
## Design review 24 Aug §2

A row read **"All reconciled"** beside **(£80,000.00)** in red. Both true —
every transaction ticked, statement balance still £80,000 away — but "all
reconciled" reads as *this account is done*, leaving the reader to resolve
the contradiction.

The badge renders from `unreconciledCount === 0`: it knows about **ticks**,
not agreement. It now says that, and the Difference column answers whether
the account agrees — which is what that column is for.

## Verification
- Reconciliation suites green (45 across three files; all three carried the
  old words, including the one whose header narrates the 2,447-vs-nothing
  incident this page was hardened against)
- Lint zero; tsc -b clean; husky full gate on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)