### PR TITLE
fix(mobile): a calendar you can page, and checkboxes that stop being thumb-sized

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,8 @@
       /* Loading spinner animation */
       @keyframes spin{to{transform:rotate(360deg)}}
       .spinner{width:48px;height:48px;border:3px solid #e2e6ed;border-top-color:#1a2332;border-radius:50%;animation:spin 1s linear infinite;margin:0 auto}
-      @media(max-width:768px){body{font-size:16px}button:not(.toggle-switch),a,input,select,textarea{min-height:44px;touch-action:manipulation}}
+      /* Checkbox/radio exempt: index.css draws them 24px with a 10px margin, which IS the 44px target without drawing a 44px control. min-height clamps, so a bare `input` here made every checkbox a large empty square on a phone. FOURTH copy of this rule (index.css, AccessibilityImprovements.tsx, this one) — the duplication is why the exemption kept being missed. */
+      @media(max-width:768px){body{font-size:16px}button:not(.toggle-switch),a,input:not([type="checkbox"]):not([type="radio"]),select,textarea{min-height:44px;touch-action:manipulation}}
     </style>
     
     <!-- Resource hints for performance -->

--- a/src/components/layout/AccessibilityImprovements.tsx
+++ b/src/components/layout/AccessibilityImprovements.tsx
@@ -114,7 +114,17 @@ export function FocusIndicator() {
          with their own >=44px hit area via padding (.toggle-switch) are
          exempt everywhere. */
       @media (hover: none) and (pointer: coarse) {
-        button:not(.toggle-switch), a, input, select, textarea, [role="button"] {
+        /* Checkboxes and radios are exempt — index.css gives them a 24px box
+           with a 10px margin, which IS a 44px target without drawing a
+           44px control. min-* clamps the used value, so an unqualified
+           \`input\` here overrode that and rendered every checkbox on a
+           phone as a large empty square (measured on the calendar's two
+           toggles, mobile sweep 24 Aug). This block is a runtime-injected
+           DUPLICATE of the one in index.css; both carry the exemption now,
+           and the duplication itself is why one of them was missed. */
+        button:not(.toggle-switch), a,
+        input:not([type="checkbox"]):not([type="radio"]),
+        select, textarea, [role="button"] {
           min-height: 44px;
           min-width: 44px;
         }

--- a/src/index.css
+++ b/src/index.css
@@ -26,10 +26,21 @@
      pinned every page off-centre — none of it ever reproducible on a
      desktop, because this media query never matches one. Positioning
      belongs to components; this block's job is minimum hit areas only. */
+  /* CHECKBOXES AND RADIOS ARE EXEMPT, and the rule below is why.
+     `min-width`/`min-height` CLAMP the used value, so they beat the
+     `width: 24px; height: 24px` that the checkbox rule further down sets —
+     which meant that rule's whole intent ("a 24px box with 10px on each
+     side is the 44px target, which is the one way to give a checkbox a
+     finger-sized region without drawing a finger-sized checkbox") was
+     inverted by this one: every checkbox on a touch device was DRAWN at
+     44px, as a large empty square beside its label. Measured on the
+     calendar's "Hide decimals" and "Daily net worth" toggles in the mobile
+     sweep, 24 Aug. Same family as the other index.css traps: a global rule
+     silently outranking the thing that was supposed to govern. */
   .touch-target,
   button:not(.toggle-switch),
   a,
-  input,
+  input:not([type="checkbox"]):not([type="radio"]),
   select,
   textarea,
   [role="button"],

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -730,10 +730,42 @@ function CalendarView() {
 
       {/* Calendar header with navigation */}
       <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 dark:border-gray-700">
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-            {windowTitle}
-          </h2>
+        {/* WRAPS, AND THE ARROWS TRAVEL WITH THE TITLE.
+
+            On a 375px phone this row measured 524px wide inside a card that
+            is `overflow-hidden`, so it was CLIPPED rather than wrapped or
+            scrolled: Today and both navigation arrows were simply
+            unreachable, and a calendar you cannot page is not a calendar.
+            (Found by measurement in the mobile sweep, 24 Aug — the row looks
+            fine at every desktop width, which is why it survived.)
+
+            Two changes, and the second is the one that makes it fit: the row
+            wraps, and the arrows move to flank the title they move — the
+            pattern every calendar app uses on a phone, and the pair that
+            actually belongs together. The owner's 19 Aug ruling governs the
+            OTHER pair ("apple style buttons for week / Month / Year on the
+            left hand side of the 'Today' button") and is untouched: those
+            two stay adjacent, in that order, and now wrap as one unit. */}
+        <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 px-4 sm:px-6 py-4 border-b border-gray-100 dark:border-gray-700">
+          <div className="flex items-center gap-1 min-w-0">
+            <button
+              onClick={() => step(-1)}
+              className="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex-shrink-0"
+              aria-label={`Previous ${view}`}
+            >
+              <ChevronLeftIcon size={20} className="text-gray-600 dark:text-gray-400" />
+            </button>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white truncate">
+              {windowTitle}
+            </h2>
+            <button
+              onClick={() => step(1)}
+              className="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex-shrink-0"
+              aria-label={`Next ${view}`}
+            >
+              <ChevronRightIcon size={20} className="text-gray-600 dark:text-gray-400" />
+            </button>
+          </div>
           <div className="flex items-center gap-2">
             {/* The view, chosen the way Apple Calendar chooses it — a
                 segmented control beside Today (owner, 19 Aug). The chosen
@@ -760,20 +792,6 @@ function CalendarView() {
               className="px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
             >
               Today
-            </button>
-            <button
-              onClick={() => step(-1)}
-              className="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-              aria-label={`Previous ${view}`}
-            >
-              <ChevronLeftIcon size={20} className="text-gray-600 dark:text-gray-400" />
-            </button>
-            <button
-              onClick={() => step(1)}
-              className="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-              aria-label={`Next ${view}`}
-            >
-              <ChevronRightIcon size={20} className="text-gray-600 dark:text-gray-400" />
             </button>
           </div>
         </div>

--- a/src/test/a11y/touchTargetExemptsCheckboxes.test.ts
+++ b/src/test/a11y/touchTargetExemptsCheckboxes.test.ts
@@ -1,0 +1,88 @@
+/**
+ * A CHECKBOX GETS A 44px TARGET WITHOUT BEING DRAWN 44px WIDE.
+ *
+ * index.css states the intent plainly: "a 24px box with 10px on each side is
+ * the 44px target, which is the one way to give a checkbox a finger-sized
+ * region without drawing a finger-sized checkbox." The cascade delivered the
+ * opposite, because `min-width`/`min-height` CLAMP the used value and
+ * therefore beat the `width: 24px; height: 24px` that follows them. Measured
+ * on a phone-width viewport in the mobile sweep (24 Aug): every checkbox in
+ * the app rendered as a 44px empty square beside its label — most visibly on
+ * the calendar's "Hide decimals" and "Daily net worth" toggles.
+ *
+ * What made it survive is the reason this guard exists: the touch-target
+ * rule is written out THREE TIMES, in three languages of the same codebase —
+ * a stylesheet, a runtime-injected <style>, and the critical CSS inlined in
+ * index.html. Fixing one leaves the other two winning, and which one wins
+ * depends on load order and media-query shape (two are pointer-based, the
+ * inline one is width-based, so it catches narrow DESKTOP windows too).
+ *
+ * This reads the source of all three and requires each to exempt checkboxes
+ * and radios. A fourth copy would need adding here, which is the point: the
+ * census fails loudly rather than the app quietly drawing thumb-sized boxes
+ * again.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const read = (p: string): string => readFileSync(resolve(process.cwd(), p), 'utf8');
+
+/** Every place the minimum-touch-target rule is declared. */
+const DECLARATIONS = [
+  { file: 'src/index.css', what: 'the stylesheet' },
+  { file: 'src/components/layout/AccessibilityImprovements.tsx', what: 'the runtime-injected copy' },
+  { file: 'index.html', what: 'the inlined critical CSS' },
+] as const;
+
+/**
+ * A block that applies a 44px minimum to a bare `input` selector — i.e. one
+ * that would clamp a checkbox. Matches the selector list, not the whole
+ * rule, so formatting differences between the three copies do not matter.
+ */
+const claimsBareInput = (source: string): boolean => {
+  // Strip comments first: all three files DISCUSS the bare-input problem in
+  // prose, and a census that matched its own explanation would never pass.
+  const code = source.replace(/\/\*[\s\S]*?\*\//g, '');
+  // A selector list containing `input` with no attribute qualifier, in a
+  // rule that sets a 44px minimum.
+  const blocks = code.match(/[^{}]*\{[^{}]*min-(?:width|height)\s*:\s*44px[^{}]*\}/g) ?? [];
+  return blocks.some(block => {
+    const selector = block.slice(0, block.indexOf('{'));
+    // `input` that is NOT followed by an attribute selector (`input[type=…]`)
+    // and NOT carrying the exemption (`input:not(…)`). Those two are the only
+    // qualified forms in the codebase, and both are safe.
+    return /(^|[,\s])input(?!\s*(?:\[|:not\())/.test(selector);
+  });
+};
+
+describe('the touch-target floor exempts checkboxes and radios', () => {
+  it('the census sees every declaration it exists for', () => {
+    for (const { file } of DECLARATIONS) {
+      const source = read(file);
+      expect(source, `${file} no longer contains a 44px touch-target rule`).toMatch(/min-(width|height)\s*:\s*44px/);
+    }
+  });
+
+  for (const { file, what } of DECLARATIONS) {
+    it(`${what} (${file}) does not clamp a bare input`, () => {
+      expect(
+        claimsBareInput(read(file)),
+        `${file} applies a 44px minimum to a bare \`input\` selector, which clamps ` +
+        `checkboxes and radios to a finger-sized BOX instead of a finger-sized ` +
+        `TARGET. Qualify it: input:not([type="checkbox"]):not([type="radio"]).`
+      ).toBe(false);
+    });
+  }
+
+  it('the 24px box and its 10px margin are still what makes the 44px target', () => {
+    // If this pair ever changes, the exemption above stops being correct and
+    // the reasoning has to be redone rather than the numbers nudged.
+    const css = read('src/index.css');
+    const rule = css.match(/input\[type="checkbox"\][\s\S]{0,120}?\{[\s\S]*?\}/);
+    expect(rule, 'the checkbox sizing rule has moved or gone').not.toBeNull();
+    expect(rule?.[0]).toMatch(/width:\s*24px/);
+    expect(rule?.[0]).toMatch(/height:\s*24px/);
+    expect(rule?.[0]).toMatch(/margin:\s*10px/);
+  });
+});


### PR DESCRIPTION
## The sweep

Run at **375px** and **440px** (the owner's Display Zoom width) across every
surface this fortnight touched, by measurement rather than eye — overflow
and hit areas are numbers.

## Two real defects, both invisible at desktop widths

**1. The calendar could not be paged on a phone.** Its header measured
**524px inside a 375px viewport**, in a card that is `overflow-hidden` — so
it was *clipped*, not wrapped or scrolled. `Today` and both navigation
arrows were unreachable. The row wraps now and the arrows flank the title
they move. The owner's 19 Aug ruling (view buttons left of `Today`) is
untouched — that pair stays adjacent and wraps as one unit.

**2. Every checkbox was drawn at 44px.** `index.css` says the intent
outright — *"a 24px box with 10px on each side is the 44px target, which is
the one way to give a checkbox a finger-sized region without drawing a
finger-sized checkbox"* — and `min-width`/`min-height` **clamp**, so they
beat the `width`/`height` two rules below. Drawn 44×44 where 24×24 was
intended.

It survived because the rule exists **three times**: the stylesheet, a
runtime-injected `<style>`, and the critical CSS inlined in `index.html`.
Two are pointer-based; the inlined one is `max-width: 768px`, so it caught
narrow desktop windows too. Fixing one left the others winning — I found
each in turn by re-measuring.

Now: **24×24 drawn, 44×44 hit area.**

## The guard

`touchTargetExemptsCheckboxes.test.ts` reads all three declarations and
fails **by name** if any drops the exemption — probe-proven by reverting
the `index.html` copy. It also pins the 24px/10px pair, so changing the
numbers forces the reasoning to be redone rather than nudged.

## Everything else was clean
No page-level horizontal scroll at either width on Dashboard, Accounts,
Calendar, Categorisation, Open Banking, Investments, Reconciliation,
Settings or the reports. Report tables overflow only inside their own
`overflow-x-auto` containers, as designed. One 3px reading on Settings was
chased and dismissed — an emulated-scrollbar artefact against a fixed
header, no content exceeds the viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)