### PR TITLE
fix(reports): the one report that draws its own period bar gets the control too

### DIFF
--- a/src/hooks/useReportPeriodDefault.ts
+++ b/src/hooks/useReportPeriodDefault.ts
@@ -1,0 +1,63 @@
+import { useCallback, useMemo, useState } from 'react';
+import { PERIOD_LABELS, type UsePeriodResult } from './usePeriod';
+import {
+  clearReportPeriodDefault,
+  matchesReportPeriodDefault,
+  readReportPeriodDefault,
+  writeReportPeriodDefault,
+} from '../utils/reportPeriodDefaults';
+
+/**
+ * The "always open this report on this window" control's whole state.
+ *
+ * A hook rather than two copies of the same six lines, because there are two
+ * places a period control can live: the hub renders one above most reports,
+ * and the net-worth report owns its own inside the chart card (the registry's
+ * `ownsPeriodBar` — Design, 22 Aug). Both need the identical answer to "is
+ * what I am looking at the saved default", and a second hand-rolled copy is
+ * how the two would come to disagree.
+ *
+ * `isDefault` is DERIVED, never stored — which is what makes the owner's
+ * "the button unticks itself" true without anything implementing unticking.
+ */
+export function useReportPeriodDefault(
+  reportId: string,
+  picker: Pick<UsePeriodResult, 'period' | 'customStart' | 'customEnd'>
+): {
+  isDefault: boolean;
+  /** The window's own name, so the control can say what it would save. */
+  periodLabel: string;
+  save: () => void;
+  clear: () => void;
+} {
+  // Bumped on write, so the derived answer re-reads what is actually stored
+  // rather than trusting a copy this hook made earlier.
+  const [version, setVersion] = useState(0);
+
+  const saved = useMemo(
+    () => readReportPeriodDefault(reportId),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [reportId, version]
+  );
+
+  const save = useCallback(() => {
+    writeReportPeriodDefault(reportId, {
+      period: picker.period,
+      customStart: picker.customStart,
+      customEnd: picker.customEnd,
+    });
+    setVersion(v => v + 1);
+  }, [reportId, picker.period, picker.customStart, picker.customEnd]);
+
+  const clear = useCallback(() => {
+    clearReportPeriodDefault(reportId);
+    setVersion(v => v + 1);
+  }, [reportId]);
+
+  return {
+    isDefault: matchesReportPeriodDefault(saved, picker),
+    periodLabel: PERIOD_LABELS[picker.period].toLowerCase(),
+    save,
+    clear,
+  };
+}

--- a/src/pages/NetWorthReport.tsx
+++ b/src/pages/NetWorthReport.tsx
@@ -31,6 +31,8 @@ import { TrendingUpIcon, ChevronRightIcon } from '../components/icons';
 import { useDecompositionSeries, useChartTooltipStyle, useChartTooltipItemStyle } from '../components/charts/chartColors';
 import type { DecompositionSeries } from '../components/charts/chartColors';
 import PeriodBar from '../components/PeriodBar';
+import ReportPeriodDefaultToggle from '../components/reports/ReportPeriodDefaultToggle';
+import { useReportPeriodDefault } from '../hooks/useReportPeriodDefault';
 import { sectionTypeForAccount, ACCOUNT_SECTION_DEFINITIONS, OTHER_SECTION_DEFINITION } from '../utils/accountGrouping';
 import { DEPTH_LEVEL_1 } from '../styles/depthShading';
 import type { ReportViewProps } from './reports/types';
@@ -111,6 +113,9 @@ const compactTick = (value: number): string => {
 
 export default function NetWorthReport({ picker, focus }: ReportViewProps): React.JSX.Element {
   const { accounts: openAccounts, transactions } = useApp();
+  // The id is this report's registry key; the hub applies whatever is saved
+  // under it when the report opens.
+  const periodDefault = useReportPeriodDefault('net-worth-over-time', picker);
   /**
    * OPEN AND CLOSED, because this page walks history.
    *
@@ -544,6 +549,17 @@ export default function NetWorthReport({ picker, focus }: ReportViewProps): Reac
                 </button>
               ))}
             </div>
+            {/* This report draws its own period bar (ownsPeriodBar), so the
+                hub does not render the save-as-default control above it —
+                it belongs beside the picker it modifies, which is this row. Same
+                hook as the hub's, so the two cannot disagree about whether
+                what is on screen is the saved window. */}
+            <ReportPeriodDefaultToggle
+              isDefault={periodDefault.isDefault}
+              periodLabel={periodDefault.periodLabel}
+              onSave={periodDefault.save}
+              onClear={periodDefault.clear}
+            />
           </div>
         </div>
         {/* The card's subtitle used to restate the page header's ("computed

--- a/src/pages/ReportsHub.tsx
+++ b/src/pages/ReportsHub.tsx
@@ -14,13 +14,8 @@ import MixedCurrencyDisclosure from '../components/MixedCurrencyDisclosure';
 import ReportCurrencyNote from '../components/reports/ReportCurrencyNote';
 import { findReport } from './reports/reportRegistry';
 import ReportPeriodDefaultToggle from '../components/reports/ReportPeriodDefaultToggle';
-import {
-  clearReportPeriodDefault,
-  matchesReportPeriodDefault,
-  readReportPeriodDefault,
-  writeReportPeriodDefault,
-} from '../utils/reportPeriodDefaults';
-import { PERIOD_LABELS } from '../hooks/usePeriod';
+import { readReportPeriodDefault } from '../utils/reportPeriodDefaults';
+import { useReportPeriodDefault } from '../hooks/useReportPeriodDefault';
 
 /** The window a report gets when it states no preference of its own. */
 const HUB_DEFAULT_PERIOD: PeriodKey = 'this-month';
@@ -92,14 +87,9 @@ export default function ReportsHub(): React.JSX.Element {
     applyArrivalPeriod(saved.period, saved.customStart, saved.customEnd);
   }, [savedDefaultReportId, applyArrivalPeriod]);
 
-  /** Re-read on every render so the tick answers to what is actually stored. */
-  const [savedDefaultVersion, setSavedDefaultVersion] = useState(0);
-  const savedDefault = useMemo(
-    () => (report === null ? null : readReportPeriodDefault(report.id)),
-    // savedDefaultVersion is the dependency: it changes when we write.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [report, savedDefaultVersion]
-  );
+  // The save-as-default control's state, shared with the one report that
+  // draws its own period bar (see hooks/useReportPeriodDefault).
+  const periodDefault = useReportPeriodDefault(report?.id ?? '', picker);
 
   /**
    * What a drill-down from the Dashboard arrived asking for: the window the
@@ -209,20 +199,10 @@ export default function ReportsHub(): React.JSX.Element {
           <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
             <PeriodBar picker={picker} label="Reporting period" />
             <ReportPeriodDefaultToggle
-              isDefault={matchesReportPeriodDefault(savedDefault, picker)}
-              periodLabel={PERIOD_LABELS[picker.period].toLowerCase()}
-              onSave={() => {
-                writeReportPeriodDefault(report.id, {
-                  period: picker.period,
-                  customStart: picker.customStart,
-                  customEnd: picker.customEnd,
-                });
-                setSavedDefaultVersion(v => v + 1);
-              }}
-              onClear={() => {
-                clearReportPeriodDefault(report.id);
-                setSavedDefaultVersion(v => v + 1);
-              }}
+              isDefault={periodDefault.isDefault}
+              periodLabel={periodDefault.periodLabel}
+              onSave={periodDefault.save}
+              onClear={periodDefault.clear}
             />
           </div>
         )}

--- a/src/pages/__tests__/ReportsHub.periodDefaults.test.tsx
+++ b/src/pages/__tests__/ReportsHub.periodDefaults.test.tsx
@@ -46,6 +46,7 @@ const TRANSACTIONS: Transaction[] = [{
 const PERIOD_KEYS = [
   'reportsPeriod', 'reportsPeriodExplicit', 'reportsPeriodCustomStart', 'reportsPeriodCustomEnd',
   'reportDefaultPeriod:account-balances', 'reportDefaultPeriodCustom:account-balances',
+  'reportDefaultPeriod:net-worth-over-time', 'reportDefaultPeriodCustom:net-worth-over-time',
 ];
 
 const renderHub = (entry: string) =>
@@ -154,5 +155,35 @@ describe('a report remembers its own window', () => {
     await waitFor(() => {
       expect(within(again.container).queryByText(/Opens on tax year/)).not.toBeNull();
     }, LOADS_LAZY_REPORT);
+  });
+});
+
+describe('every report gets the control, including the one that draws its own bar', () => {
+  /**
+   * `net-worth-over-time` is the single report with `ownsPeriodBar` — its
+   * picker lives inside the chart card (Design, 22 Aug), so the hub does not
+   * render one above it. The first cut of this feature put the save control
+   * in the hub's block only, which quietly left that report without it while
+   * the owner had asked for "each report". The control follows the picker.
+   */
+  it('the net-worth report carries its own save-as-default control', async () => {
+    renderHub('/reports/net-worth-over-time');
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^Always open on/ })).toBeInTheDocument();
+    }, LOADS_LAZY_REPORT);
+
+    // And it is the same control, backed by the same store.
+    fireEvent.click(screen.getByRole('button', { name: /^Always open on/ }));
+    expect(readReportPeriodDefault('net-worth-over-time')).not.toBeNull();
+    expect(screen.getByText(/Opens on/)).toBeInTheDocument();
+  });
+
+  it('the hub does not ALSO draw one over it', async () => {
+    // Two save controls on one page would be two answers to one question.
+    renderHub('/reports/net-worth-over-time');
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^Always open on/ })).toBeInTheDocument();
+    }, LOADS_LAZY_REPORT);
+    expect(screen.getAllByRole('button', { name: /^Always open on/ })).toHaveLength(1);
   });
 });


### PR DESCRIPTION
A gap in [#434](https://github.com/steveg1983/wealthtracker-pro/pull/434), found by asking which reports the change had actually reached.

`net-worth-over-time` is the single report with `ownsPeriodBar` — its picker lives inside the chart card (Design, 22 Aug) — so the hub doesn't render one above it, and the save-as-default control went in the hub's block only. That left one report without it, while Steve had asked for **"each report"** to have one.

## The control follows the picker

Placed at the **end** of that card's control row rather than beside the pills. Dropped in mid-row it sat between the "Assets & Liabilities" button and the Line/Bar pair, splitting two button groups with a text link.

## And the state is now shared, not written twice

Moved into `useReportPeriodDefault`. Two hand-rolled copies of *"is what I'm looking at the saved default"* is exactly how the two places would come to disagree — and that derived comparison is the whole mechanism behind "the button unticks itself", so it's the last thing that should exist in duplicate.

## Verification

Live on that report: saved *last month* → changed to *tax year* (**control unticked itself**) → navigated away to Account balances and back → it opened on *last month*, the saved window, with the control ticked again.

Two specs, both failing when the toggle is removed. One of them pins that the hub does **not** also draw one — two save controls on a page would be two answers to one question.

2,348 tests green; lint and `typecheck:strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)