### PR TITLE
fix(reports): the expense and income drills read the way the category list does

### DIFF
--- a/src/components/IncomeExpenseBreakdownModal.ordering.test.tsx
+++ b/src/components/IncomeExpenseBreakdownModal.ordering.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import IncomeExpenseBreakdownModal from './IncomeExpenseBreakdownModal';
+import { __setAppContextValue, __resetAppContextValue } from '../test/mocks/AppContextSupabase';
+import { PreferencesProvider } from '../contexts/PreferencesContext';
+import type { Category, Transaction } from '../types';
+import type { SplitExpandedTransaction } from '../utils/transactionSplits';
+
+/**
+ * THE DRILL READS IN THE ORDER THE CATEGORY LIST DOES (owner, 25 Aug):
+ * "in the order of how I read the categories from top to bottom, which is
+ * alphabetical groupings then alphabetical category names."
+ *
+ * Sections were ordered by |subtotal| — biggest spend first — which answers a
+ * question nobody asked here. This drill is opened to FIND something: the
+ * reader already knows the category and had to hunt for it down a list whose
+ * order changed with every period.
+ *
+ * The fixture is built so the two orders DISAGREE: the alphabetically-first
+ * group holds the smallest amount, so a test that passed under either rule
+ * would prove nothing.
+ *
+ * Every payee, category and figure below is invented: this repo is public.
+ */
+
+const CATEGORIES: Category[] = [
+  { id: 'type-expense', name: 'Expenses', type: 'expense', level: 'type' },
+  // Groups deliberately NOT in alphabetical order here, so the sort cannot
+  // be satisfied by insertion order.
+  { id: 'grp-house', name: 'Household', type: 'expense', level: 'sub', parentId: 'type-expense' },
+  { id: 'grp-gifts', name: 'Gifts', type: 'expense', level: 'sub', parentId: 'type-expense' },
+  { id: 'det-repairs', name: 'Repairs', type: 'expense', level: 'detail', parentId: 'grp-house' },
+  { id: 'det-water', name: 'Water', type: 'expense', level: 'detail', parentId: 'grp-house' },
+  { id: 'det-birthday', name: 'Birthday', type: 'expense', level: 'detail', parentId: 'grp-gifts' },
+];
+
+const txn = (id: string, category: string, amount: number): SplitExpandedTransaction =>
+  ({
+    id, date: new Date(Date.UTC(2026, 3, 6)), description: 'Payment ' + id,
+    amount, type: 'expense', category, accountId: 'acc-1', cleared: false,
+  } as Transaction as SplitExpandedTransaction);
+
+/**
+ * Gifts : Birthday is the SMALLEST and sorts FIRST; Household : Water is the
+ * LARGEST and sorts LAST. Under the old |subtotal| rule the order was exactly
+ * reversed, so this fixture separates the two rules cleanly.
+ */
+const ROWS: SplitExpandedTransaction[] = [
+  txn('t1', 'det-water', -900),
+  txn('t2', 'det-repairs', -500),
+  txn('t3', 'det-birthday', -100),
+];
+
+const renderDrill = (): void => {
+  render(
+    <PreferencesProvider>
+      <IncomeExpenseBreakdownModal
+        isOpen
+        onClose={vi.fn()}
+        title="Expenses — Last month"
+        bucket="expense"
+        rows={ROWS}
+        total={null}
+        categories={CATEGORIES}
+        onEditTransaction={vi.fn()}
+      />
+    </PreferencesProvider>
+  );
+};
+
+/**
+ * The section headings, top to bottom, as the reader meets them.
+ *
+ * The table renders a mobile and a desktop layout, so each heading appears
+ * twice; the trailing "(n)" is the row count. Both are stripped so the spec
+ * is about ORDER and nothing else.
+ */
+const sectionOrder = (): string[] => {
+  const seen: string[] = [];
+  for (const el of screen.getAllByText(/^(Gifts|Household) : /)) {
+    const name = el.textContent!.trim().replace(/\s*\(\d+\)\s*$/, '');
+    if (!seen.includes(name)) seen.push(name);
+  }
+  return seen;
+};
+
+beforeEach(() => {
+  __setAppContextValue({
+    categories: CATEGORIES,
+    getSubCategories: (parentId?: string) => CATEGORIES.filter(c => c.parentId === parentId),
+    getDetailCategories: (parentId?: string) => CATEGORIES.filter(c => c.parentId === parentId),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  __resetAppContextValue();
+});
+
+describe('the breakdown drill’s section order', () => {
+  it('reads alphabetically by group, then by category — not by size', () => {
+    renderDrill();
+    expect(sectionOrder()).toEqual([
+      'Gifts : Birthday',
+      'Household : Repairs',
+      'Household : Water',
+    ]);
+  });
+
+  it('is the DEFAULT, so the reader gets it without touching a control', () => {
+    // The drill opens on the category view; if biggest-first ever returns as
+    // the default, the previous spec would still pass on a second click.
+    renderDrill();
+    expect(sectionOrder()[0]).toBe('Gifts : Birthday');
+  });
+
+  it('flips to Z→A on the Category header, which is what a name column means', () => {
+    renderDrill();
+    fireEvent.click(screen.getByRole('button', { name: /Category/ }));
+    expect(sectionOrder()).toEqual([
+      'Household : Water',
+      'Household : Repairs',
+      'Gifts : Birthday',
+    ]);
+  });
+});

--- a/src/components/IncomeExpenseBreakdownModal.tsx
+++ b/src/components/IncomeExpenseBreakdownModal.tsx
@@ -197,8 +197,8 @@ export default function IncomeExpenseBreakdownModal({
       return { sections: [{ name: null as string | null, subtotal: 0, rows: sorted.slice(0, CAP) }], truncated: Math.max(0, sorted.length - CAP) };
     }
 
-    // Category sections: subtotal per section (Decimal), sections ordered by
-    // |subtotal| descending (dir flips it), rows newest-first inside.
+    // Category sections: subtotal per section (Decimal), rows newest-first
+    // inside, sections ordered A→Z (dir flips it) — see below.
     const byCategory = new Map<string, SplitExpandedTransaction[]>();
     for (const t of sorted) {
       const name = categoryName(t.category);
@@ -211,19 +211,53 @@ export default function IncomeExpenseBreakdownModal({
       subtotal: sectionRows.reduce((s, t) => s.plus(toDecimal(valueOf(t))), toDecimal(0)).toNumber(),
       rows: sectionRows.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()),
     }));
-    sections.sort((a, b) => sortDir * (Math.abs(b.subtotal) - Math.abs(a.subtotal)));
-
-    // Apply the cap across sections in order.
+    /*
+     * SECTIONS READ IN THE ORDER THE CATEGORY LIST DOES (owner, 25 Aug):
+     * "in the order of how I read the categories from top to bottom, which is
+     * alphabetical groupings then alphabetical category names".
+     *
+     * They were ordered by |subtotal| — biggest spend first — which answers a
+     * question nobody asked here. This drill is opened to FIND something: the
+     * reader already knows which category they are looking for and has to
+     * hunt for it down a list whose order changes with every period. The
+     * Categories page, the picker and the tree all read A→Z, and a list that
+     * agrees with them can be scanned without being read.
+     *
+     * One comparison does both halves of his rule, because a section's name
+     * IS "Parent : Child" (utils/categoryNames): the parent dominates the
+     * comparison, so groups sort alphabetically and categories sort
+     * alphabetically inside them.
+     *
+     * Biggest-first is still one click away — that is what the Amount column
+     * sorts by, and the direction arrow on Category now flips A→Z / Z→A,
+     * which is what a name column should mean.
+     */
+    /*
+     * WHAT TO KEEP AND WHAT ORDER TO SHOW IT IN ARE TWO QUESTIONS.
+     *
+     * The cap exists so an All-time window cannot render tens of thousands of
+     * rows, and it spends its budget across sections IN ORDER. While that
+     * order was |subtotal| the two questions had the same answer by accident:
+     * capping kept the biggest sections. Ordering alphabetically without
+     * separating them would start truncating at the end of the ALPHABET,
+     * which is an arbitrary reason to hide someone's money.
+     *
+     * So the budget is spent biggest-first — the significant sections survive
+     * — and what survives is then ordered for reading.
+     */
+    const capped = [];
     let budget = CAP;
     let truncated = 0;
-    const capped = [];
-    for (const s of sections) {
-      if (budget <= 0) { truncated += s.rows.length; continue; }
-      const take = s.rows.slice(0, budget);
-      truncated += s.rows.length - take.length;
+    for (const section of [...sections].sort((a, b) => Math.abs(b.subtotal) - Math.abs(a.subtotal))) {
+      if (budget <= 0) { truncated += section.rows.length; continue; }
+      const take = section.rows.slice(0, budget);
+      truncated += section.rows.length - take.length;
       budget -= take.length;
-      capped.push({ ...s, rows: take });
+      capped.push({ ...section, rows: take });
     }
+    capped.sort((a, b) =>
+      sortDir * (a.name ?? '').localeCompare(b.name ?? '', undefined, { sensitivity: 'base' })
+    );
     return { sections: capped, truncated };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visibleRows, sortKey, sortDir, categoryName, bucket]);


### PR DESCRIPTION
Steve, 25 Aug:

> can we have the list in the order of how I read the categories from top to bottom, which is alphabetical groupings then alphabetical category names. This could be the same for the income list too

## Why the old order was wrong for this surface

Sections were ordered by `|subtotal|` — biggest spend first. That answers a question nobody asks at this point.

The drill is opened to **find** something: the reader already knows which category they're looking for. A list whose order changes with every period has to be *read* rather than scanned. The Categories page, the picker and the tree all run A→Z; agreeing with them is what makes this list scannable.

One comparison does both halves of the rule, because a section's name **is** `"Parent : Child"` (`utils/categoryNames`) — the parent dominates the comparison, so groups sort alphabetically and categories sort alphabetically inside them. Income and expenses share this component, so both change together.

## What to keep and what order to show it in are now two questions

The row cap that stops an All-time window rendering tens of thousands of rows spends its budget across sections *in order*. While that order was `|subtotal|`, the two questions had the same answer by accident — capping kept the biggest sections.

Reordering alphabetically without separating them would have started truncating **at the end of the alphabet**, which is an arbitrary reason to hide someone's money. So the budget is now spent biggest-first, and what survives is ordered for reading.

Biggest-first is still one click away on the Amount column, and the Category header's arrow now flips A→Z / Z→A — which is what a name column should mean.

## Verification

Live on the demo ledger, the Expenses drill now reads:

> Bills & Utilities · Education · Entertainment · Groceries · Healthcare · Insurance · Restaurants · Shopping · Transportation · Travel

Three specs, on a fixture built so the two rules **disagree** — the alphabetically-first group holds the smallest amount, so a spec that passed under either rule would prove nothing. All three fail when the old ordering is put back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)