### PR TITLE
style(investments,categories): the last stock-blue series, and a tutorial that outstayed its welcome

### DIFF
--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -1599,12 +1599,18 @@ function InvestmentsView() {
                 formatter={(value) => formatCurrency(toDecimal(Number(value)))}
                 contentStyle={chartTooltipStyle} itemStyle={chartTooltipItemStyle} separator=": "
               />
-              <Line 
-                type="monotone" 
-                dataKey="value" 
-                stroke="#3B82F6" 
+              {/* The shared ramp's first step, not a stock blue (Design,
+                  24 Aug §4): this was the last chart in the app still
+                  carrying the recharts documentation colour, on a page whose
+                  Asset Allocation ring beside it uses the ramp correctly.
+                  A single series takes ramp[0], the same rule DashboardCharts'
+                  BarChart follows. */}
+              <Line
+                type="monotone"
+                dataKey="value"
+                stroke={ramp[0]}
                 strokeWidth={2}
-                dot={{ fill: '#3B82F6' }}
+                dot={{ fill: ramp[0] }}
               />
             </LineChart>
           </ResponsiveContainer>

--- a/src/pages/settings/Categories.tsx
+++ b/src/pages/settings/Categories.tsx
@@ -1000,19 +1000,14 @@ export default function CategoriesSettings() {
             </ul>
           </div>
         </div>
-      ) : (
-        <div className="bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-2xl p-4 mb-6">
-          <div className="text-sm text-gray-600 dark:text-gray-400">
-            <p className="mb-2">💡 <strong>Tip:</strong></p>
-            <ul className="list-disc list-inside space-y-1 ml-2">
-              <li>Click on any category name to view its transactions</li>
-              <li>Click the arrow buttons to expand/collapse subcategories</li>
-              <li>Use Edit Mode to rename or reorganize categories</li>
-              <li>The number in parentheses shows how many transactions are in each category</li>
-            </ul>
-          </div>
-        </div>
-      )}
+      ) : null}
+      {/* NO RESTING-STATE TUTORIAL (Design, 24 Aug §5). Four bullets
+          explaining four self-evident affordances — click a name, click an
+          arrow, the number in parentheses — sat permanently at the top of a
+          page people visit hundreds of times, and were the largest block
+          above the fold. P1: it is chrome. The one genuinely non-obvious
+          item, Edit Mode, explains itself in the panel above the moment the
+          mode is entered, which is where an instruction belongs. */}
 
       {/* Starter set import */}
       {!isEditMode && !isDeleteMode && (


### PR DESCRIPTION
## Design review 24 Aug §4 and §5

- **§4**: the portfolio chart's line and dots were `#3B82F6` — the
  recharts documentation blue, on a page whose Asset Allocation ring uses
  the ramp correctly. Now `ramp[0]`, the single-series rule
  `DashboardCharts.BarChart` already follows. Verified live in dark: the
  line strokes `#94a3b8`.
- **§5**: the permanent four-bullet tutorial on Categories is gone — four
  self-evident affordances, the largest block above the fold, on a page
  visited hundreds of times. The mode-active panels stay: they describe a
  state you just entered. Edit Mode explains itself there, at the point of
  action.

## One item NOT changed, reported instead

§4's second half — *"Total Return has a green arrow but no green figure"*.
The source colours that figure green on a gain (neutral only at zero), and
the live app agrees: `rgb(10,125,87)` on `+£2,328.57`. I'd rather hand it
back than "fix" something the code and the running app both contradict.

## Verification
- Live (dark, demo): line stroke `#94a3b8`; Categories carries no tutorial
  and no 💡
- Lint zero; tsc -b clean; husky full gate on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)