### PR TITLE
feat(open-banking): the pre-pass page joins the app — and a dead feed finally says so

### DIFF
--- a/src/pages/OpenBanking.tsx
+++ b/src/pages/OpenBanking.tsx
@@ -4,7 +4,8 @@ import { useAuth as useClerkAuth } from '@clerk/clerk-react';
 import PageWrapper from '../components/PageWrapper';
 import { bankConnectionService } from '../services/bankConnectionService';
 import type { BankConnection } from '../services/bankConnectionService';
-import { ShieldIcon, CheckCircleIcon, RefreshCwIcon, TrashIcon, AlertCircleIcon, LinkIcon } from '../components/icons';
+import { RefreshCwIcon, AlertCircleIcon, LinkIcon } from '../components/icons';
+import { formatDateTime } from '../utils/dateFormatter';
 import LinkBankAccountsModal from '../components/banking/LinkBankAccountsModal';
 
 type ConnectStatus = 'idle' | 'connecting' | 'error';
@@ -119,16 +120,52 @@ export default function OpenBanking() {
     }
   }, [getToken, loadConnections]);
 
-  const handleDisconnect = useCallback(async (connectionId: string) => {
+  const handleDisconnect = useCallback(async (connectionId: string, institutionName: string) => {
+    // A destructive control asks first, and the question states the
+    // consequence — including what does NOT happen, because "disconnect"
+    // reads scarier than it is: the accounts and every transaction stay.
+    if (!window.confirm(
+      `Disconnect ${institutionName}? Your accounts and their history stay exactly as they are — only the automatic feed stops. You can reconnect at any time.`
+    )) {
+      return;
+    }
     setDeletingIds(prev => new Set(prev).add(connectionId));
     try {
       bankConnectionService.setAuthTokenProvider(() => getToken());
       await bankConnectionService.disconnect(connectionId);
       setConnections(prev => prev.filter(c => c.id !== connectionId));
     } catch {
-      // Show error via alert or toast in future
+      // The connection's own status flips on a failed disconnect and the
+      // list below shows it.
     } finally {
       setDeletingIds(prev => {
+        const next = new Set(prev);
+        next.delete(connectionId);
+        return next;
+      });
+    }
+  }, [getToken]);
+
+  /**
+   * The remedy for a broken connection — a fresh authorisation with the
+   * bank, through the same OAuth door the connection came in by. This is
+   * what "Reconnect" on a stale row does; the redirect leaves the page.
+   */
+  const [reauthorizingIds, setReauthorizingIds] = useState<Set<string>>(new Set());
+  const handleReauthorize = useCallback(async (connectionId: string) => {
+    setReauthorizingIds(prev => new Set(prev).add(connectionId));
+    try {
+      bankConnectionService.setAuthTokenProvider(() => getToken());
+      const result = await bankConnectionService.reauthorizeConnection(connectionId);
+      if (result.url) {
+        window.location.href = result.url;
+        return;
+      }
+      setSyncNotice('The bank did not offer a reconnection link. Try again, or disconnect and connect afresh.');
+    } catch (err) {
+      setSyncNotice(err instanceof Error ? err.message : 'Reconnecting failed. Try again.');
+    } finally {
+      setReauthorizingIds(prev => {
         const next = new Set(prev);
         next.delete(connectionId);
         return next;
@@ -155,67 +192,43 @@ export default function OpenBanking() {
     }
   }, [getToken, loadConnections]);
 
-  const connectedCount = connections.filter(c => c.status === 'connected').length;
-  const totalAccounts = connections.reduce((sum, c) => sum + (c.accountsCount ?? 0), 0);
-
   return (
     <PageWrapper title="Open Banking">
-      {/* Stats Overview */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
-          <div className="flex items-center justify-between">
-            <div>
-              {/* No glyph on any of the three. A bank beside "Connected
-                  Banks" and a tick beside "Synced Accounts" restate the label
-                  in a picture; the figure is the content. Removed all three
-                  rather than two, so the row does not become one card with an
-                  icon and two without. */}
-              <p className="text-sm text-gray-600 dark:text-gray-400">Connected Banks</p>
-              <p className="text-page font-semibold text-gray-900 dark:text-white">{connectedCount}</p>
-            </div>
-          </div>
-        </div>
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm text-gray-600 dark:text-gray-400">Synced Accounts</p>
-              <p className="text-page font-semibold text-gray-900 dark:text-white">{totalAccounts}</p>
-            </div>
-          </div>
-        </div>
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm text-gray-600 dark:text-gray-400">Security Status</p>
-              <p className="text-lg font-semibold text-blue-600">Secured</p>
-            </div>
-          </div>
-        </div>
-      </div>
+      {/* NO STATS ROW, and NO "Security Status: Secured" (Design, 24 Aug
+          §3). "Secured" was a claim in stock blue dressed as a measured
+          status — the app measures nothing that could make it false, which
+          is what a status is. And two count cards over a list of one to
+          three connections restated the list. A total is earned by a
+          question; the list below answers this page's. */}
 
       {/* Connect Bank */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 mb-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6 mb-6">
         <h3 className="text-card font-semibold mb-2 text-gray-900 dark:text-white">Connect Your Bank</h3>
         <p className="text-gray-600 dark:text-gray-400 mb-4">
-          Securely connect your bank accounts to automatically import transactions and keep your balances up to date.
+          Connect a bank and its transactions and balances arrive on their own — the feed keeps
+          the accounts you link up to date.
         </p>
         <button
           type="button"
           onClick={handleConnectBank}
           disabled={connectStatus === 'connecting'}
-          className="inline-flex items-center gap-2 px-5 py-2.5 bg-[#1a2332] text-white rounded-lg hover:bg-[#2d3a4d] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="inline-flex items-center gap-2 px-5 py-2.5 bg-primary-action text-on-primary-action rounded-lg hover:bg-primary-action-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
           <LinkIcon size={18} />
-          {connectStatus === 'connecting' ? 'Redirecting to bank...' : 'Connect Bank Account'}
+          {connectStatus === 'connecting' ? 'Redirecting to bank…' : 'Connect Bank Account'}
         </button>
         {connectStatus === 'error' && connectError && (
-          <div className="mt-3 flex items-center gap-2 text-red-600 text-sm">
+          <div className="mt-3 flex items-center gap-2 text-red-600 dark:text-red-400 text-sm">
             <AlertCircleIcon size={16} />
             <span>{connectError}</span>
           </div>
         )}
-        <p className="text-xs text-gray-500 dark:text-gray-500 dark:text-gray-400 mt-2">
-          Bank connections are secured with 256-bit encryption
+        {/* One sentence of FACT where the decision is made — not the
+            landing-page security card this page used to end with (Design §3:
+            reassurance the user has already bought). */}
+        <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+          Access is read-only, through an FCA-regulated Open Banking provider, and a
+          connection can be removed at any time.
         </p>
       </div>
 
@@ -241,21 +254,30 @@ export default function OpenBanking() {
       )}
 
       {/* Connected Banks */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 mb-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6 mb-6">
         <h3 className="text-card font-semibold mb-4 text-gray-900 dark:text-white">Connected Banks</h3>
         {isLoading ? (
-          <p className="text-gray-500 dark:text-gray-400">Loading connections...</p>
+          <p className="text-gray-500 dark:text-gray-400">Loading connections…</p>
         ) : connections.length === 0 ? (
           <p className="text-gray-500 dark:text-gray-400">No bank connections yet. Click &ldquo;Connect Bank Account&rdquo; to get started.</p>
         ) : (
           <div className="space-y-3">
-            {connections.map(connection => (
+            {connections.map(connection => {
+              const broken = connection.status === 'error' || connection.status === 'reauth_required';
+              return (
               <div
                 key={connection.id}
-                className="flex items-center justify-between p-4 border border-gray-200 dark:border-gray-700 rounded-lg"
+                // The house attention mark, not a red caption (Design §3):
+                // a 3px rail down the leading edge on the rows that need
+                // work — the same idiom the reconciliation rows wear. A dead
+                // feed is the highest-stakes broken state on this page and
+                // it reads like one now.
+                className={`p-4 border border-gray-200 dark:border-gray-700 rounded-lg border-l-[3px] ${
+                  broken ? 'border-l-amber-400 dark:border-l-amber-500' : 'border-l-transparent'
+                }`}
               >
-                <div className="flex items-center gap-3">
-                  <div>
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div className="min-w-0">
                     <p className="font-medium text-gray-900 dark:text-white">{connection.institutionName}</p>
                     <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
                       <span>
@@ -263,126 +285,114 @@ export default function OpenBanking() {
                       </span>
                       {connection.lastSync && (
                         <>
-                          <span className="text-gray-300 dark:text-gray-600 dark:text-gray-400">&middot;</span>
-                          <span>Last synced: {new Date(connection.lastSync).toLocaleString()}</span>
+                          <span className="text-gray-300 dark:text-gray-600">&middot;</span>
+                          {/* The house date words, not the US locale default
+                              with seconds (Design §3): every other surface
+                              says "24 Aug 2026". */}
+                          <span>Last synced {formatDateTime(connection.lastSync)}</span>
                         </>
                       )}
                     </div>
-                    {connection.status === 'error' && (
-                      <p className="text-xs text-red-500 mt-1">{connection.error ?? 'Connection error'}</p>
+                  </div>
+                  {/* LABELLED quiet controls, not four bare icons at one
+                      weight (Design §3, the Accounts ruling from the 13th).
+                      A healthy connection carries no tick — the absence of
+                      trouble needs no signal. */}
+                  <div className="flex flex-wrap items-center gap-2">
+                    {broken && (
+                      <button
+                        type="button"
+                        onClick={() => void handleReauthorize(connection.id)}
+                        disabled={reauthorizingIds.has(connection.id)}
+                        className="px-3 py-1.5 text-sm font-medium rounded-lg border border-amber-400 bg-amber-100 text-amber-700 hover:bg-amber-200 dark:border-amber-500 dark:bg-amber-900 dark:text-amber-300 dark:hover:bg-amber-800 disabled:opacity-50 transition-colors"
+                      >
+                        {reauthorizingIds.has(connection.id) ? 'Redirecting…' : 'Reconnect'}
+                      </button>
                     )}
-                    {connection.status === 'reauth_required' && (
-                      <p className="text-xs text-amber-500 mt-1">Re-authorization required</p>
-                    )}
+                    <button
+                      type="button"
+                      onClick={() => setLinkingConnectionId(connection.id)}
+                      className="px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+                    >
+                      Link accounts
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleSync(connection.id)}
+                      disabled={syncingIds.has(connection.id)}
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:opacity-50 transition-colors"
+                    >
+                      <RefreshCwIcon size={14} className={syncingIds.has(connection.id) ? 'animate-spin' : ''} />
+                      {syncingIds.has(connection.id) ? 'Syncing…' : 'Sync'}
+                    </button>
+                    {/* The destructive action says its name and stands apart
+                        by INK, not by being one more grey icon. It asks
+                        first, and the question states the consequence. */}
+                    <button
+                      type="button"
+                      onClick={() => handleDisconnect(connection.id, connection.institutionName)}
+                      disabled={deletingIds.has(connection.id)}
+                      className="px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 disabled:opacity-50 transition-colors"
+                    >
+                      {deletingIds.has(connection.id) ? 'Disconnecting…' : 'Disconnect'}
+                    </button>
                   </div>
                 </div>
-                <div className="flex items-center gap-2">
-                  {connection.status === 'connected' && (
-                    <CheckCircleIcon size={18} className="text-blue-600" />
-                  )}
-                  {connection.status === 'error' && (
-                    <AlertCircleIcon size={18} className="text-red-500" />
-                  )}
-                  <button
-                    type="button"
-                    onClick={() => setLinkingConnectionId(connection.id)}
-                    className="p-2 text-gray-500 dark:text-gray-400 hover:text-primary hover:bg-[#1a2332]/10 rounded-lg transition-colors"
-                    title="Link bank accounts to your app accounts"
-                  >
-                    <LinkIcon size={18} />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => handleSync(connection.id)}
-                    disabled={syncingIds.has(connection.id)}
-                    className="p-2 text-gray-500 dark:text-gray-400 hover:text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg disabled:opacity-50 transition-colors"
-                    title="Sync accounts & transactions"
-                  >
-                    <RefreshCwIcon size={18} className={syncingIds.has(connection.id) ? 'animate-spin' : ''} />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => handleDisconnect(connection.id)}
-                    disabled={deletingIds.has(connection.id)}
-                    className="p-2 text-gray-500 dark:text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg disabled:opacity-50 transition-colors"
-                    title="Disconnect bank"
-                  >
-                    <TrashIcon size={18} />
-                  </button>
-                </div>
+                {/* THE CONSEQUENCE, THEN THE REMEDY (Design §3: a dead feed
+                    silently staling every balance was a red caption with
+                    neither). This is the source of the amber the Accounts
+                    page shows. */}
+                {broken && (
+                  <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+                    <span className="font-medium text-gray-900 dark:text-white">
+                      This connection has stopped working.
+                    </span>{' '}
+                    Balances and transactions from {connection.institutionName} are no longer
+                    arriving, so the accounts it feeds are going stale
+                    {connection.lastSync ? ` — nothing has come in since ${formatDateTime(connection.lastSync)}` : ''}.
+                    Reconnect to authorise it again and the feed resumes.
+                    {connection.status === 'error' && connection.error ? (
+                      <span className="block mt-1 text-xs text-gray-500 dark:text-gray-400">
+                        The provider said: {connection.error}
+                      </span>
+                    ) : null}
+                  </p>
+                )}
               </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </div>
 
-      {/* How It Works */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 mb-6">
-        <h3 className="text-card font-semibold mb-4 text-gray-900 dark:text-white">How It Works</h3>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div className="text-center">
-            <div className="w-10 h-10 bg-blue-100 dark:bg-blue-900/30 rounded-full flex items-center justify-center mx-auto mb-3">
-              <span className="text-blue-600 font-bold">1</span>
-            </div>
-            <h4 className="font-medium mb-1 text-gray-900 dark:text-white">Connect</h4>
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              Select your bank and authorize read-only access via Open Banking
-            </p>
-          </div>
-          <div className="text-center">
-            <div className="w-10 h-10 bg-blue-100 dark:bg-blue-900/30 rounded-full flex items-center justify-center mx-auto mb-3">
-              <span className="text-blue-600 font-bold">2</span>
-            </div>
-            <h4 className="font-medium mb-1 text-gray-900 dark:text-white">Sync</h4>
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              Your accounts and transactions are securely imported
-            </p>
-          </div>
-          <div className="text-center">
-            <div className="w-10 h-10 bg-blue-100 dark:bg-blue-900/30 rounded-full flex items-center justify-center mx-auto mb-3">
-              <span className="text-blue-600 font-bold">3</span>
-            </div>
-            <h4 className="font-medium mb-1 text-gray-900 dark:text-white">Track</h4>
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              View all your finances in one place with automatic updates
-            </p>
+      {/* How it works — EARNED FURNITURE: an explainer for a flow the reader
+          has not used yet, so it appears only while there is no connection.
+          Someone with a working feed does not need three tiles restating what
+          their own list above demonstrates. Neutral step markers — a number
+          is not a signal (Design §3: the blue circles and the shield were the
+          pre-pass palette). The "Bank-Level Security" marketing card that
+          used to end this page is gone outright; its one factual sentence
+          lives under the Connect button, where the decision is made. */}
+      {!isLoading && connections.length === 0 && (
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6 mb-6">
+          <h3 className="text-card font-semibold mb-4 text-gray-900 dark:text-white">How it works</h3>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {([
+              ['1', 'Connect', 'Choose your bank and authorise read-only access through Open Banking.'],
+              ['2', 'Link', 'Match each bank account to the account it feeds here — or create one.'],
+              ['3', 'Stay current', 'Transactions and balances arrive on their own from then on.'],
+            ] as const).map(([step, title, body]) => (
+              <div key={step} className="text-center">
+                <div className="w-10 h-10 bg-gray-100 dark:bg-gray-700/50 rounded-full flex items-center justify-center mx-auto mb-3">
+                  <span className="text-gray-600 dark:text-gray-300 font-bold">{step}</span>
+                </div>
+                <h4 className="font-medium mb-1 text-gray-900 dark:text-white">{title}</h4>
+                <p className="text-sm text-gray-600 dark:text-gray-400">{body}</p>
+              </div>
+            ))}
           </div>
         </div>
-      </div>
-
-      {/* Security Information */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
-        <div className="flex items-center gap-3 mb-4">
-          <ShieldIcon size={24} className="text-blue-600" />
-          <h3 className="text-card font-semibold text-gray-900 dark:text-white">Bank-Level Security</h3>
-        </div>
-        {/* Capped and gutter-ed. The card is the full page width and these are
-            two SHORT lists, so a plain 50/50 grid put "Data Protection" hard
-            against the left edge, "Privacy First" at exactly halfway, and half
-            a screen of nothing to the right of it — which reads as a column
-            that failed to load rather than as margin. Constraining the pair
-            makes the leftover space obviously the page's, not the layout's. */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-16 max-w-3xl">
-          <div>
-            <h4 className="font-medium mb-2 text-gray-900 dark:text-white">Data Protection</h4>
-            <ul className="space-y-1 text-sm text-gray-600 dark:text-gray-400">
-              <li>• 256-bit encryption for all data</li>
-              <li>• Read-only access to your accounts</li>
-              <li>• No access to move money</li>
-              <li>• Credentials never stored locally</li>
-            </ul>
-          </div>
-          <div>
-            <h4 className="font-medium mb-2 text-gray-900 dark:text-white">Privacy First</h4>
-            <ul className="space-y-1 text-sm text-gray-600 dark:text-gray-400">
-              <li>• FCA-regulated Open Banking provider</li>
-              <li>• No third-party data sharing</li>
-              <li>• Delete connections anytime</li>
-              <li>• Full control over your information</li>
-            </ul>
-          </div>
-        </div>
-      </div>
+      )}
       {/* Link Bank Accounts Modal */}
       {linkingConnectionId && (
         <LinkBankAccountsModal


### PR DESCRIPTION
## Design review 24 Aug §3 — whole page, at the owner's direction

The one surface predating the design pass, owning the highest-stakes
broken state in the product as a red caption.

**The broken state, properly**: an errored/reauth-required connection
wears the house amber rail and states consequence then remedy —
*"Balances and transactions from {bank} are no longer arriving, so the
accounts it feeds are going stale — nothing has come in since {date}.
Reconnect to authorise it again and the feed resumes."* — with
**Reconnect** wired to `reauthorizeConnection` (the real OAuth re-auth
flow). The provider's error rides underneath as detail.

Also:
- "Security Status: Secured" **deleted** (a claim dressed as a status);
  the two count cards went with it — they restated a 1–3 item list
- The "Bank-Level Security" marketing card **deleted**; one factual
  sentence lives under the Connect button instead
- Icon buttons → **labelled quiet controls**; Disconnect apart by ink and
  asking first, the confirm stating what does *not* happen
- No tick on a healthy connection — absence of trouble needs no signal
- House date format (`24 Aug 2026`), token-pair primary, hairline cards
- "How it works" appears **only with no connections**, neutral markers,
  and its steps now include Link (the old ones skipped it)

## Verification
- Live (demo, dark): no "Secured", no marketing card, fact line present,
  neutral steps, no blue circles — screenshot in session
- The broken-row treatment needs a genuinely dead connection; the owner
  has one (Revolut) and will see it on production
- Lint zero; tsc -b clean; husky full gate on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)