### PR TITLE
fix(banking): Reconnect lands on the bank, not on a list of ninety

### DIFF
--- a/api/_lib/truelayer.ts
+++ b/api/_lib/truelayer.ts
@@ -112,8 +112,35 @@ const TRUELAYER_PROVIDER_BY_INSTITUTION: Record<string, string> = {
   tsb: 'ob-tsb',
 };
 
-export const providerForInstitution = (institutionId: string | undefined): string | undefined =>
-  institutionId ? TRUELAYER_PROVIDER_BY_INSTITUTION[institutionId] : undefined;
+export const providerForInstitution = (institutionId: string | undefined): string | undefined => {
+  if (!institutionId) return undefined;
+  /*
+   * A STORED connection already holds TrueLayer's OWN provider id.
+   *
+   * `bank_connections.institution_id` is written from the provider metadata
+   * TrueLayer returns with the accounts (`provider.provider_id`), so a
+   * Revolut connection is saved as `ob-revolut` — while the shortcut map
+   * below is keyed by OUR ids (`revolut`, `amex`). The lookup therefore
+   * missed on every existing connection and fell through to the full UK
+   * list.
+   *
+   * That is nearly invisible when CONNECTING (the user picked their bank
+   * from our list a moment ago, so a chooser is merely redundant) and badly
+   * wrong when RECONNECTING: the user clicks Reconnect on a row that says
+   * REVOLUT and lands on ninety banks, which reads as the wrong page and is
+   * a very good way to abandon the journey. The owner's connection went
+   * twelve days without a completed re-authorisation while its SCA
+   * exemption sat expired.
+   *
+   * So an id that is already TrueLayer's passes straight through. Their
+   * registry (GET /api/providers, 90 entries) uses these prefixes and no
+   * others.
+   */
+  if (/^(ob|oauth|xs2a)-/.test(institutionId) || institutionId === 'mock') {
+    return institutionId;
+  }
+  return TRUELAYER_PROVIDER_BY_INSTITUTION[institutionId];
+};
 
 export const buildAuthUrl = (options: AuthUrlOptions): string => {
   const url = new URL(getAuthBaseUrl());

--- a/src/test/api-lib/bank-providers.test.ts
+++ b/src/test/api-lib/bank-providers.test.ts
@@ -108,3 +108,36 @@ describe('TrueLayer classifies its own failures', () => {
     expect(trueLayerProvider.isReauthRequiredError(new Error('Request failed: 500'))).toBe(false);
   });
 });
+
+describe('reconnecting lands on the bank, not on a list of ninety', () => {
+  /**
+   * `bank_connections.institution_id` is written from TrueLayer's own
+   * provider metadata, so a stored Revolut connection is `ob-revolut` —
+   * while the shortcut map is keyed by our ids (`revolut`). Every existing
+   * connection therefore missed the lookup and fell through to the full UK
+   * chooser. Merely redundant when connecting; actively misleading when
+   * RECONNECTING, which is the journey a lapsed SCA exemption depends on.
+   * Every id below is TrueLayer's, from their public registry.
+   */
+  it('passes a stored TrueLayer provider id straight through', async () => {
+    const { providerForInstitution } = await import('../../../api/_lib/truelayer');
+    expect(providerForInstitution('ob-revolut')).toBe('ob-revolut');
+    expect(providerForInstitution('ob-natwest')).toBe('ob-natwest');
+    expect(providerForInstitution('ob-amex')).toBe('ob-amex');
+    expect(providerForInstitution('mock')).toBe('mock');
+  });
+
+  it('still maps our own shortcut ids, so the connect journey is unchanged', async () => {
+    const { providerForInstitution } = await import('../../../api/_lib/truelayer');
+    expect(providerForInstitution('revolut')).toBe('ob-revolut');
+    expect(providerForInstitution('hsbc')).toBe('ob-hsbc');
+  });
+
+  it('still yields nothing for an id it genuinely does not know', async () => {
+    // The caller falls back to the full list — a worse journey, never a
+    // broken one.
+    const { providerForInstitution } = await import('../../../api/_lib/truelayer');
+    expect(providerForInstitution('a-bank-we-have-never-heard-of')).toBeUndefined();
+    expect(providerForInstitution(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Why the owner's reconnection never completed

His connection row is decisive: `token_last_refreshed` and `expires_at`
were written **together**, which only a token *refresh* does — a genuine
authorisation writes `expires_at: null`. So his last completed
authorisation is still **12 August**, which is when SCA was last performed,
which is why TrueLayer keeps answering *"SCA exemption has expired. This
resource is protected by SCA."*

## The cause

`bank_connections.institution_id` is written from TrueLayer's own
`provider.provider_id`, so a stored Revolut connection is **`ob-revolut`**.
The shortcut map is keyed by **our** ids (`revolut`, `amex`, `hsbc`), so
the lookup missed on **every existing connection** and fell back to
`uk-ob-all` — the full UK chooser.

Nearly invisible when *connecting* (the user chose their bank from our list
a moment earlier, so a second chooser is just redundant). Badly wrong when
**reconnecting**: you press Reconnect on a row headed REVOLUT and land on
ninety banks. That reads as the wrong page, and it is an excellent way to
abandon the journey — which is what happened, for twelve days.

## The fix

An id that is already TrueLayer's passes straight through, so Reconnect
opens Revolut's own consent screen. Our shortcut ids still map (connect
journey unchanged), and an unknown id still yields nothing and still falls
back to the list — a worse journey, never a broken one.

## Verification
- 13 specs: stored TrueLayer ids pass through, our shortcut ids still map,
  unknown ids still fall back
- Lint zero; tsc -b clean; husky full gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)