### PR TITLE
fix(accounts): the column strip heads the rows it names, not the bands above them

### DIFF
--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -2330,12 +2330,18 @@ function AccountsList() {
                         </p>
                       </button>
                       <div id={subRegionId}>
+                        {sub.isExpanded && sub.displayed.length > 0 && <AccountColumnHeader />}
                         {sub.isExpanded && sub.displayed.map(renderAccountCard)}
                       </div>
                     </div>
                   );
                 })
-              : displayed.map(renderAccountCard)}
+              : (
+                <>
+                  {displayed.length > 0 && <AccountColumnHeader />}
+                  {displayed.map(renderAccountCard)}
+                </>
+              )}
           </div>
         )}
       </div>
@@ -3008,7 +3014,18 @@ function AccountsList() {
           matches nothing leaves exactly the same strip over exactly the same
           nothing, and the filtered empty state below already explains itself
           without a column header helping. */}
-      {!isLoading && matchedTopLevelCount > 0 && <AccountColumnHeader />}
+      {/* ONLY FOR THE FLAT LIST (Design, 25 Aug §1). With bands on, the rows
+          this strip names are several levels down and BAND HEADINGS sit in
+          between — each showing a single right-aligned total under none of
+          the four column names. Four headings over a one-column layout, and
+          a reader scanning down from "TO REVIEW" landing on a band total.
+
+          The reconciliation list solved this in the August pass and this
+          page never got the same treatment: there, a run of rows and the
+          strip that heads it are ONE unit, always drawn together, because
+          the strip belongs to the row group rather than to the section.
+          Banded views below now do the same. */}
+      {!isLoading && matchedTopLevelCount > 0 && displayedList.mode === 'flat' && <AccountColumnHeader />}
       </div>
 
       {/* The `-ml-1 pl-1 pr-1` that used to be here went with the scroll


### PR DESCRIPTION
## Design's ladder review, 25 Aug §1

The strip read `BANK BAL · ACCOUNT BAL · UNRECONCILED · TO REVIEW` once at
the top of the page. Beneath it, every band heading showed a **single**
right-aligned total under none of those four names — four headings over a
one-column layout, with a reader scanning from "TO REVIEW" landing on a
band total.

## The fix, and the precedent for it

The **reconciliation list already solved this** in the August pass, and its
comment says why: *"a run of rows and the strip that heads it are ONE unit,
always drawn together"* — the strip belongs to the **row group**, not the
section. This page never got the same treatment.

The strip now renders per run of account rows, immediately above them, in
both banded shapes (a band's own rows, and each institution sub-band's).
The page-level strip stays **only for the flat list**, where it genuinely
heads the rows beneath it. The strip itself is unchanged — same row-template
column classes, so the two still can't drift.

## Verification
- **Live**: five strips on the demo ledger, every one immediately followed
  by an account row rather than a band heading; every band total now sits
  *above* its strip
- 46 tests green across the Accounts suites; lint zero; tsc -b clean

## Not included
**§2.1** (splitting Loans into `LOANS OUT` / `LOANS IN`) changes what a band
*means* rather than where a heading sits. Its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)