### PR TITLE
fix(reports,investments): the label flips rather than the figure — the signed-label ruling

### DIFF
--- a/src/components/MsMoneyImportModal.tsx
+++ b/src/components/MsMoneyImportModal.tsx
@@ -107,7 +107,11 @@ export default function MsMoneyImportModal({ isOpen, onClose, onBackup, onExecut
       <div className="bg-white dark:bg-gray-800 rounded-2xl max-w-2xl w-full max-h-[90vh] overflow-hidden flex flex-col">
         <div className="p-6 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
           <div className="flex items-center gap-3">
-            <DatabaseIcon size={22} className="text-[#1a2332] dark:text-blue-400" />
+            {/* Neutral — the header's own text colour (Design, 24 Aug §3).
+                A blue non-link glyph is the same disqualification as the
+                register chip: blue means "this is a link" everywhere else,
+                and an icon beside a title is neither a link nor a signal. */}
+            <DatabaseIcon size={22} className="text-gray-900 dark:text-white" />
             <h2 className="text-xl font-bold text-gray-900 dark:text-white">Import from Microsoft Money</h2>
           </div>
           <button onClick={handleClose} disabled={stage === 'importing'}

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -1128,18 +1128,32 @@ function InvestmentsView() {
             openBreakdown === 'contributions' ? 'border-[#6b86b3]' : 'border-line dark:border-gray-700'
           }`}
         >
-          <p className="text-body text-gray-500 dark:text-gray-400">Net Contributions</p>
+          {/* THE LABEL FLIPS RATHER THAN THE FIGURE (Design's signed-label
+              ruling, 24 Aug): a label describing a DIRECTION carrying a
+              negative value asks the reader to invert a word, and words do
+              not inverse cleanly — "Net Contributions (£19,338)" means money
+              came out, which is the opposite of what it says. The app has a
+              name for the other direction, so it uses it and prints the
+              magnitude positive.
+
+              The ruling's carve-outs hold elsewhere: this is a DERIVED
+              SUMMARY figure, so it may be renamed. Transactions, balances
+              and column totals keep the parentheses absolutely — a ledger's
+              sign is data, not phrasing. */}
+          <p className="text-body text-gray-500 dark:text-gray-400">
+            {performance.netFlows.isNegative() ? 'Net withdrawals' : 'Net Contributions'}
+          </p>
           {/* NEUTRAL, not link blue (Claude Design, 22 Aug §6): the tile IS
               clickable, but the affordance is the button's own hover border —
               permanently recolouring the number claimed link-ness in the one
-              place colour already means something else. Amounts wear semantic
-              colours or none; a negative net contribution keeps its
-              parentheses from the house formatter. */}
+              place colour already means something else. */}
           <p className="text-page font-bold text-gray-900 dark:text-white">
-            {formatCurrency(performance.netFlows)}
+            {formatCurrency(performance.netFlows.abs())}
           </p>
           <p className="text-dense text-gray-500 dark:text-gray-400 mt-1">
-            Put in less taken out over this period — click for each account's share
+            {performance.netFlows.isNegative()
+              ? 'Taken out less put in over this period — click for each account’s share'
+              : 'Put in less taken out over this period — click for each account’s share'}
           </p>
         </button>
 
@@ -1272,7 +1286,9 @@ function InvestmentsView() {
         <Modal
           isOpen={openBreakdown !== null}
           onClose={() => { setOpenBreakdown(null); setDrillLineId(null); }}
-          title={openBreakdown === 'contributions' ? 'Net Contributions by account' : 'Total Return by account'}
+          title={openBreakdown === 'contributions'
+            ? `${performance.netFlows.isNegative() ? 'Net withdrawals' : 'Net Contributions'} by account`
+            : 'Total Return by account'}
           size="lg"
         >
           <ModalBody>

--- a/src/pages/reports/PeriodComparisonReport.tsx
+++ b/src/pages/reports/PeriodComparisonReport.tsx
@@ -198,6 +198,52 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
       ? figure.current === 0 ? '—' : 'new'
       : `${figure.changePercent > 0 ? '+' : ''}${formatDecimal(figure.changePercent, 1)}%`;
 
+  /**
+   * THE DELTA, SAID IN WORDS WHEN A SIGN WOULD LIE (Design's signed-label
+   * ruling, 24 Aug).
+   *
+   * Against a NEGATIVE base — a deficit — the arithmetic is right and the
+   * reading is wrong: a deficit shrinking by £23,006.66 printed
+   * "+£23,006.66 · +10.0%", and "+10%" of a deficit sounds like more
+   * deficit. The percentage is also 10% of what, exactly — a base the reader
+   * would have to invert to make sense of.
+   *
+   * So against a deficit the pair is phrased rather than signed: the
+   * magnitude, the direction as a WORD, and the percentage as the
+   * improvement or worsening it actually is. The "was (£X)" line beneath
+   * still anchors which period it moved from, so this line does not have to
+   * name the window and risk naming it wrongly.
+   *
+   * Positive bases keep signs untouched — nothing reads awkwardly there,
+   * and the ruling's carve-out is explicit that this is for DERIVED summary
+   * figures only.
+   */
+  const deltaInWords = (figure: ComparisonFigure): React.JSX.Element => {
+    const deficitBase = figure.previous < 0;
+    if (!deficitBase || figure.change === 0 || figure.changePercent === null) {
+      return (
+        <>
+          <span className={`font-semibold tabular-nums ${moveClass(figure.change, 'up')}`}>
+            {figure.change > 0 ? '+' : ''}{money(figure.change)}
+          </span>
+          <span className="text-gray-400 dark:text-gray-500"> · {percent(figure)}</span>
+        </>
+      );
+    }
+    const improving = figure.change > 0;
+    return (
+      <>
+        <span className={`font-semibold tabular-nums ${improving ? 'text-green-700 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+          {money(Math.abs(figure.change))} {improving ? 'smaller' : 'larger'}
+        </span>
+        <span className="text-gray-400 dark:text-gray-500">
+          {' '}· a {formatDecimal(Math.abs(figure.changePercent), 1)}%{' '}
+          {improving ? 'improvement' : 'worsening'}
+        </span>
+      </>
+    );
+  };
+
   /** Green when the move is the good one: more income, or less spending. */
   const moveClass = (change: number, goodWhen: 'up' | 'down'): string => {
     if (change === 0) return 'text-gray-500 dark:text-gray-400';
@@ -233,10 +279,14 @@ export default function PeriodComparisonReport({ picker }: ReportViewProps): Rea
         </button>
       )}
       <p className="text-sm mt-2">
-        <span className={`font-semibold tabular-nums ${moveClass(figure.change, goodWhen)}`}>
-          {figure.change > 0 ? '+' : ''}{money(figure.change)}
-        </span>
-        <span className="text-gray-400 dark:text-gray-500"> · {percent(figure)}</span>
+        {figure.previous < 0 ? deltaInWords(figure) : (
+          <>
+            <span className={`font-semibold tabular-nums ${moveClass(figure.change, goodWhen)}`}>
+              {figure.change > 0 ? '+' : ''}{money(figure.change)}
+            </span>
+            <span className="text-gray-400 dark:text-gray-500"> · {percent(figure)}</span>
+          </>
+        )}
       </p>
       <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
         {bucket === null ? (

--- a/src/pages/reports/__tests__/PeriodComparisonReport.test.tsx
+++ b/src/pages/reports/__tests__/PeriodComparisonReport.test.tsx
@@ -396,4 +396,75 @@ describe('PeriodComparisonReport — which accounts, and which comparison', () =
       expect(screen.getByRole('button', { name: 'Previous period' })).not.toHaveAttribute('aria-disabled');
     });
   });
+
+  describe('the delta against a deficit is phrased, not signed (Design, 24 Aug)', () => {
+    /**
+     * A deficit that SHRANK printed "+£40.00 · +66.7%", and "+66%" of a
+     * deficit sounds like more deficit. Against a negative base the pair is
+     * said in words instead. Every figure is invented; the repo is public.
+     */
+    const deficitStory: Transaction[] = [
+      // March 2026: spent £20 more than earned — Left over is (£20).
+      txn({ id: 'd-in', amount: 100, type: 'income', category: 'grp-salary' }),
+      txn({ id: 'd-out', amount: -120 }),
+      // February 2026: spent £60 more than earned — Left over was (£60).
+      txn({ id: 'p-in', date: new Date(2026, 1, 10), amount: 100, type: 'income', category: 'grp-salary' }),
+      txn({ id: 'p-out', date: new Date(2026, 1, 12), amount: -160 }),
+    ];
+
+    beforeEach(() => {
+      localStorage.clear();
+      useMarch2026();
+      __setAppContextValue({ accounts: ACCOUNTS, categories: CATEGORIES, transactions: deficitStory });
+    });
+
+    it('says the magnitude and the DIRECTION as a word, never "+66.7%" of a deficit', () => {
+      renderReport();
+      // The deficit went from (£60) to (£20): £40 smaller, a 66.7% improvement.
+      expect(screen.getByText(/£40\.00 smaller/)).toBeInTheDocument();
+      expect(screen.getByText(/66\.7% improvement/)).toBeInTheDocument();
+      // The sign that read as "more deficit" is gone from that line.
+      expect(screen.queryByText(/\+66\.7%/)).toBeNull();
+    });
+
+    it('calls a growing deficit larger, and a worsening', () => {
+      // Swap the windows: (£20) last month, (£60) this one.
+      __setAppContextValue({
+        accounts: ACCOUNTS,
+        categories: CATEGORIES,
+        transactions: [
+          txn({ id: 'd-in', amount: 100, type: 'income', category: 'grp-salary' }),
+          txn({ id: 'd-out', amount: -160 }),
+          txn({ id: 'p-in', date: new Date(2026, 1, 10), amount: 100, type: 'income', category: 'grp-salary' }),
+          txn({ id: 'p-out', date: new Date(2026, 1, 12), amount: -120 }),
+        ],
+      });
+      renderReport();
+      expect(screen.getByText(/£40\.00 larger/)).toBeInTheDocument();
+      expect(screen.getByText(/worsening/)).toBeInTheDocument();
+    });
+
+    it('leaves a POSITIVE base alone — nothing reads awkwardly there', () => {
+      // Both windows in surplus: Left over was £400, is now £900. A signed
+      // "+£500.00 · +125.0%" reads perfectly well, so it stands untouched.
+      // (The default fixture is NOT this case — its previous window is a
+      // deficit, which is why the phrasing correctly fires there.)
+      __setAppContextValue({
+        accounts: ACCOUNTS,
+        categories: CATEGORIES,
+        transactions: [
+          txn({ id: 's-in', amount: 1000, type: 'income', category: 'grp-salary' }),
+          txn({ id: 's-out', amount: -100 }),
+          txn({ id: 'q-in', date: new Date(2026, 1, 10), amount: 500, type: 'income', category: 'grp-salary' }),
+          txn({ id: 'q-out', date: new Date(2026, 1, 12), amount: -100 }),
+        ],
+      });
+      renderReport();
+      expect(screen.queryByText(/improvement/)).toBeNull();
+      expect(screen.queryByText(/smaller/)).toBeNull();
+      // Income and Left over both moved by £500 here, so the signed form
+      // appears more than once — its presence is the assertion, not its count.
+      expect(screen.getAllByText(/\+£500\.00/).length).toBeGreaterThan(0);
+    });
+  });
 });


### PR DESCRIPTION
## Design's signed-label ruling, 24 Aug — both surfaces

> When a figure's label reads awkwardly negated, **rename the figure rather
> than sign it.**

- **Investments**: `Net Contributions (£19,338)` → **`Net withdrawals
  £19,338`** when the flow is negative. Caption and drill-modal title follow
  it, so the modal can't disagree with the tile that opened it.
- **This period vs last**: `+£23,006.66 · +10.0%` against a deficit →
  **`£23,006.66 smaller · a 10.0% improvement`** (or *larger* / *worsening*).
  The `was (£X)` line beneath anchors the comparison, so this line never
  names a window and can't name one wrongly.

**Both carve-outs hold.** Derived summary figures only — transactions,
balances and column totals keep the parentheses absolutely, because a
ledger's sign is data not phrasing. Positive bases untouched. And where
there's no honest opposite word the sign stays: `Net worth (£3,466.16)` is
unchanged, since "net debt" is a different claim about the same number.

Plus §3's first small one: the MsMoney header icon goes neutral. (The other
two need no code — the decomposition tooltip landed in #398, and the
ToggleSwitch slate is closed in our favour.)

## Verification
- 27/27 across both suites; 3 new specs — deficit shrinking, deficit
  growing, and a positive base left alone. Writing them caught that the
  existing fixture's own "Left over" base *is* a deficit, so the phrasing
  correctly fires there
- Lint zero; tsc -b clean; husky full gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)