### PR TITLE
fix(design): the count pills go neutral, and the net-worth hint stops drawing over the title

### DIFF
--- a/src/components/NetWorthSummary.tsx
+++ b/src/components/NetWorthSummary.tsx
@@ -179,7 +179,17 @@ export default function NetWorthSummary({
               type="button"
               onClick={() => onSelect(figure)}
               className="flex flex-col items-start p-4 text-left transition-colors duration-state hover:bg-surface-secondary dark:hover:bg-gray-700/50 !shadow-none"
-              title="See the accounts behind this figure"
+              /* aria-label, not title (Design, 25 Aug §3). A native `title`
+                 tooltip is positioned by the BROWSER relative to the cursor,
+                 not by us — which is why it was caught rendering over the
+                 page heading and clipping the word "Accounts". There is no
+                 anchor to change: the only choices are to drop the visual
+                 tooltip or to build a custom one. The hover state already
+                 says the tile is pressable, so the text is kept where it
+                 still does work — as the control's accessible name — and
+                 stops drawing a box over whatever the cursor happens to be
+                 near. */
+              aria-label="See the accounts behind this figure"
             >
               {content}
             </button>

--- a/src/pages/Categorisation.tsx
+++ b/src/pages/Categorisation.tsx
@@ -258,7 +258,15 @@ export default function Categorisation(): React.JSX.Element {
                   <span className="font-medium text-gray-900 dark:text-white truncate min-w-0 flex-1">
                     {accountName(accountId)}
                   </span>
-                  <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400 whitespace-nowrap">
+                  {/* NEUTRAL — a count is not a signal (Design, 25 Aug §4,
+                      and their own rule since the 13th: "a zero, a count and a
+                      settled row need none"). Five soft ambers sat here on the
+                      page representing the STOOD-DOWN categorise rung, which
+                      is precisely the erosion the ladder exists to prevent.
+                      Not rung-dependent: a per-account count has no business
+                      wearing the attention colour at any rung, so this is
+                      neutral outright rather than conditional. */}
+                  <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300 whitespace-nowrap">
                     {accountRows.length.toLocaleString()}
                   </span>
                   <ChevronRightIcon size={18} className="text-gray-400 flex-shrink-0" />


### PR DESCRIPTION
## Design's ladder review, 25 Aug — the two contained findings

**§4 — confirmed, not a compression artefact.** They flagged the
per-account count pills as amber-tinted but asked me to check the token
rather than trust the capture. The token is real: `bg-amber-100` /
`text-amber-700`. Five soft ambers on the page representing the
**stood-down** categorise rung — the exact erosion the ladder prevents.

Neutral now, and **not conditionally**: a per-account count shouldn't wear
the attention colour at any rung. Their own rule from the 13th — *a zero, a
count and a settled row need none*.

**§3 — it's a native `title` tooltip**, positioned by the browser relative
to the cursor, not by us. That's why it was caught over the page heading.
There's no anchor to change; the choices are drop it or build a custom one.
The hover state already signals the tile is pressable, so the text moves to
`aria-label` — still the accessible name, no longer drawing a box over the
page title.

## Not in this PR, deliberately
**§1** (four column headings above one-column band rows) and **§2.1** (the
Loans band split) are structural. They get their own change.

## Verification
- Lint zero; tsc -b clean; 8 specs green across both touched surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)