### PR TITLE
fix(reports): the Loans band splits, and a moved row says why

### DIFF
--- a/src/components/CSVBankTemplates.tsx
+++ b/src/components/CSVBankTemplates.tsx
@@ -118,7 +118,15 @@ export default function CSVBankTemplates({
                         // the banner further up the step.
                         aria-pressed={isSelected}
                         onClick={() => onSelectBank(template)}
-                        className={`w-full text-left px-3 py-2 rounded-lg transition-colors ${
+                        // flex-col items-start: the global `button { display:
+                        // inline-flex; align-items: center }` in index.css lays
+                        // the two block spans below SIDE BY SIDE, so the format
+                        // name and its column list ran together on one line.
+                        // Same trap, same week, as the net-worth statement's
+                        // account rows — an element selector cannot be beaten
+                        // by `block` on the children, only by stating the
+                        // direction on the flex container itself.
+                        className={`w-full flex flex-col items-start text-left px-3 py-2 rounded-lg transition-colors ${
                           isSelected
                             ? 'bg-blue-50 dark:bg-blue-900/30 ring-1 ring-blue-400'
                             : 'bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600'

--- a/src/pages/reports/NetWorthStatementReport.tsx
+++ b/src/pages/reports/NetWorthStatementReport.tsx
@@ -3,7 +3,7 @@ import { useApp } from '../../contexts/AppContextSupabase';
 import { useNetWorthConversion } from '../../hooks/useNetWorthConversion';
 import { useCurrencyDecimal } from '../../hooks/useCurrencyDecimal';
 import ReportDrillModal, { type ReportDrillTarget } from '../../components/reports/ReportDrillModal';
-import { buildAccountBalanceReport, resolveClosingSnapshot, type AccountBalanceRow } from '../../utils/accountBalanceReport';
+import { buildAccountBalanceReport, movedSideLabel, resolveClosingSnapshot, type AccountBalanceRow } from '../../utils/accountBalanceReport';
 import BalanceReportCurrencyNote from '../../components/reports/BalanceReportCurrencyNote';
 import { PERIOD_LABELS } from '../../hooks/usePeriod';
 import NetWorthSummary from '../../components/NetWorthSummary';
@@ -112,10 +112,19 @@ export default function NetWorthStatementReport({ picker }: ReportViewProps): Re
               {rows.map(row => (
                 <tr key={row.accountId} className="border-t border-gray-50 dark:border-gray-700/50">
                   <th scope="row" className="px-6 py-2.5 text-left font-normal">
+                    {/* flex-col items-start: index.css sets `button { display:
+                        inline-flex; align-items: center }` globally, which
+                        turns the two block spans below into flex items laid
+                        side by side — the name and its label ran together on
+                        one line ("Credit CardCredit cards"), silently, for as
+                        long as this table has existed. An element selector
+                        loses to a utility class, so stating the direction here
+                        is the fix; `block` on the children cannot win, because
+                        a flex item's display is blocked out either way. */}
                     <button
                       type="button"
                       onClick={() => drillIntoAccount(row)}
-                      className="text-left rounded"
+                      className="flex flex-col items-start text-left rounded"
                       title={`${row.name} — view these transactions`}
                     >
                       <span className="block text-sm text-gray-900 dark:text-white hover:text-blue-700 dark:hover:text-blue-400 hover:underline">
@@ -123,9 +132,21 @@ export default function NetWorthStatementReport({ picker }: ReportViewProps): Re
                       </span>
                       {/* mt-0.5: a long name wraps to the line above this
                           label, and with no gap the two read as one string
-                          (Design, 23 Aug §4). */}
+                          (Design, 23 Aug §4).
+
+                          WHY A ROW MOVED (Design §1.1, 25 Aug). Sections split
+                          by SIGN, bands name a TYPE, and the two disagree
+                          whenever an account is overdrawn or a card is
+                          overpaid. A reader looking for their current account
+                          under what you own, and not finding it, needs the row
+                          to say why it is on the other side. Only the moved
+                          rows carry the word: on every other row it would be
+                          restating the section heading. */}
                       <span className="block mt-0.5 text-xs text-gray-400 dark:text-gray-500">
                         {groupLabels.get(row.accountId) ?? 'Other'}
+                        {movedSideLabel(row.type, row.closing) !== null && (
+                          <> · {movedSideLabel(row.type, row.closing)}</>
+                        )}
                       </span>
                     </button>
                   </th>

--- a/src/test/a11y/buttonsStackTheirOwnRows.test.ts
+++ b/src/test/a11y/buttonsStackTheirOwnRows.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+/**
+ * A BUTTON IS A FLEX ROW WHETHER YOU ASKED FOR ONE OR NOT.
+ *
+ * `src/index.css` styles the bare element — `button { display: inline-flex;
+ * align-items: center }` — so every button in the app is a flex container.
+ * Its children are flex ITEMS, and a flex item's own `display: block` does
+ * not put it on a line of its own: the parent's direction does. Two `block`
+ * spans inside a button therefore render SIDE BY SIDE.
+ *
+ * That is not a hypothetical. The net-worth statement drew every account as a
+ * name above its section label, and the two ran together on one line —
+ * "Credit CardCredit cards · in credit" — for as long as the table had
+ * existed. It went unnoticed because the label was short enough to read as
+ * part of the name, and it was only Design's §1.1 labelling (25 Aug), which
+ * made the label longer, that made it obvious. The CSV format picker had the
+ * same fault in the same shape.
+ *
+ * This is the FOURTH member of a family: three rules in index.css that beat
+ * Tailwind utilities and present as component bugs. What they have in common
+ * is that the component looks correct in isolation — `block` really does mean
+ * block — and only the cascade says otherwise. A source census is the cheap
+ * defence, because jsdom does no layout and could not measure this even if a
+ * rendered test wanted to.
+ *
+ * THE RULE: a button whose DIRECT children include two or more `block`-classed
+ * elements must state its own direction (`flex-col`, `grid`, or `block`).
+ * Nesting them inside one wrapper span is equally fine and is what most of the
+ * app already does — that wrapper is the single flex item, and the blocks
+ * stack inside it normally.
+ */
+
+const SRC = join(process.cwd(), 'src');
+
+function walk(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__' || entry === 'test') continue;
+      walk(full, out);
+    } else if (/\.tsx$/.test(entry) && !/\.test\.tsx$/.test(entry)) {
+      out.push(full);
+    }
+  }
+}
+
+/**
+ * The opening tag with its COMMENTS REMOVED.
+ *
+ * Not fussiness: the first draft of this census passed on a button whose only
+ * mention of `flex-col` was the `//` comment explaining why the fix was
+ * needed. A census that its own explanation satisfies is worse than none —
+ * the same hole the touch-target census had to close, for the same reason.
+ */
+function withoutComments(tag: string): string {
+  return tag.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ');
+}
+
+/** The opening tag starting at `i`, respecting `{…}` so `=>` cannot end it. */
+function openTag(source: string, i: number): string {
+  let depth = 0;
+  for (let j = i; j < source.length; j += 1) {
+    const c = source[j];
+    if (c === '{') depth += 1;
+    else if (c === '}') depth -= 1;
+    else if (c === '>' && depth === 0 && source[j - 1] !== '=') return source.slice(i, j + 1);
+  }
+  return source.slice(i, i + 400);
+}
+
+/** `block`-classed elements that are DIRECT children of this button body. */
+function directBlockChildren(body: string): number {
+  const element = /<\/?(span|div|p|a)\b/g;
+  let depth = 0;
+  let count = 0;
+  let index = 0;
+  for (;;) {
+    element.lastIndex = index;
+    const match = element.exec(body);
+    if (!match) return count;
+    if (body[match.index + 1] === '/') {
+      depth -= 1;
+      index = element.lastIndex;
+      continue;
+    }
+    const tag = openTag(body, match.index);
+    if (depth === 0 && /className=(?:"|\{`)[^"`]*\bblock\b/.test(withoutComments(tag))) count += 1;
+    if (!tag.trimEnd().endsWith('/>')) depth += 1;
+    index = match.index + tag.length;
+  }
+}
+
+describe('a button states its own direction before stacking rows inside it', () => {
+  const files: string[] = [];
+  walk(SRC, files);
+
+  it('the census still has buttons to look at (never vacuously green)', () => {
+    const total = files.reduce(
+      (n, file) => n + (readFileSync(file, 'utf8').match(/<button\b/g)?.length ?? 0),
+      0
+    );
+    expect(total).toBeGreaterThan(100);
+  });
+
+  it('the global rule that makes this necessary is still in the stylesheet', () => {
+    // If someone removes it, this census becomes noise and should be deleted
+    // rather than left standing as a rule nothing enforces.
+    const css = readFileSync(join(SRC, 'index.css'), 'utf8');
+    expect(css).toMatch(/button[^{]*\{[^}]*display:\s*inline-flex/);
+  });
+
+  it('no button lays two block children out as a row by accident', () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const source = readFileSync(file, 'utf8');
+      const rel = relative(process.cwd(), file).split('\\').join('/');
+      const opener = /<button\b/g;
+      for (;;) {
+        const match = opener.exec(source);
+        if (!match) break;
+        const tag = openTag(source, match.index);
+        const close = source.indexOf('</button>', match.index);
+        if (close === -1) continue;
+        const body = source.slice(match.index + tag.length, close);
+        if (directBlockChildren(body) < 2) continue;
+        if (/flex-col|grid|\bblock\b/.test(withoutComments(tag))) continue;
+        offenders.push(`${rel}:${source.slice(0, match.index).split('\n').length}`);
+      }
+    }
+    expect(
+      offenders,
+      `These buttons stack rows inside themselves but inherit the stylesheet's ` +
+      `\`display: inline-flex\`, so their block children render SIDE BY SIDE. ` +
+      `Add \`flex flex-col items-start\` to the button, or wrap the children in ` +
+      `one span. Offenders: ${offenders.join(', ')}`
+    ).toEqual([]);
+  });
+});

--- a/src/utils/accountBalanceReport.test.ts
+++ b/src/utils/accountBalanceReport.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildAccountBalanceReport } from './accountBalanceReport';
+import { buildAccountBalanceReport, movedSideLabel, sideOfType } from './accountBalanceReport';
 import { toDecimal } from './decimal';
 import type { Account, Transaction } from '../types';
 
@@ -354,5 +354,97 @@ describe('a nested account is filed where its parent is (owner, 25 Aug)', () => 
       [ordinaryCurrent, portfolio], [], { from: null, to: null }, new Date(2026, 7, 25)
     );
     expect(labelsOf(report).sort()).toEqual(['Current accounts', 'Investments']);
+  });
+});
+
+
+/**
+ * THE LOANS BAND, AND THE WORD FOR A ROW THAT MOVED (Design §2.1 and §1.1,
+ * ruled 24 Aug and confirmed 25th, after they withdrew the type-based
+ * classification that prompted them).
+ *
+ * Every figure below is invented; this repo is public.
+ */
+describe('bands agree with the headline', () => {
+  const WIDE = { from: null, to: null };
+
+  const loans = (out: number, owed: number): Account[] => [
+    account({ id: 'lent', name: 'Money I lent', type: 'loan', openingBalance: out }),
+    account({ id: 'borrowed', name: 'Money I borrowed', type: 'loan', openingBalance: owed }),
+  ];
+
+  it('splits Loans by side when it holds both — no band nets against the headline', () => {
+    const report = buildAccountBalanceReport(loans(2000, -5000), [], WIDE);
+    const labels = report.groups.map(g => g.label);
+    expect(labels).toContain('Loans out');
+    expect(labels).toContain('Loans in');
+    expect(labels).not.toContain('Loans');
+
+    // Each band now agrees with the headline figure it feeds, instead of one
+    // −£3,000 total contradicting both.
+    expect(report.groups.find(g => g.label === 'Loans out')?.closing).toBe(2000);
+    expect(report.groups.find(g => g.label === 'Loans in')?.closing).toBe(-5000);
+    expect(report.assets).toBe(2000);
+    expect(report.liabilities).toBe(5000);
+  });
+
+  it('leaves Loans whole when every loan runs the same way', () => {
+    // Nothing to resolve: the band total and the headline already agree, and
+    // "Loans in" as the only band would draw a distinction against nothing.
+    const borrowedOnly = buildAccountBalanceReport(
+      [account({ id: 'b', name: 'Mine', type: 'loan', openingBalance: -5000 })], [], WIDE
+    );
+    expect(borrowedOnly.groups.map(g => g.label)).toEqual(['Loans']);
+
+    const lentOnly = buildAccountBalanceReport(
+      [account({ id: 'l', name: 'Theirs', type: 'loan', openingBalance: 2000 })], [], WIDE
+    );
+    expect(lentOnly.groups.map(g => g.label)).toEqual(['Loans']);
+  });
+
+  it('files a cleared loan with the borrowings, never as an asset', () => {
+    const report = buildAccountBalanceReport(
+      [...loans(2000, -5000), account({ id: 'paid', name: 'Paid off', type: 'loan', openingBalance: 0 })],
+      [], WIDE
+    );
+    const inBand = report.groups.find(g => g.label === 'Loans in');
+    expect(inBand?.rows.map(r => r.accountId).sort()).toEqual(['borrowed', 'paid']);
+  });
+
+  it('sorts the owed-to-you half up with the assets, the owed half where Loans was', () => {
+    const report = buildAccountBalanceReport(
+      [
+        ...loans(2000, -5000),
+        account({ id: 'cur', name: 'Everyday', type: 'current', openingBalance: 100 }),
+        account({ id: 'card', name: 'Card', type: 'credit', openingBalance: -50 }),
+      ],
+      [], WIDE
+    );
+    const order = report.groups.map(g => g.label);
+    // Band order is this report's only way of agreeing with the two headline
+    // figures — it has no own/owe headings to file a band under.
+    expect(order).toEqual(['Current accounts', 'Loans out', 'Credit cards', 'Loans in']);
+  });
+});
+
+describe('movedSideLabel — why a row is on the other side', () => {
+  it('names the move, in each direction', () => {
+    expect(movedSideLabel('current', -120)).toBe('overdrawn');
+    expect(movedSideLabel('savings', -1)).toBe('overdrawn');
+    expect(movedSideLabel('credit', 45)).toBe('in credit');
+    expect(movedSideLabel('mortgage', 10)).toBe('in credit');
+  });
+
+  it('says nothing when the row is where its type implies', () => {
+    // Otherwise every row in the report would carry a label restating the
+    // heading it already sits under.
+    expect(movedSideLabel('current', 500)).toBeNull();
+    expect(movedSideLabel('credit', -500)).toBeNull();
+  });
+
+  it('says nothing for a zero balance, or a type that implies no side', () => {
+    expect(movedSideLabel('current', 0)).toBeNull();
+    expect(movedSideLabel('other', -500)).toBeNull();
+    expect(sideOfType('other')).toBeNull();
   });
 });

--- a/src/utils/accountBalanceReport.ts
+++ b/src/utils/accountBalanceReport.ts
@@ -91,7 +91,66 @@ const TYPE_LABELS: Array<{ key: Account['type']; label: string }> = [
 const labelOfType = (type: Account['type']): string =>
   TYPE_LABELS.find(entry => entry.key === type)?.label ?? 'Other';
 
+/**
+ * Which side a TYPE would normally land on — not which side its balance
+ * actually puts it on, which is always the sign's business.
+ *
+ * The two differ more often than one would guess, and that is the point: an
+ * overdrawn current account is asset-typed and owed, an overpaid credit card
+ * is liability-typed and owned. The reports use this ONLY to say why a row
+ * has moved (Design §1.1, 25 Aug); nothing here classifies money.
+ *
+ * `null` for 'other', which implies no side, so a row of that type is never
+ * described as having moved anywhere.
+ */
+export type AccountSide = 'asset' | 'liability';
+
+const SIDE_OF_TYPE: Partial<Record<Account['type'], AccountSide>> = {
+  current: 'asset', checking: 'asset', savings: 'asset',
+  investment: 'asset', asset: 'asset', assets: 'asset',
+  credit: 'liability', loan: 'liability',
+  mortgage: 'liability', liability: 'liability',
+};
+
+export const sideOfType = (type: Account['type']): AccountSide | null =>
+  SIDE_OF_TYPE[type] ?? null;
+
+/**
+ * The word for a row sitting on the side its TYPE does not imply — the
+ * labelling that survived Design's own reversal on sign-vs-type (25 Aug).
+ *
+ * It was proposed to explain why a row sat on the *unexpected* side. Under
+ * sign-based classification — which is correct, because a balance sheet
+ * states claims rather than product categories — its job inverts: it explains
+ * why a row has MOVED. A reader looking for their current account under what
+ * you own, and not finding it, needs the row itself to say why it is on the
+ * other side.
+ *
+ * Null when the row is where its type implies, because then there is nothing
+ * to explain and a label would be noise on every row in the report.
+ */
+export function movedSideLabel(type: Account['type'], closing: number): string | null {
+  const side = sideOfType(type);
+  if (side === null || closing === 0) return null;
+  if (side === 'asset' && closing < 0) return 'overdrawn';
+  if (side === 'liability' && closing > 0) return 'in credit';
+  return null;
+}
+
+/**
+ * Where a band sits in the report.
+ *
+ * "Loans in" takes the place Loans held, among the bands of things you owe.
+ * "Loans out" sorts up with the asset bands instead, because that is what
+ * Design's "under what you own" means in a report that has no such heading to
+ * put it under: the band ORDER is this report's only way of agreeing with the
+ * two headline figures, so the asset half of a split loan band belongs beside
+ * the other assets rather than filed under debts by an accident of type.
+ */
 const orderOfLabel = (label: string): number => {
+  if (label === 'Loans in') return TYPE_LABELS.findIndex(entry => entry.label === 'Loans');
+  // Immediately after the last asset band, before the first liability one.
+  if (label === 'Loans out') return TYPE_LABELS.findIndex(entry => entry.label === 'Credit cards') - 0.5;
   const index = TYPE_LABELS.findIndex(entry => entry.label === label);
   return index === -1 ? TYPE_LABELS.length : index;
 };
@@ -328,9 +387,42 @@ export function buildAccountBalanceReport(
     for (const child of children) parentTypeOf.set(child.id, parent.type);
   }
 
+  /*
+   * THE LOANS BAND SPLITS BY SIDE (Design §2.1, ruled 24 Aug, confirmed 25th).
+   *
+   * The headline splits by SIGN — "In credit" against "Overdrawn / owed" —
+   * while the bands group by TYPE and net within themselves. Where a band
+   * holds both signs, its one total contradicts the two figures above it: a
+   * reader sees a loan counted as an asset up there and netted away down
+   * here, with nothing to say which reading is the real one.
+   *
+   * Loans are where this actually bites, because the two signs are two
+   * different PRODUCTS rather than one product in two states. A loan you made
+   * is money owed to you; a loan you took is money you owe. "Loans" is the
+   * only band label in the app that names both without distinguishing them —
+   * an overdrawn current account is still a current account, and Design's
+   * §1.1 row labelling is the answer for that case.
+   *
+   * Split ONLY when both signs are present. A ledger with borrowings alone
+   * has no contradiction to resolve, and "Loans in" as the sole band would be
+   * a distinction drawn against nothing.
+   */
+  const groupKeyOf = (row: AccountBalanceRow): string =>
+    labelOfType(parentTypeOf.get(row.accountId) ?? row.type);
+
+  const loanRows = rows.filter(row => groupKeyOf(row) === 'Loans');
+  const loansHoldBothSides =
+    loanRows.some(row => row.closing > 0) && loanRows.some(row => row.closing < 0);
+
   const byLabel = new Map<string, AccountBalanceRow[]>();
   for (const row of rows) {
-    const label = labelOfType(parentTypeOf.get(row.accountId) ?? row.type);
+    const base = groupKeyOf(row);
+    // A zero-balance loan sits with the borrowings: it is a loan you took and
+    // have cleared, not a loan you made. Filing it as an asset would put a
+    // settled debt under what you own.
+    const label = base === 'Loans' && loansHoldBothSides
+      ? (row.closing > 0 ? 'Loans out' : 'Loans in')
+      : base;
     const list = byLabel.get(label);
     if (list) list.push(row);
     else byLabel.set(label, [row]);


### PR DESCRIPTION
Design's **§2.1** and **§1.1**, ruled 24 Aug and confirmed on the 25th — after they withdrew the type-based classification that had prompted both. Their reversal is worth recording: summing by sign is correct, because a balance sheet states *claims*, not product categories.

## What the question actually found

The headline splits by **sign** ("In credit" / "Overdrawn / owed"). The bands group by **type** and net within themselves. Where a band holds both signs, its one total contradicts the two figures above it — a loan counted as an asset up there and netted away down here, with nothing on the page to say which reading is real.

## §2.1 — Loans split

Loans are where this bites, because the two signs are two different **products** rather than one product in two states. A loan you made is money owed to you; a loan you took is money you owe. "Loans" is the only band label in the app that names both without distinguishing them — an overdrawn current account is still a current account, and §1.1 is the answer for that case.

- Splits **only when both signs are present**. A ledger with borrowings alone has no contradiction to resolve, and "Loans in" as the sole band would draw a distinction against nothing.
- A **cleared** loan files with the borrowings — it is a debt you have paid off, not an asset.
- **"Loans out" sorts up with the asset bands.** Band order is this report's only way of agreeing with the two headline figures; it has no own/owe headings to file a band under.

## §1.1 — a row that moved says why

The `overdrawn` / `in credit` wording keeps its place with its job inverted. It no longer explains why a row sits on the *unexpected* side; it explains why a row has **moved**. Only moved rows carry it — on the others it would restate the heading they already sit under.

## And a layout bug the longer label exposed

`index.css` styles the bare element — `button { display: inline-flex; align-items: center }` — so a button's children are flex **items**, and their own `display: block` does not give them a line.

The statement's account rows had been drawing the name and its section label **side by side** — `Credit CardCredit cards` — for as long as the table had existed. It went unnoticed because the label was short enough to read as part of the name. The CSV format picker had the same fault in the same shape.

This is the **fourth** member of the index.css-beats-Tailwind family, so it gets a census rather than two quiet fixes: any button with two `block`-classed direct children must state its own direction. The census's first draft passed on a button whose only mention of `flex-col` was the comment explaining the fix — closed, same hole the touch-target census had.

## Verification

Live in the browser, on a demo ledger I gave two loans running opposite ways:

- `LOANS OUT £2,000.00` above the credit cards, `LOANS IN (£3,000.00)` below them — both agreeing with `IN CREDIT ≈ £16,144.98` and `OVERDRAWN / OWED ≈ £10,450.10`.
- `Credit cards · in credit` and `Current accounts · overdrawn`, each **stacked** under its account name — measured, not eyeballed: name top 2781 (20px high), label top 2803.

30 unit specs on the util. Census proven non-vacuous against both sites it fixes. Lint and `typecheck:strict` clean; husky gates ran on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)