### PR TITLE
fix(banking): the reauth classifier is asked properly — my own bug from #423

### DIFF
--- a/api/_lib/banking-sync.ts
+++ b/api/_lib/banking-sync.ts
@@ -1,6 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { decryptSecret, encryptSecret } from './encryption.js';
-import { getProvider, type BankProvider } from './providers/index.js';
+import { getProvider, listProviders, type BankProvider } from './providers/index.js';
 
 /**
  * A connection row, whichever provider issued it.
@@ -71,10 +71,14 @@ export const isReauthRequiredError = (error: unknown, connection?: BankConnectio
   if (provider) {
     return provider.isReauthRequiredError(error);
   }
-  // No row in hand (the handlers' outer catch): fall back to the union of
-  // what the known providers say, which is what this predicate meant before
-  // it could ask anyone.
-  return /invalid_grant|no refresh token|token refresh failed|reauth/i.test(error.message);
+  // NO ROW IN HAND: ask every provider the server knows, and take any yes.
+  //
+  // This used to be a hardcoded copy of TrueLayer's own regex, which made it
+  // a second definition free to drift from the first — and it did, the day
+  // TrueLayer learned to recognise `403 access_denied` and this did not.
+  // A union of the registered providers cannot drift, because there is
+  // nothing left to keep in step.
+  return listProviders().some(provider => provider.isReauthRequiredError(error));
 };
 
 export const getUserBankConnection = async (

--- a/api/banking/sync-accounts.ts
+++ b/api/banking/sync-accounts.ts
@@ -567,10 +567,6 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     const message = error instanceof Error ? error.message : 'Unexpected error';
     // Keep the detailed message server-side; return a generic one to the client.
     console.error('[sync-accounts] sync failed', { message });
-    const needsReauth = isReauthRequiredError(error);
-    if (!needsReauth) {
-      await captureServerError(error, { handler: 'sync-accounts' });
-    }
     const body = req.body as SyncAccountsRequest | undefined;
     // body.connectionId is client-supplied and the service-role client
     // bypasses RLS — re-validate ownership before persisting any failure
@@ -579,6 +575,15 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     const ownedConnection = body?.connectionId && authUserId
       ? await getUserBankConnection(sb, authUserId, body.connectionId.trim())
       : null;
+    // OWNERSHIP FIRST, THEN CLASSIFY — the ROW says which provider's
+    // vocabulary this error is written in, and asking without it fell back
+    // to a generic guess. That is how `403 SCA exemption has expired` — the
+    // one error that most needs the Reconnect button — was filed as an
+    // ordinary sync failure while the row went on looking healthy.
+    const needsReauth = isReauthRequiredError(error, ownedConnection ?? undefined);
+    if (!needsReauth) {
+      await captureServerError(error, { handler: 'sync-accounts' });
+    }
     if (ownedConnection && authUserId) {
       if (needsReauth) {
         await markConnectionNeedsReauth(sb, ownedConnection.id, authUserId, message);

--- a/api/banking/sync-transactions.ts
+++ b/api/banking/sync-transactions.ts
@@ -395,8 +395,18 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     // A needs-reauth failure (expired/invalid refresh token) is unrecoverable
     // without the user re-linking: persist 'reauth_required' so the UI shows its
     // Reauthorize CTA instead of a Sync button that will always fail (#21/#22).
-    const needsReauth = isReauthRequiredError(error);
     const body = req.body as SyncTransactionsRequest | undefined;
+    // OWNERSHIP FIRST, THEN CLASSIFY — because the ROW is what says
+    // which provider's vocabulary this error is written in, and
+    // asking without it silently fell back to a generic guess. That
+    // is exactly how a `403 SCA exemption has expired` — the one
+    // error that most needs the Reconnect button — was filed as an
+    // ordinary sync failure, leaving the row looking healthy.
+    const sb = getServiceRoleSupabase();
+    const ownedConnection = body?.connectionId && authUserId
+      ? await getUserBankConnection(sb, authUserId, body.connectionId.trim())
+      : null;
+    const needsReauth = isReauthRequiredError(error, ownedConnection ?? undefined);
     // needs-reauth is an expected user-action state, not a system fault — only
     // report genuine failures.
     if (!needsReauth) {
@@ -405,10 +415,6 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     // body.connectionId is client-supplied and the service-role client
     // bypasses RLS — re-validate ownership before persisting any failure
     // state, or one user could flip another's connection to error/reauth.
-    const sb = getServiceRoleSupabase();
-    const ownedConnection = body?.connectionId && authUserId
-      ? await getUserBankConnection(sb, authUserId, body.connectionId.trim())
-      : null;
     if (ownedConnection && authUserId) {
       if (needsReauth) {
         await markConnectionNeedsReauth(sb, ownedConnection.id, authUserId, message);

--- a/src/pages/OpenBanking.tsx
+++ b/src/pages/OpenBanking.tsx
@@ -106,7 +106,16 @@ export default function OpenBanking() {
     try {
       bankConnectionService.setAuthTokenProvider(() => getToken());
       const result = await bankConnectionService.syncConnection(connectionId);
-      setSyncNotice(result.success ? null : (result.errors[0] ?? 'The bank sync did not complete.'));
+      // CONSEQUENCE, THEN REMEDY — not the API's deliberately generic
+      // "Transaction sync failed", which names a subsystem rather than
+      // telling the reader anything about their money. The modal's copy of
+      // this was fixed and the PAGE's was missed; both say it now.
+      setSyncNotice(
+        result.success
+          ? null
+          : 'Some transactions didn’t come through, so this account may be behind. ' +
+            'If the row below asks you to reconnect, that is the fix; otherwise syncing again usually completes it.'
+      );
       await loadConnections();
     } catch {
       // A thrown sync failure flips the connection's own status (error /

--- a/src/test/api-lib/bank-providers.test.ts
+++ b/src/test/api-lib/bank-providers.test.ts
@@ -141,3 +141,38 @@ describe('reconnecting lands on the bank, not on a list of ninety', () => {
     expect(providerForInstitution(undefined)).toBeUndefined();
   });
 });
+
+describe('the reauth classifier is reachable from where it is called', () => {
+  /**
+   * The defect this pins: `isReauthRequiredError` was taught to ask the
+   * connection's PROVIDER, but both handlers called it without the
+   * connection — so it fell through to a generic fallback every time and
+   * the provider-aware answer never ran once in production. The owner's
+   * "403 SCA exemption has expired" was filed as an ordinary sync failure,
+   * and the row that needed a Reconnect button went on looking healthy.
+   */
+  const SCA_403 = 'TrueLayer transactions fetch failed (invented-account-id): 403 ' +
+    '{"error_description":"SCA exemption has expired. This resource is protected by SCA.","error":"access_denied"}';
+
+  it('classifies through the connection when one is given', async () => {
+    const { isReauthRequiredError } = await import('../../../api/_lib/banking-sync');
+    const connection = {
+      id: 'conn-1', user_id: 'user-1', provider: 'truelayer',
+      institution_id: 'ob-revolut', institution_name: 'Invented Bank',
+      access_token_encrypted: 'x', refresh_token_encrypted: 'y',
+    };
+    expect(isReauthRequiredError(new Error(SCA_403), connection)).toBe(true);
+  });
+
+  it('and STILL says yes with no connection in hand — the fallback asks every provider', async () => {
+    // The fallback used to be a hardcoded copy of one provider's regex,
+    // free to drift from the real one. It did.
+    const { isReauthRequiredError } = await import('../../../api/_lib/banking-sync');
+    expect(isReauthRequiredError(new Error(SCA_403))).toBe(true);
+  });
+
+  it('still says no to an ordinary failure, either way', async () => {
+    const { isReauthRequiredError } = await import('../../../api/_lib/banking-sync');
+    expect(isReauthRequiredError(new Error('TrueLayer accounts fetch failed: 500 upstream'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## The defect

#423 taught `isReauthRequiredError` to classify through the connection's
**provider**. Both handlers then called it as
`isReauthRequiredError(error)` — **without the connection** — so it fell
through to the generic fallback every time. The provider-aware
classification never ran once in production.

**The owner's evidence**: after #423 deployed, a 403 SCA refusal at 23:05
left the connection `status: connected`, `needs_reauth: false` — so the row
showed no amber rail and **no Reconnect button**, on the one failure that
most needs it. The fix was correct and unreachable.

## Two changes

- Both handlers resolve **ownership first**, then classify with the row in
  hand. The ordering is the point: the row says which provider's vocabulary
  the error is in.
- The no-connection fallback now asks **every registered provider** rather
  than running a hardcoded copy of TrueLayer's regex. That copy was a
  second definition free to drift — and it drifted the moment TrueLayer
  learned about 403 and it didn't.

Plus the **Open Banking page's** sync notice, which still read *"Transaction
sync failed"*. #423 fixed the modal's copy of that line and missed the
page's.

## Verification
- 16 specs; 3 new: classified through a connection, classified without one,
  and an ordinary 500 still an ordinary failure
- Lint zero; tsc -b clean; husky full gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)