### PR TITLE
fix(currency): the last two native sums convert — Categorisation and data health

### DIFF
--- a/src/components/CategoryDataHealthPanel.transferFiling.test.tsx
+++ b/src/components/CategoryDataHealthPanel.transferFiling.test.tsx
@@ -36,6 +36,7 @@ const CLEAN: CategoryHealth = {
   emptyCategoryIds: [],
   transferFilingMismatchCount: 0,
   transferFilingMismatchIds: [],
+  holdsForeign: false,
   hasWarnings: false,
 };
 

--- a/src/components/CategoryDataHealthPanel.tsx
+++ b/src/components/CategoryDataHealthPanel.tsx
@@ -118,7 +118,8 @@ export default function CategoryDataHealthPanel({
               uncategorised transaction{plural(health.uncategorizedCount)} sit outside every report
             </span>
             <span className={`tabular-nums ${wearsAmber ? 'text-amber-700 dark:text-amber-400' : 'text-gray-500 dark:text-gray-400'}`}>
-              ({formatCurrency(health.uncategorizedIn)} in · {formatCurrency(health.uncategorizedOut)} out)
+              ({health.holdsForeign ? '≈ ' : ''}{formatCurrency(health.uncategorizedIn)} in ·{' '}
+              {health.holdsForeign ? '≈ ' : ''}{formatCurrency(health.uncategorizedOut)} out)
             </span>
             <Link
               to={preserveDemoParam('/categorisation', location.search)}

--- a/src/pages/Categorisation.tsx
+++ b/src/pages/Categorisation.tsx
@@ -7,6 +7,9 @@ import { groupUncategorisedByAccount } from '../utils/uncategorisedByAccount';
 import { groupSuggestedByCategory, groupSuggestedByAccount } from '../utils/categoryProvenance';
 import { preferences } from '../services/preferencesService';
 import { useAttentionLadder } from '../hooks/useAttentionLadder';
+import { useFlowConvert } from '../hooks/useFlowConvert';
+import { useHistoricalAccounts } from '../hooks/useHistoricalAccounts';
+import ReportCurrencyNote from '../components/reports/ReportCurrencyNote';
 import { DEPTH_LEVEL_1 } from '../styles/depthShading';
 import { useAccountNames } from '../hooks/useAccountNames';
 import { useToast } from '../contexts/ToastContext';
@@ -37,9 +40,19 @@ const SUGGESTED_VIEW_KEY = 'categorisationSuggestedView';
  * Deliberately reads ALL transactions, not a period: a chore is only finished
  * when nothing is left, and a date filter would hide the work rather than do
  * it.
+ *
+ * MONEY IN / MONEY OUT CONVERT (Design's §5, 25 Aug). They summed native units
+ * as display units and said nothing about it — this page and the Categories
+ * data-health panel were the last two such sums in the app, both carried by
+ * the currency census at 'native-known' since the 22nd. Offered the choice
+ * between mounting the Phase 0 disclosure and converting, Design ruled
+ * convert: "disclosure was the honest interim, never the goal." So the figures
+ * go through the same flows seam every other aggregation surface uses, and
+ * ReportCurrencyNote states the basis — including the degraded case, where the
+ * seam declines to convert and the Phase 0 sentence is what says so.
  */
 export default function Categorisation(): React.JSX.Element {
-  const { transactions, transactionSplits, categories, confirmTransactionCategories } = useApp();
+  const { accounts, transactions, transactionSplits, categories, confirmTransactionCategories } = useApp();
   const { formatCurrency } = useCurrencyDecimal();
   const { showSuccess, showError } = useToast();
   // One rule, app-wide — see utils/attentionLadder.
@@ -58,7 +71,21 @@ export default function Categorisation(): React.JSX.Element {
     [transactions, transactionSplits]
   );
 
-  const flows = useMemo(() => computeIncomeExpense(rows, [], categories), [rows, categories]);
+  /**
+   * CLOSED ACCOUNTS ARE THE POINT (Design's §5, 25 Aug: convert rather than
+   * disclose). The backlog lives in old history — measured, 43 of the 90
+   * accounts behind it are closed — and a resolver built from the context's
+   * open-accounts list would hand back no factor for exactly those rows. They
+   * would sum native while the ≈ said everything was converted, which is worse
+   * than the honest native sum this replaces.
+   */
+  const historicalAccounts = useHistoricalAccounts(accounts);
+  const convert = useFlowConvert(historicalAccounts);
+
+  const flows = useMemo(
+    () => computeIncomeExpense(rows, [], categories, { convert }),
+    [rows, categories, convert]
+  );
 
   const uncategorised = flows.uncategorizedRows;
   const count = uncategorised.length;
@@ -206,18 +233,25 @@ export default function Categorisation(): React.JSX.Element {
               </div>
               <div className="text-center">
                 <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">Money in</p>
-                <p className="text-lg font-bold text-gray-900 dark:text-white tabular-nums">
-                  {formatCurrency(flows.uncategorizedIn.toNumber())}
+                <p className="text-lg font-bold text-gray-900 dark:text-white tabular-nums" data-testid="categorisation-money-in">
+                  {flows.holdsForeign ? '≈ ' : ''}{formatCurrency(flows.uncategorizedIn.toNumber())}
                 </p>
               </div>
               <div className="text-center col-span-2 md:col-span-1">
                 <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">Money out</p>
-                <p className="text-lg font-bold text-gray-900 dark:text-white tabular-nums">
-                  {formatCurrency(flows.uncategorizedOut.toNumber())}
+                <p className="text-lg font-bold text-gray-900 dark:text-white tabular-nums" data-testid="categorisation-money-out">
+                  {flows.holdsForeign ? '≈ ' : ''}{formatCurrency(flows.uncategorizedOut.toNumber())}
                 </p>
               </div>
             </div>
           </div>
+
+          {/* The basis these two figures are on. Same component the report hub
+              mounts, so this page cannot drift from a report that quotes the
+              same backlog — and it degrades the same way: no ECB history, no
+              conversion, and the Phase 0 sentence says the totals are native
+              rather than a third basis nobody stated. */}
+          <ReportCurrencyNote />
 
           {/* The three ways through, cheapest first: a transfer sweep can clear
               thousands of rows without a decision, filing a payee clears every

--- a/src/pages/__tests__/Categorisation.currency.test.tsx
+++ b/src/pages/__tests__/Categorisation.currency.test.tsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PreferencesProvider } from '../../contexts/PreferencesContext';
+import { ToastProvider } from '../../contexts/ToastContext';
+import { NotificationProvider } from '../../contexts/NotificationContext';
+import Categorisation from '../Categorisation';
+import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import { __resetHistoricalRatesForTests } from '../../services/historicalRatesService';
+import type { Account, Category, Transaction } from '../../types';
+
+/**
+ * CATEGORISATION'S MONEY FIGURES CONVERT (Design's §5, 25 Aug).
+ *
+ * "Money in" and "Money out" describe the backlog — the money the reports
+ * cannot see until it is filed. They summed NATIVE units as display units
+ * until now, and said nothing about it: the last two undisclosed native sums
+ * in the app, both recorded by the currency census as 'native-known'. Design
+ * ruled convert rather than disclose ("disclosure was the honest interim,
+ * never the goal"), so this pins the converted behaviour and its ≈.
+ *
+ * The rate served below is invented and the amounts are invented; this repo
+ * is public. 2.0 is deliberately not a plausible USD rate — a wrong basis
+ * has to be visible at a glance rather than arguable.
+ */
+
+vi.mock('@data', () => ({
+  dataPort: {
+    listClosedAccounts: vi.fn(async () => []),
+  },
+}));
+
+const account = (id: string, currency: string): Account =>
+  ({ id, name: id, type: 'current', balance: 0, currency, isActive: true,
+     lastUpdated: new Date(2024, 0, 1) } as unknown as Account);
+
+const CATEGORIES: Category[] = [
+  { id: 'type-expense', name: 'Expenses', type: 'expense', level: 'type' },
+];
+
+/** An UNCATEGORISED row — blank category is what puts it in the backlog. */
+const unfiled = (id: string, accountId: string, amount: number): Transaction =>
+  ({ id, date: new Date(2024, 5, 10), description: id, amount, accountId,
+     category: '', type: amount >= 0 ? 'income' : 'expense' } as unknown as Transaction);
+
+/** The ECB history the flows seam values each row's own date against. */
+const historyResponds = (): void => {
+  vi.stubGlobal('fetch', vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ rates: { '2024-06-10': { USD: 2 } }, base: 'GBP' }),
+  }) as unknown as Response));
+};
+
+const providerDead = (): void => {
+  vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('offline'); }));
+};
+
+const renderPage = (): void => {
+  render(
+    <MemoryRouter>
+      <PreferencesProvider>
+        <ToastProvider>
+          <NotificationProvider>
+            <Categorisation />
+          </NotificationProvider>
+        </ToastProvider>
+      </PreferencesProvider>
+    </MemoryRouter>
+  );
+};
+
+beforeEach(async () => {
+  await __resetHistoricalRatesForTests();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  __resetAppContextValue();
+});
+
+describe('Categorisation — the backlog figures and their basis', () => {
+  it('converts a foreign row and marks the figure ≈', async () => {
+    historyResponds();
+    __setAppContextValue({
+      accounts: [account('gbp', 'GBP'), account('usd', 'USD')],
+      transactions: [unfiled('t1', 'usd', 100)],
+      transactionSplits: [],
+      categories: CATEGORIES,
+    });
+    renderPage();
+
+    // $100 at the served rate is £50 — never £100, which is the falsehood
+    // this whole seam exists to stop.
+    // The ECB history is the THIRD network call (today's rates, the ECB
+    // overlay, then the range), so the ≈ arrives a tick after first paint.
+    await screen.findByTestId('report-currency-basis', undefined, { timeout: 5000 });
+    const moneyIn = screen.getByTestId('categorisation-money-in');
+    expect(moneyIn).toHaveTextContent(/≈/);
+    expect(moneyIn).toHaveTextContent(/50/);
+    expect(moneyIn).not.toHaveTextContent(/100/);
+  });
+
+  it('states the basis it converted on, in the reports own words', async () => {
+    historyResponds();
+    __setAppContextValue({
+      accounts: [account('gbp', 'GBP'), account('usd', 'USD')],
+      transactions: [unfiled('t1', 'usd', 100)],
+      transactionSplits: [],
+      categories: CATEGORIES,
+    });
+    renderPage();
+
+    // The same component the report hub mounts — so this page and a report
+    // quoting the same backlog cannot claim different bases.
+    expect(
+      await screen.findByTestId('report-currency-basis', undefined, { timeout: 5000 })
+    ).toHaveTextContent(/Converted at each day.s ECB reference rate/);
+  });
+
+  it('degrades to native WITH the disclosure, never to a third basis', async () => {
+    providerDead();
+    __setAppContextValue({
+      accounts: [account('gbp', 'GBP'), account('usd', 'USD')],
+      transactions: [unfiled('t1', 'usd', 100)],
+      transactionSplits: [],
+      categories: CATEGORIES,
+    });
+    renderPage();
+
+    // No history → no conversion. The figure stays native and loses the ≈,
+    // and the Phase 0 sentence is what says so.
+    expect(await screen.findByTestId('mixed-currency-disclosure', undefined, { timeout: 5000 })).toBeInTheDocument();
+    const moneyIn = screen.getByTestId('categorisation-money-in');
+    expect(moneyIn).toHaveTextContent(/100/);
+    expect(moneyIn).not.toHaveTextContent(/≈/);
+  });
+
+  it('says nothing about currency to a single-currency ledger', async () => {
+    historyResponds();
+    __setAppContextValue({
+      accounts: [account('gbp', 'GBP')],
+      transactions: [unfiled('t1', 'gbp', 100)],
+      transactionSplits: [],
+      categories: CATEGORIES,
+    });
+    renderPage();
+
+    const moneyIn = await screen.findByTestId('categorisation-money-in');
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(moneyIn).not.toHaveTextContent(/≈/);
+    expect(screen.queryByTestId('report-currency-basis')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mixed-currency-disclosure')).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/settings/Categories.tsx
+++ b/src/pages/settings/Categories.tsx
@@ -12,6 +12,9 @@ import { useAttentionLadder } from '../../hooks/useAttentionLadder';
 import IncomeExpenseBreakdownModal from '../../components/IncomeExpenseBreakdownModal';
 import EditTransactionModal from '../../components/EditTransactionModal';
 import { computeCategoryHealth } from '../../utils/categoryHealth';
+import { useFlowConvert } from '../../hooks/useFlowConvert';
+import { useHistoricalAccounts } from '../../hooks/useHistoricalAccounts';
+import ReportCurrencyNote from '../../components/reports/ReportCurrencyNote';
 import { findMismatchedTransferFilings } from '../../utils/transferCoherence';
 import { ARRIVAL_ROW_CLASS, useArrivalRowFocus } from '../../hooks/useArrivalFocus';
 import { AlertCircleIcon, Settings2Icon, GripVerticalIcon, MergeIcon } from '../../components/icons';
@@ -208,6 +211,7 @@ function movingClause(transactions: number, splitLines: number, budgets: number)
 
 export default function CategoriesSettings() {
   const {
+    accounts,
     transactions,
     categories,
     budgets,
@@ -249,9 +253,15 @@ export default function CategoriesSettings() {
   // One rule, app-wide — see utils/attentionLadder.
   const ladder = useAttentionLadder();
 
+  // Its money figures convert on the same basis the Categorisation page's do,
+  // through the same seam — closed accounts included, because that is where
+  // most of the backlog is (see the note on that page).
+  const historicalAccounts = useHistoricalAccounts(accounts);
+  const flowConvert = useFlowConvert(historicalAccounts);
+
   const categoryHealth = useMemo(
-    () => computeCategoryHealth(transactions, transactionSplits, categories),
-    [transactions, transactionSplits, categories]
+    () => computeCategoryHealth(transactions, transactionSplits, categories, { convert: flowConvert }),
+    [transactions, transactionSplits, categories, flowConvert]
   );
 
   // The type-level ids are user-specific UUIDs after cloud migration — the old
@@ -1045,6 +1055,12 @@ export default function CategoriesSettings() {
         onShowEmptyCategories={showEmptyCategories}
         onFixTransferFilings={fixTransferFilings}
       />
+
+      {/* The basis the panel's money figures are on — mounted HERE rather than
+          inside the panel, which is deliberately presentational and testable
+          without a provider. Gated on the only line that shows an amount: a
+          basis line above no figures is a statement about nothing. */}
+      {categoryHealth.uncategorizedCount > 0 && <ReportCurrencyNote />}
 
       {/* Categories Tree */}
       <div className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">

--- a/src/utils/__tests__/currencyAggregationCensus.test.ts
+++ b/src/utils/__tests__/currencyAggregationCensus.test.ts
@@ -76,12 +76,19 @@ const LEDGER: Record<string, Partial<Record<(typeof PRIMITIVES)[number], Status>
   'src/pages/Accounts.tsx': { calculateTotalBalance: 'converts' },
 
   // ── the audit's known native sums, phase-ordered in the ruling ──
+  // All converted as of 25 Aug. The last two were Categorisation and the
+  // Categories data-health panel: the census had them at 'native-known' for a
+  // fortnight, which is the status doing exactly its job — it named them
+  // before anyone looked at the screen, and Design's §5 ruling ("convert;
+  // disclosure was the honest interim, never the goal") closed them out.
+  // NOTHING is at 'native-known' for computeIncomeExpense any more, and new
+  // code may not enter at that status.
   'src/hooks/useReportDataset.ts': { computeIncomeExpense: 'converts' },
   'src/components/dashboard/ImprovedDashboard.tsx': { computeIncomeExpense: 'converts' },
   'src/pages/Calendar.tsx': { computeIncomeExpense: 'converts' },
-  'src/pages/Categorisation.tsx': { computeIncomeExpense: 'native-known' },
+  'src/pages/Categorisation.tsx': { computeIncomeExpense: 'converts' },
   'src/pages/reports/PeriodComparisonReport.tsx': { computeIncomeExpense: 'converts' },
-  'src/utils/categoryHealth.ts': { computeIncomeExpense: 'native-known' },
+  'src/utils/categoryHealth.ts': { computeIncomeExpense: 'converts' },
 
   // ── callers that read no money at all ──
   // The ladder asks "is there outstanding work of this kind?" and reads

--- a/src/utils/categoryHealth.test.ts
+++ b/src/utils/categoryHealth.test.ts
@@ -284,3 +284,56 @@ describe('computeCategoryHealth', () => {
     });
   });
 });
+
+describe('computeCategoryHealth — the flows seam (Design §5, 25 Aug)', () => {
+  // Every figure below is invented; this repo is public. The factor 2 is
+  // chosen because it makes a wrong basis visible at a glance rather than
+  // plausible — a real rate never would.
+  const FOREIGN = txn({ id: 't1', category: '', type: 'income', amount: 100, accountId: 'acc-usd' });
+
+  it('the money figures convert when a resolver hands back a factor', () => {
+    const health = computeCategoryHealth([FOREIGN], [], CATEGORIES, {
+      convert: row => (row.accountId === 'acc-usd' ? 2 : null),
+    });
+    expect(health.uncategorizedIn).toBe(200);
+    expect(health.uncategorizedCount).toBe(1);
+  });
+
+  it('holdsForeign gates the ≈: true only when a factor was actually applied', () => {
+    const converted = computeCategoryHealth([FOREIGN], [], CATEGORIES, {
+      convert: row => (row.accountId === 'acc-usd' ? 2 : null),
+    });
+    expect(converted.holdsForeign).toBe(true);
+
+    // A resolver that declines every row is the single-currency case: nothing
+    // converted, so nothing may wear the mark.
+    const declined = computeCategoryHealth([FOREIGN], [], CATEGORIES, { convert: () => null });
+    expect(declined.holdsForeign).toBe(false);
+    expect(declined.uncategorizedIn).toBe(100);
+  });
+
+  it('no resolver → native, and the mark stays off (the degraded path)', () => {
+    // Not a defect: with no ECB history the seam declines to convert, and the
+    // caller's basis line falls back to saying the totals are native. The one
+    // state the ruling forbids is converting on a basis nobody stated.
+    const health = computeCategoryHealth([FOREIGN], [], CATEGORIES);
+    expect(health.uncategorizedIn).toBe(100);
+    expect(health.holdsForeign).toBe(false);
+  });
+
+  it('a row the resolver has no factor for stays native and does not fake the mark', () => {
+    // THE CLOSED-ACCOUNT CASE, which is why both callers build their resolver
+    // from useHistoricalAccounts: 43 of the 90 accounts behind the real
+    // backlog are closed, and a resolver built from open accounts alone would
+    // return null for exactly those rows.
+    const health = computeCategoryHealth(
+      [FOREIGN, txn({ id: 't2', category: '', type: 'income', amount: 50, accountId: 'acc-closed' })],
+      [],
+      CATEGORIES,
+      { convert: row => (row.accountId === 'acc-usd' ? 2 : null) }
+    );
+    // 200 converted + 50 left native — the arithmetic the ≈ is admitting to.
+    expect(health.uncategorizedIn).toBe(250);
+    expect(health.holdsForeign).toBe(true);
+  });
+});

--- a/src/utils/categoryHealth.ts
+++ b/src/utils/categoryHealth.ts
@@ -1,5 +1,5 @@
 import type { Category, Transaction, TransactionSplit } from '../types';
-import { computeIncomeExpense } from './incomeExpense';
+import { computeIncomeExpense, type FlowFactorResolver } from './incomeExpense';
 import { expandSplitTransactions } from './transactionSplits';
 import { findMismatchedTransferFilings } from './transferCoherence';
 
@@ -34,6 +34,13 @@ import { findMismatchedTransferFilings } from './transferCoherence';
  *
  * (2) and (3) are filtered out of (1)'s rows rather than recomputed, so they are
  * exact subsets and can never drift from the classifier.
+ *
+ * The two MONEY figures convert through the flows seam when the caller hands
+ * one over (`opts.convert`), at each row's own date — the same resolver the
+ * report dataset uses, so the health line and the report it links to cannot
+ * quote the same backlog on two different bases. Without a resolver they stay
+ * native and `holdsForeign` is false, which is what the caller's basis line
+ * needs in order to say so.
  *
  * Each measure carries whatever its REMEDY needs to act — which bucket, which
  * categories — not just a number. A warning the user cannot act on from where
@@ -84,6 +91,17 @@ export interface CategoryHealth {
    * the number the user reads and the list they open can never disagree.
    */
   transferFilingMismatchIds: string[];
+  /**
+   * True when a conversion factor was actually applied to one of the money
+   * figures above — the ≈ gate, passed straight through from the flows seam
+   * rather than re-derived, so the mark and the arithmetic share one source.
+   *
+   * False on a single-currency ledger AND when the caller passed no resolver,
+   * which are different situations that call for the same mark: no ≈, because
+   * nothing was converted. Which of the two it is, the caller's basis line
+   * says — see ReportCurrencyNote.
+   */
+  holdsForeign: boolean;
   /** True when at least one measure is non-zero — the panel renders nothing otherwise. */
   hasWarnings: boolean;
 }
@@ -95,14 +113,15 @@ export interface CategoryHealth {
 export function computeCategoryHealth(
   transactions: Transaction[],
   transactionSplits: TransactionSplit[],
-  categories: Category[]
+  categories: Category[],
+  opts: { convert?: FlowFactorResolver } = {}
 ): CategoryHealth {
   // Expand split parents into per-line rows ONCE, then reuse those rows for
   // every measure — the same view `useReportDataset` builds, so counts here and
   // figures there read the identical rows. Splits are passed empty to
   // computeIncomeExpense because the rows are already expanded (no re-expansion).
   const rows = expandSplitTransactions(transactions, transactionSplits);
-  const flows = computeIncomeExpense(rows, [], categories);
+  const flows = computeIncomeExpense(rows, [], categories, { convert: opts.convert });
 
   const categoryIds = new Set(categories.map(c => c.id));
   const bucketIds = new Set(
@@ -178,6 +197,7 @@ export function computeCategoryHealth(
     emptyCategoryIds,
     transferFilingMismatchCount: transferFilingMismatchIds.length,
     transferFilingMismatchIds,
+    holdsForeign: flows.holdsForeign,
     hasWarnings:
       uncategorizedCount > 0 ||
       unassignedBucketCount > 0 ||


### PR DESCRIPTION
Design's §5 ruling, 25 Aug, answering a question I put to them after their ladder review.

## What was wrong

Categorisation's **Money in / Money out** and the Categories **data-health** line summed NATIVE units as display units, and said nothing about it. A dollar counted as a pound in the one place the app tells you what your unfiled backlog is worth.

They were the **last two undisclosed native sums in the app**.

## Why the census earns its keep here

Both were already on the currency census at `native-known` — the status meaning "sums native, recorded, awaiting its phase". It named them a fortnight before anyone looked at the screen. That is the difference between a ledger and a screenshot happening to catch something.

Offered the choice between mounting the Phase 0 disclosure and converting, Design ruled convert: *"disclosure was the honest interim, never the goal."* So the census now records **no `native-known` caller of `computeIncomeExpense` at all**, and new code may not enter at that status.

## What changed

- `computeCategoryHealth` takes an optional `convert` resolver and returns `holdsForeign` — passed straight through from the seam, so the ≈ and the arithmetic share one source rather than being derived twice.
- Categorisation and Categories both build their resolver and pass it.
- ≈ on all four figures, gated on a factor having actually been applied.
- `ReportCurrencyNote` — the same component the report hub mounts — states the basis, so this page and a report quoting the same backlog cannot claim different ones.

## The closed-account trap

Both resolvers are built from `useHistoricalAccounts`, not the context's open-accounts list, because **closed accounts are where the backlog is** — measured, 43 of the 90 accounts behind it are closed.

A resolver over open accounts alone would return no factor for exactly those rows. They would sum native *under an ≈ claiming everything had converted* — worse than the honest native sum this replaces. There is a spec for that case.

## Verification

- **4 rendered-DOM specs** drive the real page through the real hooks against a stubbed ECB endpoint: converted-and-marked, basis stated, degraded-to-native-with-disclosure, and single-currency-says-nothing.
- **4 unit specs** on the seam, including the no-factor-for-this-row case.
- Both sets **proven non-vacuous**: stripping the conversion fails 3 of 4; stripping the note fails 3 of 4.
- Full suite **2,911 passing**; lint and `typecheck:strict` clean; husky gates ran on commit.

Note for reviewers: the test clock is pinned to 2025-01-20, so fixtures must be dated before it — the ECB history is fetched up to "today", and a future-dated row silently gets no factor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)