### PR TITLE
feat(design): the amber ladder is evaluated per app, not per page

### DIFF
--- a/src/components/CategoryDataHealthPanel.tsx
+++ b/src/components/CategoryDataHealthPanel.tsx
@@ -50,8 +50,15 @@ export default function CategoryDataHealthPanel({
   onFileUnassignedBucket,
   onShowEmptyCategories,
   onFixTransferFilings,
+  wearsAmber,
 }: {
   health: CategoryHealth;
+  /**
+   * Whether the categorise rung is the app's current next thing (see
+   * utils/attentionLadder). Passed in rather than read here, so this stays
+   * a presentational panel and its state is testable without a provider.
+   */
+  wearsAmber: boolean;
   /** Open the import bucket's rows for filing (the id is the one measured). */
   onFileUnassignedBucket: (categoryId: string) => void;
   /** Show the empty categories in the tree, with deletion reachable. */
@@ -77,24 +84,40 @@ export default function CategoryDataHealthPanel({
   const bucketId = health.unassignedBucketCategoryId;
 
   return (
+    /* THE COLOUR IS THE LADDER'S, THE CONTENT IS THIS PANEL'S (Design's
+       per-app ruling, 24 Aug). This panel and Categorisation's summary
+       report the SAME rung — "a rung is a kind of work, not a location", so
+       two surfaces reporting one rung is normal where two rungs reporting
+       one condition would double-count it. They therefore light and stand
+       down together, and every finding, figure and remedy stays legible in
+       both states: what is surrendered is the claim to be next, not the
+       information. */
     <section
       aria-labelledby="category-data-health-heading"
-      className="lg:shrink-0 rounded-2xl border border-amber-300 dark:border-amber-600 bg-amber-50 dark:bg-amber-900/20 p-4 mb-6"
+      className={`lg:shrink-0 rounded-2xl border p-4 mb-6 ${
+        wearsAmber
+          ? 'border-amber-300 dark:border-amber-600 bg-amber-50 dark:bg-amber-900/20'
+          : 'border-line dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50'
+      }`}
     >
       <h3
         id="category-data-health-heading"
-        className="text-sm font-semibold text-amber-800 dark:text-amber-300 mb-2"
+        className={`text-sm font-semibold mb-2 ${
+          wearsAmber ? 'text-amber-800 dark:text-amber-300' : 'text-gray-900 dark:text-white'
+        }`}
       >
         Data health
       </h3>
-      <ul className="space-y-1.5 text-sm text-amber-800 dark:text-amber-200">
+      <ul className={`space-y-1.5 text-sm ${
+        wearsAmber ? 'text-amber-800 dark:text-amber-200' : 'text-gray-700 dark:text-gray-300'
+      }`}>
         {health.uncategorizedCount > 0 && (
           <li className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
             <span>
               <strong className="tabular-nums">{health.uncategorizedCount.toLocaleString()}</strong>{' '}
               uncategorised transaction{plural(health.uncategorizedCount)} sit outside every report
             </span>
-            <span className="text-amber-700 dark:text-amber-400 tabular-nums">
+            <span className={`tabular-nums ${wearsAmber ? 'text-amber-700 dark:text-amber-400' : 'text-gray-500 dark:text-gray-400'}`}>
               ({formatCurrency(health.uncategorizedIn)} in · {formatCurrency(health.uncategorizedOut)} out)
             </span>
             <Link

--- a/src/hooks/useAttentionLadder.ts
+++ b/src/hooks/useAttentionLadder.ts
@@ -1,0 +1,85 @@
+import { useMemo } from 'react';
+import { useApp } from '../contexts/AppContextSupabase';
+import { useBankConnectionSnapshot } from './useBankConnectionSnapshot';
+import { useReconciliation } from './useReconciliation';
+import { countAwaitingReview } from '../utils/transactionReview';
+import { computeCategoryHealth } from '../utils/categoryHealth';
+import { computeIncomeExpense } from '../utils/incomeExpense';
+import { expandSplitTransactions } from '../utils/transactionSplits';
+import {
+  activeRung,
+  rungWearsAmber,
+  type AttentionRung,
+  type AttentionState,
+} from '../utils/attentionLadder';
+
+/**
+ * WHAT THE APP IS POINTING AT, asked from anywhere.
+ *
+ * Every consuming surface reads THIS rather than its own count, which is
+ * the whole mechanism: a page cannot know it is the next thing by looking
+ * only at itself. Accounts' feed button knew nothing about Categorisation's
+ * backlog, Categorisation knew nothing about a dead feed, and on a real
+ * ledger both were amber at once — each correctly, by its own lights, and
+ * wrongly together.
+ *
+ * The rung order and the reasoning live in utils/attentionLadder; this hook
+ * only gathers the state. Keeping the rule in a pure module is deliberate:
+ * the ordering is the part worth testing exhaustively, and it should not
+ * need React to do it.
+ *
+ * ── COST ───────────────────────────────────────────────────────────────────
+ * Every input here is already computed by the pages that consume it, and all
+ * four are memoised on the same context arrays those pages read, so this is
+ * arithmetic over data already in hand — not a second pass over the ledger.
+ *
+ * ── EDITIONS ───────────────────────────────────────────────────────────────
+ * The desktop edition has no bank feeds at all (see docs/edition-gating), so
+ * its feed rung is permanently zero and the ladder degrades to review-first.
+ * That falls out of the snapshot returning nothing rather than needing a
+ * branch here.
+ */
+export interface AttentionLadder {
+  /** The one rung that may wear amber, or null when nothing is outstanding. */
+  active: AttentionRung | null;
+  /** Every rung's outstanding count — surfaces still SHOW theirs. */
+  state: AttentionState;
+  /**
+   * "May I wear amber?" — asked by the rung a surface reports, so the answer
+   * cannot be accidentally inverted.
+   */
+  wearsAmber: (rung: AttentionRung) => boolean;
+}
+
+export function useAttentionLadder(): AttentionLadder {
+  const { accounts, transactions, transactionSplits, categories } = useApp();
+  const connections = useBankConnectionSnapshot();
+  const { totalUnreconciledCount } = useReconciliation(accounts, transactions);
+
+  const state = useMemo((): AttentionState => {
+    const feed = connections.filter(
+      c => c.status === 'error' || c.status === 'reauth_required'
+    ).length;
+
+    const review = countAwaitingReview(transactions);
+
+    // CATEGORISE IS ONE RUNG ACROSS TWO SURFACES (Design's ruling): the
+    // unfiled backlog and the data-health findings are the same kind of
+    // work, so they are summed into one rung rather than competing as two.
+    const rows = expandSplitTransactions(transactions, transactionSplits);
+    const flows = computeIncomeExpense(rows, [], categories);
+    const health = computeCategoryHealth(transactions, transactionSplits, categories);
+    const categorise =
+      flows.uncategorizedRows.length +
+      health.emptyCategoryCount +
+      health.transferFilingMismatchCount;
+
+    return { feed, review, reconcile: totalUnreconciledCount, categorise };
+  }, [connections, transactions, transactionSplits, categories, totalUnreconciledCount]);
+
+  return useMemo(() => ({
+    active: activeRung(state),
+    state,
+    wearsAmber: (rung: AttentionRung) => rungWearsAmber(state, rung),
+  }), [state]);
+}

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -49,6 +49,7 @@ import { useNetWorthConversion } from '../hooks/useNetWorthConversion';
 import { useReconciliation } from '../hooks/useReconciliation';
 import { countAwaitingReviewByAccount } from '../utils/transactionReview';
 import { useAccountBankSync } from '@service';
+import { useAttentionLadder } from '../hooks/useAttentionLadder';
 import PageWrapper from '../components/PageWrapper';
 import PageTip from '../components/PageTip';
 import { calculateTotalBalance } from '../utils/calculations-decimal';
@@ -380,6 +381,9 @@ function AccountsList() {
   );
   // Per-account bank connection metadata + one-click "pull fresh bank data".
   const { getAccountLink, isAccountSyncing, syncAccount, syncAllConnections, connectedCount, feedsNeedingAttention, isSyncingAny } = useAccountBankSync({ onSynced: refreshAccountsAndTransactions });
+  // WHAT THE APP IS POINTING AT — one rule, read by every amber-bearing
+  // surface (Design's per-app ruling, 24 Aug). See utils/attentionLadder.
+  const ladder = useAttentionLadder();
 
   // Only OPEN accounts appear in the main list and totals; closed ones live in
   // the Closed Accounts section below (the Microsoft Money model — closing
@@ -2895,10 +2899,16 @@ function AccountsList() {
                 mixed one: amber-700 on amber-100 measures 5.5:1, amber-300 on
                 amber-900 10.7:1. Its neighbour Refresh feeds keeps the quiet
                 outline, so there is still exactly one loud control here. */}
+            {/* The COLOUR now comes from the app-wide ladder (Design,
+                24 Aug), not from this page's own count — feed is the top
+                rung, so in practice it wins whenever it has work, but it
+                asks rather than assumes. The LABEL and the count are
+                unchanged either way: standing down surrenders the colour,
+                never the facts. */}
             <button
               onClick={() => setBankConnectionsView('plain')}
               className={`w-full sm:w-auto justify-center px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors flex items-center gap-2 ${
-                feedsNeedingAttention > 0
+                ladder.wearsAmber('feed')
                   ? 'border-amber-400 bg-amber-100 text-amber-700 hover:bg-amber-200 dark:border-amber-500 dark:bg-amber-900 dark:text-amber-300 dark:hover:bg-amber-800'
                   : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
               }`}
@@ -2936,7 +2946,12 @@ function AccountsList() {
               const label = nextJob === 'review'
                 ? `Review ${reviewTotal} new transaction${reviewTotal === 1 ? '' : 's'}`
                 : `Reconcile ${reconcileAccountCount} account${reconcileAccountCount === 1 ? '' : 's'}`;
-              const wearsAmber = feedsNeedingAttention === 0 && !isFocused;
+              // Was "no feed trouble and not focused" — this page reasoning
+              // about one other page's rung. It asks the ladder for its own
+              // rung now, so a Categorisation backlog or a dead feed
+              // anywhere in the app is accounted for by one rule rather than
+              // by each surface guessing about its neighbours.
+              const wearsAmber = ladder.wearsAmber(nextJob) && !isFocused;
               const other: 'review' | 'reconcile' = focusMode === 'review' ? 'reconcile' : 'review';
               const otherHasWork = other === 'review' ? reviewTotal > 0 : reconcileAccountCount > 0;
               return (

--- a/src/pages/Categorisation.tsx
+++ b/src/pages/Categorisation.tsx
@@ -6,6 +6,7 @@ import { expandSplitTransactions, type SplitExpandedTransaction } from '../utils
 import { groupUncategorisedByAccount } from '../utils/uncategorisedByAccount';
 import { groupSuggestedByCategory, groupSuggestedByAccount } from '../utils/categoryProvenance';
 import { preferences } from '../services/preferencesService';
+import { useAttentionLadder } from '../hooks/useAttentionLadder';
 import { DEPTH_LEVEL_1 } from '../styles/depthShading';
 import { useAccountNames } from '../hooks/useAccountNames';
 import { useToast } from '../contexts/ToastContext';
@@ -41,6 +42,8 @@ export default function Categorisation(): React.JSX.Element {
   const { transactions, transactionSplits, categories, confirmTransactionCategories } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   const { showSuccess, showError } = useToast();
+  // One rule, app-wide — see utils/attentionLadder.
+  const ladder = useAttentionLadder();
 
   const [drill, setDrill] = useState<ReportDrillTarget | null>(null);
   const [showTransferSweep, setShowTransferSweep] = useState(false);
@@ -178,11 +181,26 @@ export default function Categorisation(): React.JSX.Element {
         <>
           {/* What is outstanding, and what it is worth. Two columns on a phone,
               four on a desktop — the same shape as the reconciliation bar. */}
-          <div className="bg-white dark:bg-gray-800 rounded-xl border-2 border-amber-300 dark:border-amber-600 p-4">
+          {/* THE LADDER DECIDES THE COLOUR, NOT THE COUNT (Design's per-app
+              ruling, 24 Aug). Categorise is the bottom rung: while a feed is
+              dead, or rows are unreviewed, or an account disagrees with its
+              bank, this panel's figures are not yet facts — so it keeps
+              every one of them and gives up only the amber. Standing down
+              is about which work is NEXT, never about what the reader is
+              allowed to know. */}
+          <div className={`bg-white dark:bg-gray-800 rounded-xl border-2 p-4 ${
+            ladder.wearsAmber('categorise')
+              ? 'border-amber-300 dark:border-amber-600'
+              : 'border-line dark:border-gray-700'
+          }`}>
             <div className="grid grid-cols-2 gap-3 md:grid-cols-3 md:gap-4">
               <div className="text-center">
                 <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">Needs a category</p>
-                <p className="text-lg font-bold text-amber-700 dark:text-amber-400 tabular-nums">
+                <p className={`text-lg font-bold tabular-nums ${
+                  ladder.wearsAmber('categorise')
+                    ? 'text-amber-700 dark:text-amber-400'
+                    : 'text-gray-900 dark:text-white'
+                }`}>
                   {count.toLocaleString()}
                 </p>
               </div>

--- a/src/pages/settings/Categories.tsx
+++ b/src/pages/settings/Categories.tsx
@@ -8,6 +8,7 @@ import EditCategoryModal from '../../components/EditCategoryModal';
 import CategorySelector from '../../components/CategorySelector';
 import CategoryTransactionsModal from '../../components/CategoryTransactionsModal';
 import CategoryDataHealthPanel from '../../components/CategoryDataHealthPanel';
+import { useAttentionLadder } from '../../hooks/useAttentionLadder';
 import IncomeExpenseBreakdownModal from '../../components/IncomeExpenseBreakdownModal';
 import EditTransactionModal from '../../components/EditTransactionModal';
 import { computeCategoryHealth } from '../../utils/categoryHealth';
@@ -245,6 +246,9 @@ export default function CategoriesSettings() {
   // Where the category data is weak — uncategorised rows, import buckets,
   // dangling references, empty categories. Shares the reports' classifier and
   // split expansion so the numbers agree with the report band this points at.
+  // One rule, app-wide — see utils/attentionLadder.
+  const ladder = useAttentionLadder();
+
   const categoryHealth = useMemo(
     () => computeCategoryHealth(transactions, transactionSplits, categories),
     [transactions, transactionSplits, categories]
@@ -1036,6 +1040,7 @@ export default function CategoriesSettings() {
           that land on THIS page are wired here. */}
       <CategoryDataHealthPanel
         health={categoryHealth}
+        wearsAmber={ladder.wearsAmber('categorise')}
         onFileUnassignedBucket={fileUnassignedBucket}
         onShowEmptyCategories={showEmptyCategories}
         onFixTransferFilings={fixTransferFilings}

--- a/src/utils/__tests__/attentionLadder.test.ts
+++ b/src/utils/__tests__/attentionLadder.test.ts
@@ -1,0 +1,84 @@
+/**
+ * THE LADDER — the rule that makes "amber means this one, next" true across
+ * the whole app rather than four times over.
+ *
+ * On a real ledger four surfaces were amber at once, each correct by its own
+ * lights: Accounts' feed button, Categorisation's panel, its seven Confirm
+ * buttons, and Categories' data-health panel. Design ruled the ladder is
+ * evaluated per APP (24 Aug), because a user does not experience one page at
+ * a time.
+ *
+ * These pin the ORDER and its consequences. The order is a dependency chain,
+ * not an importance ranking, and the test that produced it is stated in
+ * attentionLadder.ts — every one of these cases is that test applied.
+ */
+import { describe, it, expect } from 'vitest';
+import { ATTENTION_RUNGS, activeRung, rungWearsAmber } from '../attentionLadder';
+
+describe('the attention ladder picks exactly one rung', () => {
+  it('is ordered feed → review → reconcile → categorise', () => {
+    // The array IS the order, so a reordering edit fails here rather than
+    // silently changing what the app points at.
+    expect([...ATTENTION_RUNGS]).toEqual(['feed', 'review', 'reconcile', 'categorise']);
+  });
+
+  it('says nothing at all when nothing is outstanding', () => {
+    expect(activeRung({})).toBeNull();
+    expect(activeRung({ feed: 0, review: 0, reconcile: 0, categorise: 0 })).toBeNull();
+    // A surface that reports a clean rung must not light up.
+    expect(rungWearsAmber({}, 'categorise')).toBe(false);
+  });
+
+  it('a dead feed outranks everything below it', () => {
+    const state = { feed: 1, review: 29, reconcile: 7, categorise: 30 };
+    expect(activeRung(state)).toBe('feed');
+    // The exact situation from the owner's ledger: three other surfaces had
+    // work, and all three stand down while the feed is down — because their
+    // counts are not yet facts.
+    expect(rungWearsAmber(state, 'review')).toBe(false);
+    expect(rungWearsAmber(state, 'reconcile')).toBe(false);
+    expect(rungWearsAmber(state, 'categorise')).toBe(false);
+  });
+
+  it('review outranks reconcile — you cannot honestly reconcile rows nobody has read', () => {
+    const state = { feed: 0, review: 3, reconcile: 7, categorise: 30 };
+    expect(activeRung(state)).toBe('review');
+    expect(rungWearsAmber(state, 'reconcile')).toBe(false);
+  });
+
+  it('reconcile outranks categorise', () => {
+    const state = { review: 0, reconcile: 7, categorise: 30 };
+    expect(activeRung(state)).toBe('reconcile');
+    expect(rungWearsAmber(state, 'categorise')).toBe(false);
+  });
+
+  it('categorise gets its turn once the chain above it is clear', () => {
+    const state = { feed: 0, review: 0, reconcile: 0, categorise: 30 };
+    expect(activeRung(state)).toBe('categorise');
+    expect(rungWearsAmber(state, 'categorise')).toBe(true);
+  });
+
+  it('an ABSENT rung counts as clean, so no surface can silence one it cannot see', () => {
+    // A page that knows only about categorise must not be able to suppress
+    // the feed rung by omitting it — omission means "nothing outstanding
+    // here", never "nothing outstanding anywhere".
+    expect(activeRung({ categorise: 5 })).toBe('categorise');
+    expect(activeRung({ feed: 1, categorise: 5 })).toBe('feed');
+  });
+
+  it('exactly one rung is ever active, for every combination', () => {
+    // Exhaustive over presence/absence: 16 states, never two ambers.
+    for (let mask = 0; mask < 16; mask++) {
+      const state = {
+        feed: mask & 1 ? 1 : 0,
+        review: mask & 2 ? 1 : 0,
+        reconcile: mask & 4 ? 1 : 0,
+        categorise: mask & 8 ? 1 : 0,
+      };
+      const lit = ATTENTION_RUNGS.filter(rung => rungWearsAmber(state, rung));
+      expect(lit.length, `state ${JSON.stringify(state)} lit ${lit.join(', ')}`).toBeLessThanOrEqual(1);
+      const anyWork = Object.values(state).some(n => n > 0);
+      expect(lit.length).toBe(anyWork ? 1 : 0);
+    }
+  });
+});

--- a/src/utils/__tests__/currencyAggregationCensus.test.ts
+++ b/src/utils/__tests__/currencyAggregationCensus.test.ts
@@ -27,6 +27,14 @@ import { join, relative } from 'node:path';
  * - 'native-known'        — sums native, recorded by the audit, awaiting its
  *                           phase in the ruling's order. New code may NOT
  *                           enter at this status: convert or exclude-and-say.
+ * - 'counts-only'         — reads only ROW COUNTS from the primitive and no
+ *                           money figure at all, so currency cannot affect
+ *                           its output. Not part of the ruling's four-state
+ *                           table, because that table is about disclosing
+ *                           money: a caller that never shows an amount has
+ *                           nothing to disclose. New code MAY enter here,
+ *                           but only if it genuinely touches no total —
+ *                           reading one figure moves it to 'converts'.
  */
 
 const PRIMITIVES = [
@@ -37,7 +45,7 @@ const PRIMITIVES = [
   'buildPortfolioHistory',
 ] as const;
 
-type Status = 'converts' | 'excludes-and-states' | 'native-known';
+type Status = 'converts' | 'excludes-and-states' | 'native-known' | 'counts-only';
 
 /** file (repo-relative, posix) → the statuses of the primitives it calls. */
 const LEDGER: Record<string, Partial<Record<(typeof PRIMITIVES)[number], Status>>> = {
@@ -74,6 +82,12 @@ const LEDGER: Record<string, Partial<Record<(typeof PRIMITIVES)[number], Status>
   'src/pages/Categorisation.tsx': { computeIncomeExpense: 'native-known' },
   'src/pages/reports/PeriodComparisonReport.tsx': { computeIncomeExpense: 'converts' },
   'src/utils/categoryHealth.ts': { computeIncomeExpense: 'native-known' },
+
+  // ── callers that read no money at all ──
+  // The ladder asks "is there outstanding work of this kind?" and reads
+  // `uncategorizedRows.length` — never a total. Its answer is a rung name,
+  // so no exchange rate could change it.
+  'src/hooks/useAttentionLadder.ts': { computeIncomeExpense: 'counts-only' },
 };
 
 const SRC = join(process.cwd(), 'src');

--- a/src/utils/attentionLadder.ts
+++ b/src/utils/attentionLadder.ts
@@ -1,0 +1,101 @@
+/**
+ * THE APP'S ONE NEXT THING.
+ *
+ * Amber means "this one, next" — singular. It was singular per PAGE, which
+ * on a real ledger meant four surfaces each claiming to be the next thing at
+ * the same time: Accounts' feed button, Categorisation's panel, its seven
+ * Confirm buttons, and Categories' data-health panel. Design's ruling of
+ * 24 August: the ladder is evaluated **per app**, because a user does not
+ * experience one page at a time.
+ *
+ * ── THE ORDER, AND THE TEST THAT PRODUCED IT ────────────────────────────────
+ *
+ *   feed → review → reconcile → categorise
+ *
+ * Not an importance ranking — a DEPENDENCY chain. The test for any future
+ * rung, so this never needs re-deciding:
+ *
+ *   > Does this rung's output become untrue if the rung above it is
+ *   > outstanding?
+ *
+ *   feed → review        passes: missing rows change the count.
+ *   review → reconcile   passes: unreviewed rows make the difference
+ *                        provisional.
+ *   reconcile → categorise  FAILS: an uncategorised row is untidy whether or
+ *                        not the account agrees.
+ *
+ * So categorise is last not because it matters least, but because nothing
+ * depends on it — the honest reason, and a more durable one than importance.
+ *
+ * ── WHAT STANDING DOWN MEANS ────────────────────────────────────────────────
+ *
+ * COUNTS NEVER HIDE. A surface that is not the active rung keeps every
+ * figure and every word it had; it gives up only the COLOUR. The work is
+ * still real and still visible — it simply stops claiming to be the thing to
+ * do first. Hiding the count would be a different and much worse product:
+ * the app would be deciding what the user may know.
+ *
+ * ── WHAT THIS DOES NOT GOVERN ───────────────────────────────────────────────
+ *
+ * In-flow marks. The ladder answers "where should I go?"; a mark inside a
+ * flow answers "where am I?", and a reader who has arrived no longer needs
+ * directing. Design's boundary, so the exemption cannot become a loophole —
+ * an in-flow amber qualifies only if ALL THREE hold:
+ *
+ *   1. the user navigated here deliberately;
+ *   2. it marks position or progress rather than soliciting a click;
+ *   3. it disappears when the flow completes.
+ *
+ * Reconciliation's row rails pass all three and are untouched. A banner
+ * offering work on a page the user landed on incidentally fails (1) and
+ * belongs to the ladder.
+ */
+
+/** The rungs, in dependency order. The array IS the order. */
+export const ATTENTION_RUNGS = ['feed', 'review', 'reconcile', 'categorise'] as const;
+
+export type AttentionRung = typeof ATTENTION_RUNGS[number];
+
+/**
+ * What is outstanding, per rung. A caller supplies whatever it knows;
+ * anything absent is treated as "nothing outstanding" rather than unknown,
+ * because a surface that cannot see a rung must not be able to silence one.
+ */
+export interface AttentionState {
+  /** Bank connections that have stopped delivering. */
+  feed?: number;
+  /** Imported rows nobody has looked at yet. */
+  review?: number;
+  /** Accounts whose statement balance disagrees. */
+  reconcile?: number;
+  /**
+   * Work of the CATEGORISE kind, wherever it is reported. Design's ruling:
+   * a rung is a kind of work, not a location — two surfaces reporting one
+   * rung is normal, where two rungs reporting one condition would
+   * double-count the same outstanding work. So Categorisation's unfiled
+   * rows and Categories' data-health findings are one rung between them.
+   */
+  categorise?: number;
+}
+
+/**
+ * The single rung that may wear amber right now, or null when there is no
+ * outstanding work at all.
+ */
+export function activeRung(state: AttentionState): AttentionRung | null {
+  for (const rung of ATTENTION_RUNGS) {
+    if ((state[rung] ?? 0) > 0) return rung;
+  }
+  return null;
+}
+
+/**
+ * May this surface wear amber?
+ *
+ * The question every consumer asks, phrased so the answer cannot be
+ * accidentally inverted: a surface names the rung it REPORTS, and gets back
+ * whether it is the one the app is pointing at.
+ */
+export function rungWearsAmber(state: AttentionState, rung: AttentionRung): boolean {
+  return activeRung(state) === rung;
+}


### PR DESCRIPTION
## Design's ruling, 24 August — all three questions

Four surfaces were amber at once on the owner's ledger, each correct alone
and wrong together. Amber means *this one, next*; four of them means none
of them does.

**Order — `feed → review → reconcile → categorise`.** A dependency chain,
with Design's test so it never needs re-deciding: *does this rung's output
become untrue if the rung above it is outstanding?* feed→review passes,
review→reconcile passes, reconcile→categorise **fails** — so categorise is
last because **nothing depends on it**, not because it matters least.

**One rung, two surfaces.** Categorisation's backlog and Categories' data
health are the same *kind* of work — they light and stand down together.

**Counts never hide.** A stood-down surface keeps every figure, word and
remedy; it surrenders only the colour. Hiding the count would be the app
deciding what the user may know.

**In-flow marks are out of scope**, per the three-part boundary.
Reconciliation's row rails pass all three and are untouched.

## Shape

The rule is a **pure module** (`utils/attentionLadder`) so the ordering is
testable without React; `useAttentionLadder` only gathers state, from
values the consuming pages already compute. Consumers ask
`wearsAmber(rung)` — phrased so the answer can't be accidentally inverted.

The desktop edition has no feeds, so its feed rung is permanently zero and
the ladder degrades to review-first — no branch needed.

## The census earned its keep

It caught the new hook immediately: it calls `computeIncomeExpense`, and
every caller must be classified. It reads only `uncategorizedRows.length`
and no money figure, so it enters under a new honest status —
**`counts-only`**, for a caller whose output no exchange rate could change.
The ruling's four-state table is about *disclosing money*; a caller that
never shows an amount has nothing to disclose.

## Verification
- 8 ladder specs including an **exhaustive 16-state check**: never two
  ambers, exactly one when any work exists, absent rung treated as clean
- **6,286 unit tests pass**; 573 page tests; lint zero; tsc -b clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)