### PR TITLE
feat(banking): the provider seam the schema has been waiting for

### DIFF
--- a/api/_lib/banking-sync.ts
+++ b/api/_lib/banking-sync.ts
@@ -1,8 +1,16 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { decryptSecret, encryptSecret } from './encryption.js';
-import { refreshAccessToken } from './truelayer.js';
+import { getProvider, type BankProvider } from './providers/index.js';
 
-export interface TrueLayerConnectionRow {
+/**
+ * A connection row, whichever provider issued it.
+ *
+ * Named for TrueLayer until 24 Aug because it could only ever BE TrueLayer:
+ * the loader below rejected every other provider, so a second provider's
+ * connection 404'd as "Connection not found" on every sync. The row carries
+ * its own provider and the shared path dispatches on it now.
+ */
+export interface BankConnectionRow {
   id: string;
   user_id: string;
   provider: string;
@@ -12,11 +20,20 @@ export interface TrueLayerConnectionRow {
   refresh_token_encrypted: string | null;
 }
 
-const isUnauthorizedTrueLayerError = (error: unknown): boolean => {
-  if (!(error instanceof Error)) {
-    return false;
+/**
+ * The provider that drives this row, or a thrown error naming the row that
+ * cannot be driven. Called at the top of every operation that talks to a
+ * bank, so an unknown provider fails once, loudly, rather than being
+ * mistaken for the default one.
+ */
+const providerFor = (connection: BankConnectionRow): BankProvider => {
+  const provider = getProvider(connection.provider);
+  if (!provider) {
+    throw new Error(
+      `Connection ${connection.id} names provider "${connection.provider}", which this server cannot drive`
+    );
   }
-  return /\b401\b/.test(error.message);
+  return provider;
 };
 
 /**
@@ -39,21 +56,32 @@ export class ReauthRequiredError extends Error {
  * (HTTP 400), not 401, so a literal-401 check (issue #22) misses it. Treat any
  * refresh-call failure, plus a missing refresh token, as needs-reauth.
  */
-export const isReauthRequiredError = (error: unknown): boolean => {
+export const isReauthRequiredError = (error: unknown, connection?: BankConnectionRow): boolean => {
   if (error instanceof ReauthRequiredError) {
     return true;
   }
   if (!(error instanceof Error)) {
     return false;
   }
+  // Each provider classifies in its OWN vocabulary — TrueLayer says
+  // `invalid_grant` on a 400, Plaid says ITEM_LOGIN_REQUIRED in a JSON body
+  // and never uses 401 for a dead item. A shared regex would retry forever
+  // on one provider while raising the reauth CTA correctly on the other.
+  const provider = connection ? getProvider(connection.provider) : null;
+  if (provider) {
+    return provider.isReauthRequiredError(error);
+  }
+  // No row in hand (the handlers' outer catch): fall back to the union of
+  // what the known providers say, which is what this predicate meant before
+  // it could ask anyone.
   return /invalid_grant|no refresh token|token refresh failed|reauth/i.test(error.message);
 };
 
-export const getUserTrueLayerConnection = async (
+export const getUserBankConnection = async (
   supabase: SupabaseClient,
   userId: string,
   connectionId: string
-): Promise<TrueLayerConnectionRow | null> => {
+): Promise<BankConnectionRow | null> => {
   const { data, error } = await supabase
     .from('bank_connections')
     .select('id, user_id, provider, institution_id, institution_name, access_token_encrypted, refresh_token_encrypted')
@@ -65,11 +93,16 @@ export const getUserTrueLayerConnection = async (
     return null;
   }
 
-  if (data.provider !== 'truelayer') {
+  // DISPATCH, not a guard. This used to `return null` for anything that was
+  // not TrueLayer, which is why the schema's second provider was unreachable
+  // from the day it was allowed. An unknown provider is still refused —
+  // driving a connection with the wrong provider's client is how one bank's
+  // data would land in another's account — but a KNOWN one now passes.
+  if (!getProvider(data.provider)) {
     return null;
   }
 
-  return data as TrueLayerConnectionRow;
+  return data as BankConnectionRow;
 };
 
 interface AccessTokenResolution {
@@ -79,30 +112,33 @@ interface AccessTokenResolution {
 
 const refreshConnectionAccessToken = async (
   supabase: SupabaseClient,
-  connection: TrueLayerConnectionRow
+  connection: BankConnectionRow
 ): Promise<AccessTokenResolution> => {
+  const provider = providerFor(connection);
   if (!connection.refresh_token_encrypted) {
-    throw new ReauthRequiredError('TrueLayer access token expired and no refresh token is stored');
+    throw new ReauthRequiredError(
+      `${provider.displayName} access token expired and no refresh token is stored`
+    );
   }
 
   const refreshToken = decryptSecret(connection.refresh_token_encrypted);
   let refreshed;
   try {
-    refreshed = await refreshAccessToken(refreshToken);
+    refreshed = await provider.refreshAccessToken(refreshToken);
   } catch (error) {
     // A failed refresh (invalid_grant / 400 / 401 / expired refresh token) is
     // unrecoverable without the user re-linking — surface it as needs-reauth
     // rather than a transient error.
     const detail = error instanceof Error ? error.message : 'token refresh failed';
-    throw new ReauthRequiredError(`TrueLayer token refresh failed: ${detail}`);
+    throw new ReauthRequiredError(`${provider.displayName} token refresh failed: ${detail}`);
   }
-  const encryptedAccess = encryptSecret(refreshed.access_token);
-  const encryptedRefresh = refreshed.refresh_token
-    ? encryptSecret(refreshed.refresh_token)
+  const encryptedAccess = encryptSecret(refreshed.accessToken);
+  const encryptedRefresh = refreshed.refreshToken
+    ? encryptSecret(refreshed.refreshToken)
     : connection.refresh_token_encrypted;
 
-  const expiresAt = typeof refreshed.expires_in === 'number' && Number.isFinite(refreshed.expires_in)
-    ? new Date(Date.now() + refreshed.expires_in * 1000).toISOString()
+  const expiresAt = refreshed.expiresInSeconds !== null
+    ? new Date(Date.now() + refreshed.expiresInSeconds * 1000).toISOString()
     : null;
 
   const nowIso = new Date().toISOString();
@@ -121,21 +157,24 @@ const refreshConnectionAccessToken = async (
     .eq('user_id', connection.user_id);
 
   return {
-    accessToken: refreshed.access_token,
+    accessToken: refreshed.accessToken,
     refreshed: true
   };
 };
 
-export const withTrueLayerAccessToken = async <T>(
+export const withProviderAccessToken = async <T>(
   supabase: SupabaseClient,
-  connection: TrueLayerConnectionRow,
+  connection: BankConnectionRow,
   operation: (accessToken: string) => Promise<T>
 ): Promise<T> => {
+  const provider = providerFor(connection);
   const accessToken = decryptSecret(connection.access_token_encrypted);
   try {
     return await operation(accessToken);
   } catch (error) {
-    if (!isUnauthorizedTrueLayerError(error)) {
+    // "Is this a stale ACCESS token?" — the provider's own answer, because a
+    // literal 401 is TrueLayer's convention and not everyone's.
+    if (!provider.isExpiredTokenError(error)) {
       throw error;
     }
   }

--- a/api/_lib/providers/index.ts
+++ b/api/_lib/providers/index.ts
@@ -1,0 +1,51 @@
+import type { BankProvider } from './types.js';
+import { trueLayerProvider } from './truelayer.js';
+
+export type { BankProvider, ProviderTokens } from './types.js';
+
+/**
+ * THE REGISTRY — every bank-feed provider the server knows how to drive.
+ *
+ * Adding one is: write the adapter, add it here, add its id to the two CHECK
+ * constraints if it is not already allowed (`bank_connections.provider` and
+ * `transactions.external_provider` already permit 'plaid'), and — if it uses
+ * a browser SDK rather than a redirect — allowlist its origins in BOTH
+ * content security policies. That last one is not optional and not
+ * cosmetic: a dev server sends no CSP, so an SDK blocked in production
+ * passes every local check and fails only for real users. That exact failure
+ * hid a broken currency conversion for weeks (see
+ * connectSrcCoversFetchOrigins.test.ts, which now guards it).
+ *
+ * The registry is keyed by the string stored in `bank_connections.provider`,
+ * so a row IS the routing decision — no second source of truth about which
+ * provider a connection belongs to.
+ */
+const PROVIDERS: Record<string, BankProvider> = {
+  [trueLayerProvider.id]: trueLayerProvider,
+};
+
+/**
+ * The provider that drives this connection, or null when the row names one
+ * the server does not know. Null is a real case, not a defensive
+ * afterthought: a row written by a newer deploy, or a provider retired
+ * between deploys, must fail as "this connection cannot be driven" rather
+ * than being silently treated as the default one — which is precisely how a
+ * feed would sync the wrong bank's data into the wrong account.
+ */
+export const getProvider = (providerId: string | null | undefined): BankProvider | null => {
+  if (!providerId) return null;
+  return PROVIDERS[providerId] ?? null;
+};
+
+/** Every provider the server can drive, for the health endpoint. */
+export const listProviders = (): BankProvider[] => Object.values(PROVIDERS);
+
+/**
+ * The provider a NEW connection should use when the client did not name one.
+ *
+ * Kept explicit rather than "the first one in the object": when a second
+ * provider lands, which one an unqualified request gets is a product
+ * decision, and it should be visible here rather than emergent from key
+ * order.
+ */
+export const defaultProviderId = (): string => trueLayerProvider.id;

--- a/api/_lib/providers/truelayer.ts
+++ b/api/_lib/providers/truelayer.ts
@@ -1,0 +1,73 @@
+import type { BankProvider, ProviderTokens } from './types.js';
+import {
+  refreshAccessToken as trueLayerRefresh,
+  revokeAccessToken as trueLayerRevoke,
+} from '../truelayer.js';
+import { getOptionalEnv } from '../env.js';
+
+/**
+ * TrueLayer, behind the shared provider interface.
+ *
+ * A thin adapter, deliberately: `api/_lib/truelayer.ts` keeps every byte of
+ * its HTTP knowledge and is not touched. All this does is answer the four
+ * questions the shared sync path asks, in TrueLayer's own vocabulary — which
+ * is the whole reason the questions are asked of a provider rather than
+ * answered by a regex in the shared path.
+ *
+ * NOTE the `.js` import suffixes. `serverlessImportClosure.test.ts` walks the
+ * whole `api/**` import graph and rejects extensionless relative imports,
+ * because a missing suffix took `discover-accounts` and `sync-accounts` down
+ * in production on 2026-08-09 — the module simply fails to load in the
+ * serverless runtime, so the failure is a 500 at request time, not a build
+ * error anyone would have seen.
+ */
+export const trueLayerProvider: BankProvider = {
+  id: 'truelayer',
+  displayName: 'TrueLayer',
+
+  isConfigured(): boolean {
+    return Boolean(
+      getOptionalEnv('TRUELAYER_CLIENT_ID') &&
+      getOptionalEnv('TRUELAYER_CLIENT_SECRET') &&
+      getOptionalEnv('TRUELAYER_REDIRECT_URI')
+    );
+  },
+
+  async refreshAccessToken(refreshToken: string): Promise<ProviderTokens> {
+    const refreshed = await trueLayerRefresh(refreshToken);
+    return {
+      accessToken: refreshed.access_token,
+      // TrueLayer may or may not rotate the refresh token; when it does not,
+      // the caller keeps the one it already holds.
+      refreshToken: refreshed.refresh_token ?? null,
+      expiresInSeconds:
+        typeof refreshed.expires_in === 'number' && Number.isFinite(refreshed.expires_in)
+          ? refreshed.expires_in
+          : null,
+    };
+  },
+
+  /**
+   * TrueLayer signals a stale ACCESS token as a literal 401, which the HTTP
+   * helpers fold into the error message. Recoverable: refresh and retry.
+   */
+  isExpiredTokenError(error: unknown): boolean {
+    return error instanceof Error && /\b401\b/.test(error.message);
+  },
+
+  /**
+   * A dead REFRESH token comes back as `invalid_grant` on an HTTP 400 — not a
+   * 401 — which is why a literal-401 check missed it (issue #22) and left the
+   * user with a Sync button that could never succeed.
+   */
+  isReauthRequiredError(error: unknown): boolean {
+    return (
+      error instanceof Error &&
+      /invalid_grant|no refresh token|token refresh failed|reauth/i.test(error.message)
+    );
+  },
+
+  async revokeAccessToken(accessToken: string): Promise<void> {
+    await trueLayerRevoke(accessToken);
+  },
+};

--- a/api/_lib/providers/types.ts
+++ b/api/_lib/providers/types.ts
@@ -1,0 +1,86 @@
+/**
+ * WHAT A BANK-FEED PROVIDER HAS TO BE ABLE TO DO.
+ *
+ * The database has expected two providers since it was written —
+ * `bank_connections.provider` is `CHECK (provider IN ('truelayer','plaid'))`,
+ * the uniqueness constraint is `UNIQUE (user_id, institution_id, provider)`,
+ * and `transactions.external_provider` carries the same check. The CODE never
+ * caught up: the client passed a provider argument that never left the
+ * browser, the exchange handler wrote the literal `'truelayer'`, and
+ * `banking-sync` REJECTED any row whose provider was not TrueLayer — so a
+ * second provider's connection would have 404'd as "Connection not found" on
+ * every sync.
+ *
+ * This interface is the seam that was missing. It is deliberately narrow: it
+ * covers only the things that genuinely differ between providers and that the
+ * shared sync path has to ask about. Everything else the feed does — AES-GCM
+ * token storage, the HMAC state token, account re-adoption, balance
+ * snapshots, the atomic import RPC, dedup — is already provider-neutral and
+ * stays where it is.
+ *
+ * ── THE TWO ERROR PREDICATES ARE THE POINT ─────────────────────────────────
+ *
+ * The old code decided "should I refresh?" with `/\b401\b/` against an error
+ * MESSAGE, and "is this unrecoverable?" with a regex for `invalid_grant`.
+ * Both are TrueLayer's vocabulary. Plaid says `ITEM_LOGIN_REQUIRED` in a JSON
+ * body and does not use 401 for an expired item at all, so a provider that
+ * inherited those regexes would retry forever on a dead item and never raise
+ * the reauth CTA. Each provider therefore owns its own classification, and
+ * the shared path only asks the question.
+ */
+
+/** What a token refresh yields, in the shape the connection row stores. */
+export interface ProviderTokens {
+  accessToken: string;
+  /** Null when the provider does not rotate (or does not issue) refresh tokens. */
+  refreshToken: string | null;
+  /** Seconds until the access token expires, when the provider states it. */
+  expiresInSeconds: number | null;
+}
+
+export interface BankProvider {
+  /**
+   * The value stored in `bank_connections.provider`. Must be one of the
+   * values the table's CHECK constraint allows, or an insert will fail with
+   * PG 23514 rather than anything helpful.
+   */
+  readonly id: string;
+
+  /** Human name, for errors and the health endpoint. */
+  readonly displayName: string;
+
+  /**
+   * True when the provider's credentials are present in the environment.
+   * A deploy configured for one provider must report healthy, not degraded,
+   * merely because the other one's variables are absent.
+   */
+  isConfigured(): boolean;
+
+  /**
+   * Exchange a stored refresh token for a fresh access token. Throws when the
+   * refresh itself fails — the caller turns that into `reauth_required`,
+   * because a dead refresh token can only be fixed by the user re-consenting.
+   */
+  refreshAccessToken(refreshToken: string): Promise<ProviderTokens>;
+
+  /**
+   * "This call failed because the ACCESS token is stale — refresh and retry
+   * once." Distinct from the predicate below: this one is recoverable
+   * without the user.
+   */
+  isExpiredTokenError(error: unknown): boolean;
+
+  /**
+   * "Only the user re-linking their bank can fix this." Drives the
+   * `reauth_required` status, the 409, and the Reconnect button.
+   */
+  isReauthRequiredError(error: unknown): boolean;
+
+  /**
+   * Tell the provider to forget the connection, on disconnect. Optional:
+   * not every provider exposes a revoke, and a provider that does not must
+   * not stop the row being deleted — the local delete is what the user
+   * asked for.
+   */
+  revokeAccessToken?(accessToken: string): Promise<void>;
+}

--- a/api/banking/discover-accounts.ts
+++ b/api/banking/discover-accounts.ts
@@ -9,8 +9,8 @@ import { getServiceRoleSupabase } from '../_lib/supabase.js';
 import { setCorsHeaders } from '../_lib/cors.js';
 import { createErrorResponse } from '../_lib/http-error.js';
 import {
-  getUserTrueLayerConnection,
-  withTrueLayerAccessToken
+  getUserBankConnection,
+  withProviderAccessToken
 } from '../_lib/banking-sync.js';
 import { fetchAccountBalance, fetchAccounts, fetchCardBalance, fetchCards } from '../_lib/truelayer.js';
 import {
@@ -58,12 +58,12 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     const connectionId = body.connectionId.trim();
-    const connection = await getUserTrueLayerConnection(supabase, auth.userId, connectionId);
+    const connection = await getUserBankConnection(supabase, auth.userId, connectionId);
     if (!connection) {
       return createErrorResponse(res, 404, 'Connection not found', 'not_found');
     }
 
-    const accounts = await withTrueLayerAccessToken(supabase, connection, async (accessToken) => {
+    const accounts = await withProviderAccessToken(supabase, connection, async (accessToken) => {
       const truelayerAccounts = await fetchAccounts(accessToken);
       // Credit cards live on a separate API surface. fetchCards returns []
       // when the connection's token lacks the cards scope (pre-cards links).

--- a/api/banking/health.ts
+++ b/api/banking/health.ts
@@ -3,19 +3,25 @@ import { AuthError, requireAuth } from '../_lib/auth.js';
 import { isBankingOpsAdmin } from '../_lib/banking-ops.js';
 import { setCorsHeaders } from '../_lib/cors.js';
 import { withSentry } from '../_lib/sentry.js';
+import { listProviders } from '../_lib/providers/index.js';
 
 /**
- * Every var the TrueLayer connect flow needs before it can succeed. The client
- * only ever learns whether ALL of them are present ('ok') or not ('degraded') —
- * enough to decide whether to offer "Connect a bank", and nothing more.
+ * Whether the bank-feed flow can succeed at all. The client only ever learns
+ * 'ok' or 'degraded' — enough to decide whether to offer "Connect a bank",
+ * and nothing more; the per-variable inventory below stays ops-admin only.
  */
-const isBankingConfigured = (): boolean =>
-  Boolean(
-    process.env.TRUELAYER_CLIENT_ID &&
-      process.env.TRUELAYER_CLIENT_SECRET &&
-      process.env.BANKING_STATE_SECRET &&
-      process.env.TRUELAYER_REDIRECT_URI
-  );
+const isBankingConfigured = (): boolean => {
+  // The state secret is shared by every provider — it signs OUR callback
+  // token, not theirs — so it gates the whole feature.
+  if (!process.env.BANKING_STATE_SECRET) {
+    return false;
+  }
+  // ANY configured provider means the feature works (24 Aug). This used to
+  // demand TrueLayer's three variables specifically, so a deploy configured
+  // for a different provider would have reported 'degraded' and the client
+  // would have hidden "Connect a bank" on a perfectly working install.
+  return listProviders().some(provider => provider.isConfigured());
+};
 
 function handler(req: VercelRequest, res: VercelResponse) {
   if (setCorsHeaders(req, res)) {

--- a/api/banking/link-accounts.ts
+++ b/api/banking/link-accounts.ts
@@ -9,9 +9,9 @@ import { setCorsHeaders } from '../_lib/cors.js';
 import { createErrorResponse } from '../_lib/http-error.js';
 import { applyRateLimit } from '../_lib/rate-limit.js';
 import {
-  getUserTrueLayerConnection,
-  withTrueLayerAccessToken,
-  type TrueLayerConnectionRow
+  getUserBankConnection,
+  withProviderAccessToken,
+  type BankConnectionRow
 } from '../_lib/banking-sync.js';
 import { fetchAccountBalance, fetchCardBalance } from '../_lib/truelayer.js';
 import { withSentry } from '../_lib/sentry.js';
@@ -43,11 +43,11 @@ import {
  */
 const fetchLinkBalances = async (
   supabase: ReturnType<typeof getServiceRoleSupabase>,
-  connection: TrueLayerConnectionRow,
+  connection: BankConnectionRow,
   links: LinkAccountsRequest['links']
 ): Promise<Map<string, BankBalanceSnapshot>> => {
   try {
-    return await withTrueLayerAccessToken(supabase, connection, async (accessToken) => {
+    return await withProviderAccessToken(supabase, connection, async (accessToken) => {
       const entries = await Promise.all(
         links.map(async (link): Promise<[string, BankBalanceSnapshot]> => [
           link.externalAccountId,
@@ -105,7 +105,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     const connectionId = body.connectionId.trim();
-    const connection = await getUserTrueLayerConnection(supabase, auth.userId, connectionId);
+    const connection = await getUserBankConnection(supabase, auth.userId, connectionId);
     if (!connection) {
       return createErrorResponse(res, 404, 'Connection not found', 'not_found');
     }

--- a/api/banking/sync-accounts.ts
+++ b/api/banking/sync-accounts.ts
@@ -11,12 +11,12 @@ import { applyRateLimit } from '../_lib/rate-limit.js';
 import { createErrorResponse } from '../_lib/http-error.js';
 import { captureServerError, withSentry } from '../_lib/sentry.js';
 import {
-  getUserTrueLayerConnection,
+  getUserBankConnection,
   isReauthRequiredError,
   markConnectionNeedsReauth,
   markConnectionSyncFailure,
   markConnectionSyncSuccess,
-  withTrueLayerAccessToken
+  withProviderAccessToken
 } from '../_lib/banking-sync.js';
 import { fetchAccountBalance, fetchAccounts, fetchCardBalance, fetchCards } from '../_lib/truelayer.js';
 import {
@@ -438,12 +438,12 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     const connectionId = body.connectionId.trim();
-    const connection = await getUserTrueLayerConnection(supabase, auth.userId, connectionId);
+    const connection = await getUserBankConnection(supabase, auth.userId, connectionId);
     if (!connection) {
       return createErrorResponse(res, 404, 'Connection not found', 'not_found');
     }
 
-    const accounts = await withTrueLayerAccessToken(supabase, connection, async (accessToken) => {
+    const accounts = await withProviderAccessToken(supabase, connection, async (accessToken) => {
       const truelayerAccounts = await fetchAccounts(accessToken);
       // Cards live on a separate API surface; [] when the token predates the
       // cards scope, so old bank connections sync exactly as before.
@@ -454,7 +454,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
           // Retried, then believed — including when the answer is "no figure".
           // The old code caught the failure and left `balance` at its initial
           // 0, which the seeding path below then wrote to three columns as a
-          // fact. A 401 is re-thrown from here so withTrueLayerAccessToken can
+          // fact. A 401 is re-thrown from here so withProviderAccessToken can
           // refresh the token and replay the whole operation.
           const balance = await resolveBalanceSnapshot(
             () => fetchAccountBalance(accessToken, account.account_id),
@@ -577,7 +577,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     // state, or one user could flip another's connection to error/reauth.
     const sb = getServiceRoleSupabase();
     const ownedConnection = body?.connectionId && authUserId
-      ? await getUserTrueLayerConnection(sb, authUserId, body.connectionId.trim())
+      ? await getUserBankConnection(sb, authUserId, body.connectionId.trim())
       : null;
     if (ownedConnection && authUserId) {
       if (needsReauth) {

--- a/api/banking/sync-transactions.ts
+++ b/api/banking/sync-transactions.ts
@@ -11,13 +11,13 @@ import { captureServerError, withSentry } from '../_lib/sentry.js';
 import { applyRateLimit } from '../_lib/rate-limit.js';
 import { getServiceRoleSupabase } from '../_lib/supabase.js';
 import {
-  getUserTrueLayerConnection,
+  getUserBankConnection,
   isReauthRequiredError,
   markConnectionNeedsReauth,
   markConnectionSyncFailure,
   markConnectionSyncNoAccounts,
   markConnectionSyncSuccess,
-  withTrueLayerAccessToken
+  withProviderAccessToken
 } from '../_lib/banking-sync.js';
 import type { TrueLayerTransaction } from '../_lib/truelayer.js';
 import { fetchCardTransactions, fetchTransactions } from '../_lib/truelayer.js';
@@ -141,7 +141,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     const connectionId = body.connectionId.trim();
-    const connection = await getUserTrueLayerConnection(supabase, auth.userId, connectionId);
+    const connection = await getUserBankConnection(supabase, auth.userId, connectionId);
     if (!connection) {
       return createErrorResponse(res, 404, 'Connection not found', 'not_found');
     }
@@ -204,7 +204,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
       return res.status(200).json(response);
     }
 
-    const fetchedTransactions = await withTrueLayerAccessToken(supabase, connection, async (accessToken) => {
+    const fetchedTransactions = await withProviderAccessToken(supabase, connection, async (accessToken) => {
       const allTransactions: Array<{
         accountId: string;
         transaction: TrueLayerTransaction;
@@ -256,13 +256,13 @@ async function handler(req: VercelRequest, res: VercelResponse) {
           account_id: accountId,
           connection_id: connection.id,
           external_transaction_id: externalTransactionId,
-          external_provider: 'truelayer',
+          external_provider: connection.provider,
           description,
           amount,
           type,
           date: toDateOnly(transaction.timestamp),
           metadata: {
-            provider: 'truelayer',
+            provider: connection.provider,
             sourceKind: isCard ? 'card' : 'account',
             sourceAccountId: transaction.account_id,
             transactionType: transaction.transaction_type ?? null,
@@ -407,7 +407,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     // state, or one user could flip another's connection to error/reauth.
     const sb = getServiceRoleSupabase();
     const ownedConnection = body?.connectionId && authUserId
-      ? await getUserTrueLayerConnection(sb, authUserId, body.connectionId.trim())
+      ? await getUserBankConnection(sb, authUserId, body.connectionId.trim())
       : null;
     if (ownedConnection && authUserId) {
       if (needsReauth) {

--- a/scripts/plaid-institution-search.mjs
+++ b/scripts/plaid-institution-search.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Does Plaid actually cover this bank?
+ *
+ * The gating question before any Plaid work: TrueLayer does not link Coutts,
+ * which is the whole reason for looking at Plaid — and Plaid's public docs
+ * render their institution list from JavaScript, so it cannot be read from
+ * outside. This asks Plaid itself.
+ *
+ *   PLAID_CLIENT_ID=… PLAID_SECRET=… node scripts/plaid-institution-search.mjs Coutts
+ *
+ * Defaults to the SANDBOX host, which answers institution queries without
+ * touching a live connection or spending a production call. Pass
+ * --env=development or --env=production to ask the environment your keys
+ * belong to — coverage can differ between them, and production is the one
+ * that decides whether this is worth building.
+ *
+ * Your keys are read from the environment and never printed. Nothing here
+ * writes, links, or authorises anything: /institutions/search is read-only.
+ */
+
+const HOSTS = {
+  sandbox: 'https://sandbox.plaid.com',
+  development: 'https://development.plaid.com',
+  production: 'https://production.plaid.com',
+};
+
+const args = process.argv.slice(2);
+const envArg = args.find(a => a.startsWith('--env='))?.split('=')[1] ?? 'sandbox';
+const query = args.filter(a => !a.startsWith('--')).join(' ') || 'Coutts';
+
+const clientId = process.env.PLAID_CLIENT_ID;
+const secret = process.env.PLAID_SECRET;
+
+if (!clientId || !secret) {
+  console.error(
+    'Set PLAID_CLIENT_ID and PLAID_SECRET in the environment first.\n' +
+    'They are in your Plaid dashboard under Team Settings → Keys.\n' +
+    'Example:\n' +
+    '  PLAID_CLIENT_ID=xxx PLAID_SECRET=yyy node scripts/plaid-institution-search.mjs Coutts'
+  );
+  process.exit(1);
+}
+
+const host = HOSTS[envArg];
+if (!host) {
+  console.error(`Unknown --env=${envArg}. Use sandbox, development or production.`);
+  process.exit(1);
+}
+
+const response = await fetch(`${host}/institutions/search`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    client_id: clientId,
+    secret,
+    query,
+    products: ['transactions'],
+    country_codes: ['GB'],
+  }),
+});
+
+const body = await response.json();
+
+if (!response.ok) {
+  // Plaid names its own failures well; pass the message through rather than
+  // inventing one. Never echo the request body — it holds the secret.
+  console.error(`Plaid said ${response.status}: ${body.error_code ?? ''} ${body.error_message ?? ''}`);
+  process.exit(1);
+}
+
+const found = body.institutions ?? [];
+console.log(`\n"${query}" in GB, ${envArg}, for transactions — ${found.length} match(es)\n`);
+
+if (found.length === 0) {
+  console.log('  Nothing. Either Plaid does not cover it in this environment, or it is');
+  console.log('  listed under a different name — try the parent group (e.g. "NatWest").\n');
+  process.exit(0);
+}
+
+for (const institution of found) {
+  const oauth = institution.oauth ? 'OAuth' : 'credentials';
+  console.log(`  ${institution.name}`);
+  console.log(`    id: ${institution.institution_id}  ·  ${oauth}  ·  products: ${(institution.products ?? []).join(', ')}`);
+  if (institution.status?.item_logins?.status) {
+    console.log(`    login health right now: ${institution.status.item_logins.status}`);
+  }
+  console.log('');
+}

--- a/src/services/banking/bankBalanceSnapshot.ts
+++ b/src/services/banking/bankBalanceSnapshot.ts
@@ -121,7 +121,7 @@ export const httpStatusOfError = (error: unknown): number | undefined => {
 
 /**
  * 401 means the access token has expired, which is not this module's problem
- * to solve: withTrueLayerAccessToken refreshes the token and replays the whole
+ * to solve: withProviderAccessToken refreshes the token and replays the whole
  * operation. Such an error is re-thrown rather than retried or swallowed —
  * swallowing it is how an expired token used to become a £0.00 balance.
  */

--- a/src/test/api-lib/bank-providers.test.ts
+++ b/src/test/api-lib/bank-providers.test.ts
@@ -1,0 +1,87 @@
+/**
+ * THE PROVIDER SEAM — the thing whose absence made the schema's second
+ * provider unreachable.
+ *
+ * `bank_connections.provider` has allowed 'plaid' since the table was
+ * written, and `UNIQUE (user_id, institution_id, provider)` was designed so
+ * the same bank could exist under two providers at once. The code never
+ * caught up: `banking-sync` returned null for any row that was not
+ * TrueLayer, so such a connection 404'd as "Connection not found" on every
+ * single sync.
+ *
+ * These specs pin the seam that replaced that guard. Every id and message
+ * below is invented; the repo is public.
+ */
+import { describe, it, expect } from 'vitest';
+// api/** is excluded from the vitest project (see vitest.config.ts), so the
+// serverless helpers are exercised from here — the same arrangement
+// timing-safe.test.ts and quotes.test.ts use.
+import { getProvider, listProviders, defaultProviderId } from '../../../api/_lib/providers/index';
+import { trueLayerProvider } from '../../../api/_lib/providers/truelayer';
+
+describe('the bank-provider registry', () => {
+  it('answers for a provider it knows, keyed by the value the ROW stores', () => {
+    // The row is the routing decision — there is no second source of truth
+    // about which provider a connection belongs to.
+    expect(getProvider('truelayer')).toBe(trueLayerProvider);
+  });
+
+  it('refuses an unknown provider rather than falling back to the default', () => {
+    // A silent fallback is how one bank's data would be fetched with another
+    // bank's client and land in the wrong account.
+    expect(getProvider('some-provider-this-server-cannot-drive')).toBeNull();
+    expect(getProvider('')).toBeNull();
+    expect(getProvider(null)).toBeNull();
+    expect(getProvider(undefined)).toBeNull();
+  });
+
+  it('names a default explicitly rather than letting key order decide it', () => {
+    expect(defaultProviderId()).toBe('truelayer');
+    expect(getProvider(defaultProviderId())).not.toBeNull();
+  });
+
+  it('every registered provider is reachable by its own id', () => {
+    const providers = listProviders();
+    expect(providers.length).toBeGreaterThan(0);
+    for (const provider of providers) {
+      expect(getProvider(provider.id)).toBe(provider);
+      expect(provider.displayName).toBeTruthy();
+    }
+  });
+
+  it('every registered id is one the database CHECK constraint allows', () => {
+    // bank_connections.provider CHECK (provider IN ('truelayer','plaid')) —
+    // registering an id outside that set would fail at INSERT with PG 23514,
+    // which surfaces as an opaque 500 long after the mistake was made.
+    const allowedByCheckConstraint = ['truelayer', 'plaid'];
+    for (const provider of listProviders()) {
+      expect(allowedByCheckConstraint).toContain(provider.id);
+    }
+  });
+});
+
+describe('TrueLayer classifies its own failures', () => {
+  it('reads a literal 401 as a stale ACCESS token — recoverable by refresh', () => {
+    expect(trueLayerProvider.isExpiredTokenError(new Error('Request failed: 401'))).toBe(true);
+    expect(trueLayerProvider.isExpiredTokenError(new Error('Request failed: 500'))).toBe(false);
+    expect(trueLayerProvider.isExpiredTokenError('not an error')).toBe(false);
+  });
+
+  it('reads invalid_grant as needing the USER, not a retry', () => {
+    // The bug this encodes (issue #22): a dead refresh token comes back as
+    // `invalid_grant` on an HTTP 400, so a literal-401 check missed it and
+    // left a Sync button that could never succeed.
+    expect(trueLayerProvider.isReauthRequiredError(new Error('invalid_grant'))).toBe(true);
+    expect(trueLayerProvider.isReauthRequiredError(new Error('token refresh failed: 400'))).toBe(true);
+    expect(trueLayerProvider.isReauthRequiredError(new Error('Request failed: 500'))).toBe(false);
+  });
+
+  it('keeps the two questions apart', () => {
+    // A 401 is recoverable without the user; invalid_grant is not. A
+    // provider that answered both the same way would either retry forever on
+    // a dead item or send the user to re-consent over a blip.
+    const transient = new Error('Request failed: 401');
+    expect(trueLayerProvider.isExpiredTokenError(transient)).toBe(true);
+    expect(trueLayerProvider.isReauthRequiredError(transient)).toBe(false);
+  });
+});


### PR DESCRIPTION
## The finding

The **database was built for two providers**:
`bank_connections.provider CHECK IN ('truelayer','plaid')`,
`UNIQUE (user_id, institution_id, provider)` (so one bank can exist under
both at once), `transactions.external_provider` with the same check, plus
an unused `sync_metadata.transactions_cursor` and a `webhook_events` table.
**The code never caught up** — the client's provider argument never left
the browser, and `banking-sync` returned null for any non-TrueLayer row, so
a second provider's connection would 404 as "Connection not found" on every
sync.

## What this adds

- `api/_lib/providers/` — a narrow `BankProvider` interface and a registry
  keyed by the value the **row** stores, so a connection *is* the routing
  decision. Unknown provider → refused, never defaulted
- TrueLayer behind a thin adapter; `api/_lib/truelayer.ts` untouched
- `banking-sync` dispatches instead of guarding; both error predicates
  become provider questions (TrueLayer's `401` / `invalid_grant` are *its*
  vocabulary — Plaid uses `ITEM_LOGIN_REQUIRED` and never 401 for a dead
  item, so an inherited regex would retry forever and never raise reauth)
- Imported transactions stamp the connection's own provider
- `health` asks the registry, so a non-TrueLayer deploy stops reporting
  degraded

Plus `scripts/plaid-institution-search.mjs` — asks a provider whether it
covers a bank (their docs render the list from JS). Credentials from env,
never printed.

## Verification
- **80/80** across the banking suites + `serverlessImportClosure` (the
  guard that exists because an extensionless import took two endpoints
  down in production — every new file obeys it)
- 8 new registry specs: row-keyed lookup, unknown refused, explicit
  default, every registered id allowed by the DB CHECK constraint, and the
  two error predicates held apart
- Behaviour identical for existing connections; lint zero; tsc -b clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)