### PR TITLE
fix(open-banking): dead-feed rows offer only what can work, and Disconnect waits for intent

### DIFF
--- a/src/pages/OpenBanking.tsx
+++ b/src/pages/OpenBanking.tsx
@@ -283,12 +283,16 @@ export default function OpenBanking() {
                       <span>
                         {connection.accountsCount ?? 0} account{(connection.accountsCount ?? 0) !== 1 ? 's' : ''}
                       </span>
-                      {connection.lastSync && (
+                      {/* The house date words, not the US locale default with
+                          seconds (Design §3): every other surface says
+                          "24 Aug 2026". Dropped WHILE BROKEN (Design, 24 Aug
+                          §4): the consequence sentence below already carries
+                          the same timestamp as its evidence, and the same
+                          figure twice in one row reads as a rendering fault
+                          to anyone scanning rather than reading. */}
+                      {connection.lastSync && !broken && (
                         <>
                           <span className="text-gray-300 dark:text-gray-600">&middot;</span>
-                          {/* The house date words, not the US locale default
-                              with seconds (Design §3): every other surface
-                              says "24 Aug 2026". */}
                           <span>Last synced {formatDateTime(connection.lastSync)}</span>
                         </>
                       )}
@@ -309,30 +313,45 @@ export default function OpenBanking() {
                         {reauthorizingIds.has(connection.id) ? 'Redirecting…' : 'Reconnect'}
                       </button>
                     )}
-                    <button
-                      type="button"
-                      onClick={() => setLinkingConnectionId(connection.id)}
-                      className="px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
-                    >
-                      Link accounts
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => handleSync(connection.id)}
-                      disabled={syncingIds.has(connection.id)}
-                      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:opacity-50 transition-colors"
-                    >
-                      <RefreshCwIcon size={14} className={syncingIds.has(connection.id) ? 'animate-spin' : ''} />
-                      {syncingIds.has(connection.id) ? 'Syncing…' : 'Sync'}
-                    </button>
-                    {/* The destructive action says its name and stands apart
-                        by INK, not by being one more grey icon. It asks
-                        first, and the question states the consequence. */}
+                    {/* AN AFFORDANCE THAT LEADS NOWHERE IS A DEFECT (Design,
+                        24 Aug §3 — the clickable-zero rule, one surface on).
+                        Linking an account to a feed that is not delivering,
+                        or syncing one that cannot authorise, produces
+                        nothing. While the connection is broken, Reconnect is
+                        the only thing that can change the state, so it is the
+                        only thing offered besides leaving. */}
+                    {!broken && (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() => setLinkingConnectionId(connection.id)}
+                          className="px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+                        >
+                          Link accounts
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleSync(connection.id)}
+                          disabled={syncingIds.has(connection.id)}
+                          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:opacity-50 transition-colors"
+                        >
+                          <RefreshCwIcon size={14} className={syncingIds.has(connection.id) ? 'animate-spin' : ''} />
+                          {syncingIds.has(connection.id) ? 'Syncing…' : 'Sync'}
+                        </button>
+                      </>
+                    )}
+                    {/* NEUTRAL AT REST, RED AT THE MOMENT OF INTENT (the
+                        Accounts ruling of the 13th, restated 24 Aug §1).
+                        Three resting expense-token reds made the loudest
+                        thing on the page the thing you least want pressed —
+                        the same overspend as the Export PDF fill. What keeps
+                        this apart from its neighbours is its POSITION and the
+                        confirm it raises, not a colour worn permanently. */}
                     <button
                       type="button"
                       onClick={() => handleDisconnect(connection.id, connection.institutionName)}
                       disabled={deletingIds.has(connection.id)}
-                      className="px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 disabled:opacity-50 transition-colors"
+                      className="px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:border-red-300 hover:bg-red-50 hover:text-red-600 dark:hover:border-red-800 dark:hover:bg-red-900/20 dark:hover:text-red-400 disabled:opacity-50 transition-colors"
                     >
                       {deletingIds.has(connection.id) ? 'Disconnecting…' : 'Disconnect'}
                     </button>


### PR DESCRIPTION
## Design's before/after review of #417 — three of four

- **§1** `Disconnect` was a resting red on every row. Neutral at rest, red
  on hover — the Accounts ruling of the 13th. Position and the confirm are
  what set it apart, not a permanent colour
- **§3** A broken connection offered four controls, two of which cannot
  work in that state (linking to a feed that isn't delivering; syncing one
  that can't authorise). While broken, **Reconnect is the only action
  offered** that can change the state
- **§4** The errored row printed the same timestamp twice. The consequence
  sentence keeps it as evidence; the metadata line drops it while broken

## §2 — handed back, not fixed

The claim: a missing space in *"going stale— nothing"*. It isn't missing.

- Source bytes: `` ` `` `0x20` `e2 80 94` — backtick, **space**, em dash
- esbuild's JSX output: `last ? " — nothing has come in since ${last}" : ""`
  as its own child, leading space intact

The space is in the source, survives the transform, and renders. Read from
a capture rather than the DOM, an em dash sitting tight against the
preceding word at small size looks exactly like this. Worth a second look
at the original capture before we change a template that four other sites
share.

## Verification
- Lint zero; tsc -b clean; serverlessImportClosure green; husky full gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)