### PR TITLE
feat(accounts): an investment can sit inside an investment, and reports file it there

### DIFF
--- a/src/components/AccountSettingsModal.test.tsx
+++ b/src/components/AccountSettingsModal.test.tsx
@@ -396,25 +396,39 @@ describe('AccountSettingsModal', () => {
       });
     });
 
-    it('does not offer pairing for an investment account — pairing runs one way', () => {
+    /*
+     * These two pinned the OLD rule — cash only inside an investment — which
+     * the owner asked to widen on 25 Aug. His case: a sleeve typed `current`
+     * sat correctly inside its portfolio, but retyping it `investment`, which
+     * is what it actually is, took the field away and threw it back to the
+     * top level. They now pin the widened rule and, more importantly, that
+     * ONE DEEP still holds without the type test doing that work.
+     */
+    it('offers pairing to an investment account too — an investment may sit in an investment', () => {
       render(<AccountSettingsModal {...pairable} account={{ ...mockAccount, type: 'investment' }} />);
 
-      expect(screen.queryByLabelText('Part of investment account')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('Part of investment account')).toBeInTheDocument();
     });
 
-    it('takes the field away, and writes nothing, when the type is switched to Investments', async () => {
+    it('keeps a sleeve INSIDE its portfolio when its type is switched to Investments', async () => {
+      // The owner's exact case, 25 Aug: a cash sleeve filed inside a
+      // portfolio, retyped to Investments because that is what it is. It
+      // used to lose the field and be thrown back to the top level.
       const onSave = vi.fn();
-      render(<AccountSettingsModal {...pairable} onSave={onSave} />);
+      const sleeve = { ...mockAccount, parentAccountId: 'inv1' };
+      render(<AccountSettingsModal {...pairable} account={sleeve} onSave={onSave} />);
 
-      expect(screen.getByLabelText('Part of investment account')).toBeInTheDocument();
+      expect(screen.getByLabelText('Part of investment account')).toHaveValue('inv1');
       fireEvent.change(screen.getByDisplayValue('Current Account'), { target: { value: 'investment' } });
-      expect(screen.queryByLabelText('Part of investment account')).not.toBeInTheDocument();
+      // The field SURVIVES the type change — that is the whole ask — and it
+      // is still pointing at the portfolio.
+      expect(screen.getByLabelText('Part of investment account')).toHaveValue('inv1');
 
       fireEvent.click(screen.getByText('Save Changes'));
       await waitFor(() => {
         expect(onSave).toHaveBeenCalledTimes(1);
       });
-      expect(onSave.mock.calls[0][1]).not.toHaveProperty('parentAccountId');
+      expect(onSave.mock.calls[0][1]).toMatchObject({ parentAccountId: 'inv1', type: 'investment' });
     });
 
     it('does not offer pairing to an account that already has accounts inside it', () => {

--- a/src/components/AccountSettingsModal.tsx
+++ b/src/components/AccountSettingsModal.tsx
@@ -87,16 +87,25 @@ interface PairingState {
 /**
  * Investment↔cash pairing, from the account being edited outwards.
  *
- * Pairing is ONE-DIRECTIONAL and ONE DEEP (the Microsoft Money model): a cash
- * account sits inside an investment account, and that is the whole shape. So
- * the field is offered only while this account is not itself an investment
- * account and nothing is already nested inside it, and the candidates exclude
- * any investment account that is itself paired — three guards that between them
- * make a grandparent, a self-parent and a cycle unrepresentable from the UI.
+ * Pairing is ONE-DIRECTIONAL and ONE DEEP (the Microsoft Money model): an
+ * account sits inside an investment account, and that is the whole shape.
  *
- * `selectedType` is the type CURRENTLY CHOSEN in the form, not the stored one:
- * switching an account to Investments takes the field away with it, exactly as
- * switching to Credit Card takes the sort code away.
+ * WHAT MAY BE NESTED WIDENED ON 25 AUG, at the owner's ask. It was cash only,
+ * which forced a false choice: a cash sleeve typed `current` sat correctly
+ * inside its portfolio, but retyping it `investment` — which is what it
+ * actually is, in a wrapper holding several sleeves — took the pairing field
+ * away and threw it back out to the top level. Any type may now name a
+ * parent; the shape is unchanged.
+ *
+ * ONE DEEP IS STILL ENFORCED, and by the two guards that were always doing
+ * that work rather than by the type test: nothing may be nested inside this
+ * account (`!hasChildren`), and the candidates exclude any investment that is
+ * itself already paired. Between them a grandparent, a self-parent and a
+ * cycle stay unrepresentable from the UI — which is why dropping the type
+ * test costs nothing structurally.
+ *
+ * `selectedType` is the type CURRENTLY CHOSEN in the form, not the stored
+ * one, so the field reacts to the type dropdown as the reader changes it.
  *
  * The account's existing parent is always among the candidates, even if it
  * would no longer qualify. A select whose value is missing from its own option
@@ -122,7 +131,10 @@ function resolvePairing(
     options.push(current);
   }
   return {
-    offered: selectedType !== 'investment' && !hasChildren && options.length > 0,
+    // No type test: an investment may sit inside an investment too (owner,
+    // 25 Aug). `selectedType` is still read so a future type-specific rule
+    // has it to hand, and so the dependency is honest.
+    offered: Boolean(selectedType) && !hasChildren && options.length > 0,
     options
   };
 }
@@ -567,10 +579,12 @@ export default function AccountSettingsModal({
                 <GroupedAccountOptions accounts={pairing.options} />
               </select>
               <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                For the cash held alongside an investment account. This account
-                keeps its own register and transactions; it moves inside that
-                account on the Accounts page, and its balance counts towards
-                that investment's value.
+                For anything held inside an investment account — the cash
+                alongside it, or a sleeve of it. This account keeps its own
+                register and transactions; it moves inside that account on the
+                Accounts page, its balance counts towards that investment's
+                value, and reports file it under Investments rather than under
+                its own type.
               </p>
             </div>
           )}

--- a/src/utils/accountBalanceReport.test.ts
+++ b/src/utils/accountBalanceReport.test.ts
@@ -301,3 +301,58 @@ describe('resolveClosingSnapshot — which day values the closings', () => {
     ).toBe(conversionToday);
   });
 });
+
+describe('a nested account is filed where its parent is (owner, 25 Aug)', () => {
+  // Every name and figure is invented; the repo is public.
+  const portfolio = account({ id: 'acc-portfolio', name: 'Test Portfolio', type: 'investment', openingBalance: 1000 });
+  const cashSleeve = account({
+    id: 'acc-sleeve', name: 'Test Portfolio (Cash)', type: 'current',
+    openingBalance: 250, parentAccountId: 'acc-portfolio',
+  });
+  const ordinaryCurrent = account({ id: 'acc-current', name: 'Test Current', type: 'current', openingBalance: 400 });
+
+  const labelsOf = (report: ReturnType<typeof buildAccountBalanceReport>): string[] =>
+    report.groups.map(g => g.label);
+
+  it('puts a cash sleeve under Investments, not Current accounts', () => {
+    const report = buildAccountBalanceReport(
+      [portfolio, cashSleeve, ordinaryCurrent], [], { from: null, to: null }, new Date(2026, 7, 25)
+    );
+    const investments = report.groups.find(g => g.label === 'Investments');
+    const current = report.groups.find(g => g.label === 'Current accounts');
+    // The sleeve's money sits with the portfolio it belongs to…
+    expect(investments?.rows.map(r => r.accountId).sort()).toEqual(['acc-portfolio', 'acc-sleeve']);
+    expect(investments?.closing).toBe(1250);
+    // …and no longer inflates the current-account total, which is now just
+    // the account that really is one.
+    expect(current?.rows.map(r => r.accountId)).toEqual(['acc-current']);
+    expect(current?.closing).toBe(400);
+  });
+
+  it('files an INVESTMENT nested in an investment there too', () => {
+    // The owner's actual ask: retyping a sleeve to Investments must not throw
+    // it back out to the top level.
+    const sleeveAsInvestment = { ...cashSleeve, type: 'investment' as const };
+    const report = buildAccountBalanceReport(
+      [portfolio, sleeveAsInvestment], [], { from: null, to: null }, new Date(2026, 7, 25)
+    );
+    expect(labelsOf(report)).toEqual(['Investments']);
+    expect(report.groups[0].closing).toBe(1250);
+  });
+
+  it('falls back to its own type when the parent is not in the window', () => {
+    // accountNesting's first invariant: a parent that is not in the set is no
+    // parent. Filing the child into a band nobody is drawing would lose it.
+    const report = buildAccountBalanceReport(
+      [cashSleeve], [], { from: null, to: null }, new Date(2026, 7, 25)
+    );
+    expect(labelsOf(report)).toEqual(['Current accounts']);
+  });
+
+  it('leaves an unnested account exactly where it was', () => {
+    const report = buildAccountBalanceReport(
+      [ordinaryCurrent, portfolio], [], { from: null, to: null }, new Date(2026, 7, 25)
+    );
+    expect(labelsOf(report).sort()).toEqual(['Current accounts', 'Investments']);
+  });
+});

--- a/src/utils/accountBalanceReport.ts
+++ b/src/utils/accountBalanceReport.ts
@@ -3,6 +3,7 @@ import type { PeriodRange } from '../hooks/usePeriod';
 import { dailyFactorLookup, type NetWorthConversion } from './netWorthSeries';
 import { toDecimal, type DecimalInstance } from './decimal';
 import { resolveEffectiveOpeningDates } from './openingDates';
+import { buildChildrenByParent } from './accountNesting';
 
 /**
  * "Account balances" and "Net worth" — the two Microsoft Money statements,
@@ -300,9 +301,36 @@ export function buildAccountBalanceReport(
     };
   });
 
+  /*
+   * A NESTED ACCOUNT IS FILED WHERE ITS PARENT IS (owner, 25 Aug).
+   *
+   * The Accounts page has always nested a cash sleeve inside its investment
+   * and counted it toward that band — accountNesting's own header calls its
+   * rules "the whole answer to where does this account's money belong, so
+   * two pages can never disagree about what a paired account is worth". This
+   * report never asked it, and grouped by the row's own type. So a cash
+   * sleeve inside a portfolio appeared under Current accounts and inflated
+   * that total, while the same account sat inside Investments one page over.
+   * Same money, two homes, and the reader had no way to tell which was the
+   * lie.
+   *
+   * The parent must be present in the set to count — accountNesting's first
+   * invariant, and the reason this uses the same resolution rather than
+   * reading parentAccountId directly: on a window whose accounts exclude the
+   * parent, the child falls back to its own type rather than into a band
+   * that is not being drawn.
+   */
+  const childrenByParent = buildChildrenByParent(accounts);
+  const parentTypeOf = new Map<string, Account['type']>();
+  for (const [parentId, children] of childrenByParent) {
+    const parent = accounts.find(a => a.id === parentId);
+    if (!parent) continue;
+    for (const child of children) parentTypeOf.set(child.id, parent.type);
+  }
+
   const byLabel = new Map<string, AccountBalanceRow[]>();
   for (const row of rows) {
-    const label = labelOfType(row.type);
+    const label = labelOfType(parentTypeOf.get(row.accountId) ?? row.type);
     const list = byLabel.get(label);
     if (list) list.push(row);
     else byLabel.set(label, [row]);


### PR DESCRIPTION
## The owner's ask, and what it exposed

**Asked for**: a cash sleeve typed `current` sits correctly inside its
portfolio, but retyping it `investment` — what it actually is — removed the
pairing field and threw it back to the top level. Any type may now name an
investment parent.

**One deep is unchanged**, enforced by the two guards that were always doing
that work (nothing nested inside this account; candidates exclude
already-paired investments). `accountNesting` was already type-agnostic —
only the form wasn't.

## The half that matters more

`accountNesting`'s header says its rules are *"the whole answer to where
does this account's money belong, so two pages can never disagree"* — and
**the balance reports never asked it.** They grouped by the row's own type,
so a cash sleeve appeared under **Current accounts**, inflating that total,
while the same account sat inside **Investments** one page over. Same money,
two homes, nothing to tell the reader which was the lie. That's the bug he
actually reported.

A nested account now files under its **parent's** section, through the same
resolution the Accounts page uses — invariant included: a parent absent from
the window is no parent, so the child falls back to its own type rather than
into a band nobody is drawing.

## Verification
- 107 tests green across the three touched suites
- 4 new report specs: sleeve lands under Investments and leaves the
  current-account total alone, investment-in-investment, absent-parent
  fallback, unnested account unmoved
- 2 older specs pinned the reversed rule and now pin the new one — including
  that a sleeve keeps its parent across the type change
- Lint zero; tsc -b clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)