### PR TITLE
feat(reports): the period control moves onto the reports, and each can keep its own

### DIFF
--- a/src/components/reports/ReportPeriodDefaultToggle.tsx
+++ b/src/components/reports/ReportPeriodDefaultToggle.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { CheckCircleIcon } from '../icons';
+
+/**
+ * "Open this report on this period from now on."
+ *
+ * The owner's design, 25 Aug: changing the window is a LOOK, saving it is a
+ * DECISION. So the period pills do not persist anything, and this is the
+ * control that does — ticked exactly while the saved default equals what is
+ * on screen, which is why "the button unticks itself" when the window
+ * changes without anyone implementing unticking.
+ *
+ * It is a button rather than a checkbox on purpose. A checkbox describes a
+ * state you are free to toggle; this performs an action in one direction —
+ * pressing it while it is already ticked would either do nothing or silently
+ * FORGET the default, and neither is what a tick invites. Clearing is
+ * available and says so in words instead.
+ *
+ * Quiet by default, per the house rule: this is a settled state, not
+ * something needing attention, so the ticked form is neutral rather than
+ * green. Colour marks what needs looking at.
+ */
+export default function ReportPeriodDefaultToggle({
+  isDefault,
+  periodLabel,
+  onSave,
+  onClear,
+}: {
+  /** True while the saved default is what the reader is looking at. */
+  isDefault: boolean;
+  /** The window's own name, so the control says what it would save. */
+  periodLabel: string;
+  onSave: () => void;
+  onClear: () => void;
+}): React.JSX.Element {
+  if (isDefault) {
+    return (
+      <div className="flex items-center gap-2 text-dense text-gray-500 dark:text-gray-400">
+        <span className="inline-flex items-center gap-1.5">
+          <CheckCircleIcon size={14} aria-hidden="true" />
+          Opens on {periodLabel}
+        </span>
+        <button
+          type="button"
+          onClick={onClear}
+          className="underline underline-offset-2 hover:text-gray-700 dark:hover:text-gray-200 rounded"
+        >
+          Clear
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onSave}
+      className="text-dense text-gray-500 dark:text-gray-400 underline underline-offset-2 hover:text-gray-700 dark:hover:text-gray-200 rounded"
+    >
+      Always open on {periodLabel}
+    </button>
+  );
+}

--- a/src/pages/ReportsHub.tsx
+++ b/src/pages/ReportsHub.tsx
@@ -13,6 +13,14 @@ import ReportGallery from './reports/ReportGallery';
 import MixedCurrencyDisclosure from '../components/MixedCurrencyDisclosure';
 import ReportCurrencyNote from '../components/reports/ReportCurrencyNote';
 import { findReport } from './reports/reportRegistry';
+import ReportPeriodDefaultToggle from '../components/reports/ReportPeriodDefaultToggle';
+import {
+  clearReportPeriodDefault,
+  matchesReportPeriodDefault,
+  readReportPeriodDefault,
+  writeReportPeriodDefault,
+} from '../utils/reportPeriodDefaults';
+import { PERIOD_LABELS } from '../hooks/usePeriod';
 
 /** The window a report gets when it states no preference of its own. */
 const HUB_DEFAULT_PERIOD: PeriodKey = 'this-month';
@@ -24,7 +32,11 @@ const HUB_DEFAULT_PERIOD: PeriodKey = 'this-month';
  *
  * The hub owns the shared reporting period and hands it to whichever report
  * is open, so the period PERSISTS as the user moves between reports instead
- * of resetting each time. Each report lives at its own /reports/<id> URL and
+ * of resetting each time. The CONTROL, though, only appears on a report: on
+ * the gallery it changed a window nothing on screen was showing, which is
+ * how the owner came to report it as doing nothing (25 Aug). A report may
+ * also have its own saved window that outranks the shared one — see
+ * utils/reportPeriodDefaults. Each report lives at its own /reports/<id> URL and
  * is code-split, so opening the gallery never loads eight reports' worth of
  * charts.
  *
@@ -52,6 +64,42 @@ export default function ReportsHub(): React.JSX.Element {
   useEffect(() => {
     applyDefaultPeriod(preferredPeriod);
   }, [applyDefaultPeriod, preferredPeriod]);
+
+  /**
+   * A REPORT'S OWN SAVED WINDOW WINS WHEN IT OPENS (owner, 25 Aug).
+   *
+   * Through `applyArrivalPeriod` rather than `applyDefaultPeriod`, because
+   * those two words mean different things here: a surface DEFAULT stands down
+   * the moment the user has ever chosen a period for themselves, which is
+   * correct for "a window this report is worth reading over" and wrong for
+   * "the window this user told this report to open on". A saved default is
+   * the user's own instruction and has to outrank their last casual pick
+   * elsewhere.
+   *
+   * It also inherits the property that makes arrival right: it does NOT write
+   * to the shared reporting period. Opening a report that remembers Last
+   * month must not quietly move every other report to Last month.
+   *
+   * Keyed on the report id alone, so re-picking the window inside a report
+   * does not immediately snap back to the saved one — this fires when the
+   * report changes, which is exactly when "opens on" means anything.
+   */
+  const savedDefaultReportId = report?.id ?? null;
+  useEffect(() => {
+    if (savedDefaultReportId === null) return;
+    const saved = readReportPeriodDefault(savedDefaultReportId);
+    if (saved === null) return;
+    applyArrivalPeriod(saved.period, saved.customStart, saved.customEnd);
+  }, [savedDefaultReportId, applyArrivalPeriod]);
+
+  /** Re-read on every render so the tick answers to what is actually stored. */
+  const [savedDefaultVersion, setSavedDefaultVersion] = useState(0);
+  const savedDefault = useMemo(
+    () => (report === null ? null : readReportPeriodDefault(report.id)),
+    // savedDefaultVersion is the dependency: it changes when we write.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [report, savedDefaultVersion]
+  );
 
   /**
    * What a drill-down from the Dashboard arrived asking for: the window the
@@ -138,7 +186,7 @@ export default function ReportsHub(): React.JSX.Element {
           <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
             {report
               ? report.description
-              : 'Choose a report. The period you pick follows you from one to the next.'}
+              : 'Choose a report. Each one carries its own period control.'}
           </p>
         }
         contentClassName="space-y-6"
@@ -148,8 +196,35 @@ export default function ReportsHub(): React.JSX.Element {
             the report's title, so it has to say what it governs on its own.
 
             No card around it any more — see components/PeriodBar. */}
-        {(report?.usesPeriod ?? true) && !report?.ownsPeriodBar && (
-          <PeriodBar picker={picker} label="Reporting period" />
+        {/*
+            ONLY ON A REPORT, NEVER ON THE GALLERY (owner, 25 Aug: "on the
+            front report page doesn't change anything").
+
+            It did do something — it set the window the next report would open
+            on — but nothing on the gallery moves when you press it, and a
+            control whose effect you cannot see reads as broken. It now
+            appears exactly where its effect is visible.
+        */}
+        {report !== null && (report.usesPeriod ?? true) && !report.ownsPeriodBar && (
+          <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+            <PeriodBar picker={picker} label="Reporting period" />
+            <ReportPeriodDefaultToggle
+              isDefault={matchesReportPeriodDefault(savedDefault, picker)}
+              periodLabel={PERIOD_LABELS[picker.period].toLowerCase()}
+              onSave={() => {
+                writeReportPeriodDefault(report.id, {
+                  period: picker.period,
+                  customStart: picker.customStart,
+                  customEnd: picker.customEnd,
+                });
+                setSavedDefaultVersion(v => v + 1);
+              }}
+              onClear={() => {
+                clearReportPeriodDefault(report.id);
+                setSavedDefaultVersion(v => v + 1);
+              }}
+            />
+          </div>
         )}
 
         {ReportView ? (
@@ -174,10 +249,14 @@ export default function ReportsHub(): React.JSX.Element {
             heading in the gallery (§3.5). The id is deliberately NOT bumped:
             this content is a strict subset of what it already said, so anyone
             who dismissed it has read all of it. */}
+        {/* The tip describes the period rule, so it moved on with the control.
+            The id is BUMPED because the words changed materially: anyone who
+            dismissed the old sentence dismissed a claim about a picker that
+            is no longer on this page. */}
         <PageTip
-          id="reports-gallery-2"
-          title="The period follows you"
-          description="Pick a report — net worth, balances, spending by category or payee, period comparisons — and the period you choose follows you from one to the next."
+          id="reports-period-3"
+          title="Each report remembers its own period"
+          description="Pick a window inside a report and it follows you to the next one. If a report is always worth reading over the same window, save it there and that report will open on it."
         />
       </PageWrapper>
     </>

--- a/src/pages/__tests__/ReportsHub.anatomy.test.tsx
+++ b/src/pages/__tests__/ReportsHub.anatomy.test.tsx
@@ -151,8 +151,13 @@ describe('the Reports heading is the app’s heading', () => {
 });
 
 describe('the period control is a control, directly under the heading', () => {
-  it('sits below the heading with no card around it, and still governs the report', () => {
-    renderHub('/reports');
+  it('sits below the heading with no card around it, and still governs the report', async () => {
+    // On a REPORT — since 25 Aug the gallery has no period control, because
+    // there it changed a window nothing on the page was showing and so read
+    // as doing nothing (owner). The shape assertions below are unchanged;
+    // only the page they are made on moved.
+    renderHub('/reports/account-balances');
+    await screen.findByRole('heading', { name: 'Balances by account' }, LOADS_LAZY_REPORT);
 
     const group = screen.getByRole('group', { name: 'Reporting period' });
 
@@ -166,7 +171,7 @@ describe('the period control is a control, directly under the heading', () => {
     expect(group.closest('.bg-white')).toBeNull();
 
     // Below the heading, not beside it inside the header.
-    const heading = screen.getByRole('heading', { level: 1, name: 'Reports' });
+    const heading = screen.getByRole('heading', { level: 1, name: 'Account balances' });
     expect(heading.compareDocumentPosition(group) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(heading.parentElement?.contains(group)).toBe(false);
 
@@ -174,6 +179,15 @@ describe('the period control is a control, directly under the heading', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Last month' }));
     expect(screen.getByRole('button', { name: 'Last month' })).toHaveAttribute('aria-pressed', 'true');
     expect(preferences.getItem('reportsPeriod')).toBe('last-month');
+  });
+
+  it('is absent from the GALLERY, which shows no window for it to govern', () => {
+    // The owner's report, 25 Aug: "on the front report page doesn't change
+    // anything". It did set what the next report would open on, but nothing
+    // here moves when you press it — a control whose effect is invisible
+    // reads as broken, so it lives only where the effect is visible.
+    renderHub('/reports');
+    expect(screen.queryByRole('group', { name: 'Reporting period' })).not.toBeInTheDocument();
   });
 
   it('is absent, not inert, on a report that shows no period', async () => {

--- a/src/pages/__tests__/ReportsHub.periodDefaults.test.tsx
+++ b/src/pages/__tests__/ReportsHub.periodDefaults.test.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { PreferencesProvider } from '../../contexts/PreferencesContext';
+import { ToastProvider } from '../../contexts/ToastContext';
+import { __setAppContextValue, __resetAppContextValue } from '../../test/mocks/AppContextSupabase';
+import { preferences } from '../../services/preferencesService';
+import ReportsHub from '../ReportsHub';
+import { readReportPeriodDefault } from '../../utils/reportPeriodDefaults';
+import type { Account, Category, Transaction } from '../../types';
+
+/**
+ * THE PERIOD CONTROL LIVES WHERE ITS EFFECT IS VISIBLE, AND A REPORT CAN
+ * REMEMBER ITS OWN WINDOW (owner, 25 Aug).
+ *
+ * "On the report last page, we have the length of time options which on the
+ * front report page doesn't change anything." It did set the window the next
+ * report would open on — but nothing on the gallery moves when you press it,
+ * so it read as broken.
+ *
+ * And his design for the replacement: the picker lives on each report, with a
+ * save-as-default control, and "if they change the length, the button unticks
+ * itself and the user has to press it again to update the default".
+ *
+ * Every account, category and figure below is invented: this repo is public.
+ */
+
+const LOADS_LAZY_REPORT = { timeout: 15_000 } as const;
+
+const ACCOUNT: Account = {
+  id: 'acc-p', name: 'Synthetic Current', type: 'current', balance: 0,
+  currency: 'GBP', lastUpdated: new Date('2026-01-01'), openingBalance: 0, isActive: true,
+};
+
+const CATEGORIES: Category[] = [
+  { id: 'type-expense', name: 'Expenses', type: 'expense', level: 'type', isSystem: true },
+  { id: 'det-groceries', name: 'Groceries', type: 'expense', level: 'detail', parentId: 'type-expense' },
+];
+
+const TRANSACTIONS: Transaction[] = [{
+  id: 'txn-p', date: new Date('2024-08-15'), description: 'Synthetic shop',
+  amount: -50, type: 'expense', category: 'det-groceries', accountId: ACCOUNT.id, cleared: false,
+}];
+
+const PERIOD_KEYS = [
+  'reportsPeriod', 'reportsPeriodExplicit', 'reportsPeriodCustomStart', 'reportsPeriodCustomEnd',
+  'reportDefaultPeriod:account-balances', 'reportDefaultPeriodCustom:account-balances',
+];
+
+const renderHub = (entry: string) =>
+  render(
+    <MemoryRouter initialEntries={[entry]}>
+      <PreferencesProvider>
+        <ToastProvider>
+          <Routes>
+            <Route path="/reports" element={<ReportsHub />} />
+            <Route path="/reports/:reportId" element={<ReportsHub />} />
+          </Routes>
+        </ToastProvider>
+      </PreferencesProvider>
+    </MemoryRouter>
+  );
+
+beforeEach(() => {
+  localStorage.clear();
+  for (const key of PERIOD_KEYS) preferences.removeItem(key);
+  __setAppContextValue({
+    accounts: [ACCOUNT], transactions: TRANSACTIONS, categories: CATEGORIES, transactionSplits: [],
+  });
+});
+
+afterEach(() => {
+  __resetAppContextValue();
+});
+
+describe('the period control appears only where its effect is visible', () => {
+  it('the gallery has no period bar', () => {
+    renderHub('/reports');
+    // The gallery is a chooser. A window control here changed something the
+    // page was not showing, which is the complaint.
+    expect(document.querySelector('[data-period-bar]')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Last month' })).toBeNull();
+  });
+
+  it('the gallery does not promise a control it no longer has', () => {
+    renderHub('/reports');
+    expect(screen.queryByText(/period you pick follows you/i)).toBeNull();
+  });
+
+  it('a report has one', async () => {
+    renderHub('/reports/account-balances');
+    await waitFor(() => {
+      expect(document.querySelector('[data-period-bar]')).not.toBeNull();
+    }, LOADS_LAZY_REPORT);
+  });
+});
+
+describe('a report remembers its own window', () => {
+  const saveControl = () => screen.getByRole('button', { name: /^Always open on/ });
+
+  it('saves what is on screen, and says so', async () => {
+    renderHub('/reports/account-balances');
+    await waitFor(() => saveControl(), LOADS_LAZY_REPORT);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Last month' }));
+    fireEvent.click(saveControl());
+
+    expect(readReportPeriodDefault('account-balances')?.period).toBe('last-month');
+    expect(screen.getByText(/Opens on last month/)).toBeInTheDocument();
+  });
+
+  it('unticks itself when the window changes — the owner’s rule, derived not stored', async () => {
+    renderHub('/reports/account-balances');
+    await waitFor(() => saveControl(), LOADS_LAZY_REPORT);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Last month' }));
+    fireEvent.click(saveControl());
+    expect(screen.getByText(/Opens on last month/)).toBeInTheDocument();
+
+    // Look at a different window. The saved default is untouched; the control
+    // stops claiming this one is it, and offers to make it so.
+    fireEvent.click(screen.getByRole('button', { name: 'Tax year' }));
+    expect(screen.queryByText(/Opens on/)).toBeNull();
+    expect(screen.getByRole('button', { name: /^Always open on tax year/ })).toBeInTheDocument();
+    expect(readReportPeriodDefault('account-balances')?.period).toBe('last-month');
+  });
+
+  it('clearing puts the report back on the shared period', async () => {
+    renderHub('/reports/account-balances');
+    await waitFor(() => saveControl(), LOADS_LAZY_REPORT);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Last month' }));
+    fireEvent.click(saveControl());
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+
+    expect(readReportPeriodDefault('account-balances')).toBeNull();
+    expect(screen.getByRole('button', { name: /^Always open on/ })).toBeInTheDocument();
+  });
+
+  it('opens on the saved window even after the user picked another one elsewhere', async () => {
+    renderHub('/reports/account-balances');
+    await waitFor(() => saveControl(), LOADS_LAZY_REPORT);
+    fireEvent.click(screen.getByRole('button', { name: 'Tax year' }));
+    fireEvent.click(saveControl());
+
+    // A choice made elsewhere is stored in the SHARED period. The saved
+    // default has to outrank it, or "always open on" is not true — which is
+    // why this uses the arrival path rather than the surface-default one.
+    preferences.setItem('reportsPeriod', 'this-month');
+    preferences.setItem('reportsPeriodExplicit', 'true');
+
+    const again = renderHub('/reports/account-balances');
+    await waitFor(() => {
+      expect(within(again.container).queryByText(/Opens on tax year/)).not.toBeNull();
+    }, LOADS_LAZY_REPORT);
+  });
+});

--- a/src/pages/__tests__/ReportsHub.test.tsx
+++ b/src/pages/__tests__/ReportsHub.test.tsx
@@ -114,14 +114,26 @@ describe('ReportsHub gallery', () => {
     expect(screen.getByRole('link', { name: /Net worth over time/ })).toBeInTheDocument();
   });
 
+
+/**
+ * Pick a period the only place the control now lives — inside a report
+ * (owner, 25 Aug: on the gallery it "doesn't change anything").
+ *
+ * These specs are about what the CHOICE does as you move around; where the
+ * pills are drawn is not their subject, so this keeps them saying what they
+ * always said.
+ */
+const openReportAndPick = async (linkName: RegExp, heading: string, period: string): Promise<void> => {
+  fireEvent.click(screen.getByRole('link', { name: linkName }));
+  await screen.findByRole('heading', { name: heading }, LOADS_LAZY_REPORT);
+  fireEvent.click(screen.getByRole('button', { name: period }));
+  expect(screen.getByRole('button', { name: period })).toHaveAttribute('aria-pressed', 'true');
+};
+
   it('keeps the chosen period as the user moves between reports', async () => {
     renderHub();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Last month' }));
-    expect(screen.getByRole('button', { name: 'Last month' })).toHaveAttribute('aria-pressed', 'true');
-
-    fireEvent.click(screen.getByRole('link', { name: /Account balances/ }));
-    await screen.findByRole('heading', { name: 'Balances by account' }, LOADS_LAZY_REPORT);
+    await openReportAndPick(/Account balances/, 'Balances by account', 'Last month');
 
     // Still last month — the hub owns the period, not the report.
     expect(screen.getByRole('button', { name: 'Last month' })).toHaveAttribute('aria-pressed', 'true');
@@ -196,7 +208,8 @@ describe('ReportsHub gallery', () => {
   it('never overrides a period the user chose, whatever the report prefers', async () => {
     renderHub();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Tax year' }));
+    await openReportAndPick(/Account balances/, 'Balances by account', 'Tax year');
+    fireEvent.click(screen.getByRole('link', { name: 'All reports' }));
 
     fireEvent.click(screen.getByRole('link', { name: /Net worth over time/ }));
     await screen.findByRole('heading', { name: 'Net Worth Over Time' }, LOADS_LAZY_REPORT);
@@ -213,7 +226,7 @@ describe('ReportsHub gallery', () => {
 
   it('remembers the choice after a reload, so no report can undo it', async () => {
     const first = renderHub();
-    fireEvent.click(screen.getByRole('button', { name: 'Tax year' }));
+    await openReportAndPick(/Account balances/, 'Balances by account', 'Tax year');
     first.unmount();
 
     // A fresh visit — straight to the report with the strongest preference.
@@ -226,6 +239,8 @@ describe('ReportsHub gallery', () => {
   it('treats a custom range as a choice like any other', async () => {
     renderHub();
 
+    fireEvent.click(screen.getByRole('link', { name: /Account balances/ }));
+    await screen.findByRole('heading', { name: 'Balances by account' }, LOADS_LAZY_REPORT);
     fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
     // dd/mm/yyyy — the ONLY format the date field commits (parseTypedDate);
     // the ISO string this spec used to type never parsed, so it sat as an
@@ -238,6 +253,7 @@ describe('ReportsHub gallery', () => {
       target: { value: '10/01/2026' },
     });
 
+    fireEvent.click(screen.getByRole('link', { name: 'All reports' }));
     fireEvent.click(screen.getByRole('link', { name: /Net worth over time/ }));
     await screen.findByRole('heading', { name: 'Net Worth Over Time' }, LOADS_LAZY_REPORT);
 

--- a/src/utils/reportPeriodDefaults.ts
+++ b/src/utils/reportPeriodDefaults.ts
@@ -1,0 +1,103 @@
+import { preferences } from '../services/preferencesService';
+import { isPeriodKey, type PeriodKey } from '../hooks/usePeriod';
+
+/**
+ * EACH REPORT'S OWN DEFAULT WINDOW (owner, 25 Aug).
+ *
+ * ─ THE COMPLAINT ──────────────────────────────────────────────────────────
+ *
+ * "On the report last page, we have the length of time options which on the
+ * front report page doesn't change anything." It did change something — it
+ * set the window the next report would open on — but nothing on the gallery
+ * moves when you press it, and a control with no visible effect reads as
+ * broken. The picker now appears only where its effect is visible: on a
+ * report.
+ *
+ * ─ WHY A SAVED DEFAULT RATHER THAN JUST REMEMBERING ───────────────────────
+ *
+ * Different reports want different windows — net worth over ALL of it,
+ * spending over last month — and one shared period makes you re-pick on every
+ * navigation. The obvious fix is to have each report silently remember what
+ * you last used, but that costs something real: you could no longer LOOK at
+ * twelve months without changing what the report opens on tomorrow.
+ *
+ * So the owner's design is the right one: changing the window is a look, and
+ * saving is a decision. "If they change the length, the button unticks itself
+ * and the user has to press it again to update the default."
+ *
+ * ─ WHY THE TICK IS DERIVED, NEVER STORED ──────────────────────────────────
+ *
+ * The control is ticked exactly when the saved default EQUALS what is on
+ * screen. Nothing tracks "ticked" separately, so the unticking he described
+ * is not a behaviour anyone had to implement — it is the same comparison,
+ * and it cannot drift out of step with the thing it claims to describe.
+ *
+ * ─ WHAT IT DOES NOT CHANGE ────────────────────────────────────────────────
+ *
+ * A report with no saved default behaves exactly as before: it opens on the
+ * shared reporting period, so the window still follows you from one report to
+ * the next. This is additive — nobody loses the old behaviour by not using
+ * the new one.
+ *
+ * Kept in `preferences` rather than localStorage for the reason usePeriod
+ * gives: which window a report opens on belongs to the USER, not to the
+ * machine they happen to be sitting at.
+ */
+
+const storageKey = (reportId: string): string => `reportDefaultPeriod:${reportId}`;
+const customKey = (reportId: string): string => `reportDefaultPeriodCustom:${reportId}`;
+
+/** A saved default's full selection — custom carries its own bounds. */
+export interface ReportPeriodDefault {
+  period: PeriodKey;
+  customStart: string;
+  customEnd: string;
+}
+
+export function readReportPeriodDefault(reportId: string): ReportPeriodDefault | null {
+  const stored = preferences.getItem(storageKey(reportId));
+  if (stored === null || !isPeriodKey(stored)) return null;
+  if (stored !== 'custom') return { period: stored, customStart: '', customEnd: '' };
+
+  // A custom window is meaningless without its bounds; a half-saved one is
+  // treated as no default rather than as "custom, from nowhere to nowhere".
+  const bounds = preferences.getItem(customKey(reportId));
+  if (bounds === null) return null;
+  const [customStart = '', customEnd = ''] = bounds.split('..');
+  if (!customStart && !customEnd) return null;
+  return { period: 'custom', customStart, customEnd };
+}
+
+export function writeReportPeriodDefault(
+  reportId: string,
+  selection: ReportPeriodDefault
+): void {
+  preferences.setItem(storageKey(reportId), selection.period);
+  if (selection.period === 'custom') {
+    preferences.setItem(customKey(reportId), `${selection.customStart}..${selection.customEnd}`);
+  } else {
+    preferences.removeItem(customKey(reportId));
+  }
+}
+
+export function clearReportPeriodDefault(reportId: string): void {
+  preferences.removeItem(storageKey(reportId));
+  preferences.removeItem(customKey(reportId));
+}
+
+/**
+ * Is what is on screen the saved default? The whole of the tick's behaviour.
+ *
+ * Custom compares its BOUNDS too: two custom windows over different dates are
+ * different answers to "what should this report open on", and a tick that
+ * ignored them would claim a date range had been saved when another one had.
+ */
+export function matchesReportPeriodDefault(
+  saved: ReportPeriodDefault | null,
+  current: { period: PeriodKey; customStart: string; customEnd: string }
+): boolean {
+  if (saved === null) return false;
+  if (saved.period !== current.period) return false;
+  if (saved.period !== 'custom') return true;
+  return saved.customStart === current.customStart && saved.customEnd === current.customEnd;
+}


### PR DESCRIPTION
Steve, 25 Aug:

> On the report last page, we have the 'length of time options' which on the front report page doesn't change anything. Is it better to take it out of the main reports page and just have the options within each of the individual reports and then for each report have a 'save as default' button so that each report can remember which default length of time the user has chosen. If they change the length, the button 'unticks itself' and the user has to press it again to update the default

**Yes on both counts**, and this is his design.

## The gallery's picker

It was not literally inert — it set the window the next report would open on — but nothing on the gallery moves when you press it, and **a control whose effect you cannot see reads as broken**. It now appears only where the effect is visible.

The page's subtitle and its tip both described that control, so both moved with it. The tip's id is bumped, because anyone who dismissed the old sentence dismissed a claim about a picker that is no longer on the page.

## Why a saved default rather than just remembering

Different reports want different windows — net worth over all of it, spending over last month — and one shared period makes you re-pick on every navigation.

The obvious fix is to have each report silently remember what you last used. That costs something real: **you could no longer *look* at twelve months without changing what the report opens on tomorrow.** Steve's design avoids it. Changing the window is a look; saving it is a decision.

## The tick is derived, never stored

The control is ticked exactly when the saved default equals what's on screen. So "the button unticks itself" is not a behaviour anyone had to implement — it is that same comparison, and it cannot drift out of step with what it claims to describe.

## One subtlety worth naming

A saved window is applied through `applyArrivalPeriod`, **not** `applyDefaultPeriod`. Those mean different things:

- a surface **default** stands down the moment the user has ever chosen a period — right for *"a window this report is worth reading over"*, wrong for *"the window this user told this report to open on"*;
- arrival also does **not** write to the shared period, so opening a report that remembers Last month cannot quietly move every other report to Last month.

**Additive**: a report with no saved window behaves exactly as before, and the period still follows you from one report to the next.

## Verification

Live, in order: saved "all time" on Account balances → changed to Last month (**the control unticked itself** and offered the new window) → navigated to Net worth over time, which correctly showed **Last month**, the shared period following → back to Account balances, which opened on **All time**.

Seven new specs. Both halves proven non-vacuous: restoring the gallery picker fails the absence spec, and swapping `applyArrivalPeriod` for `applyDefaultPeriod` fails the outranking spec.

Four existing specs picked the period on the gallery. They now pick it inside a report **with every assertion unchanged**, and the anatomy spec's shape assertions moved page rather than being weakened. 3,076 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)