### PR TITLE
fix(desktop): the Mac installer goes universal — the Intel runner is dead

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -35,12 +35,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest # arm64 (Apple Silicon)
+          # ONE universal .dmg rather than two single-arch ones. The first run
+          # tried `macos-13` for Intel and the job sat queued for 40 minutes
+          # while both siblings finished — that runner label is retired, and a
+          # retired label queues forever instead of failing. An arm64 runner
+          # cross-compiles x86_64 fine (same OS, second rustup target), and
+          # `universal-apple-darwin` lipos the two into the one artefact Mac
+          # users expect anyway. The renderer is arch-neutral; only the ~16 MB
+          # binary doubles.
+          - os: macos-latest
             bundles: app,dmg
-            artifact: macos-arm64
-          - os: macos-13 # x86_64 (Intel)
-            bundles: app,dmg
-            artifact: macos-x64
+            target: universal-apple-darwin
+            artifact: macos-universal
           - os: windows-latest
             bundles: nsis
             artifact: windows-x64
@@ -54,6 +60,9 @@ jobs:
           cache: npm
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          # The universal build needs both halves; harmless elsewhere.
+          targets: ${{ matrix.target && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -79,13 +88,14 @@ jobs:
         shell: bash
 
       - name: Build the installer
-        run: npm run --prefix apps/desktop tauri -- build --bundles ${{ matrix.bundles }}
+        run: npm run --prefix apps/desktop tauri -- build --bundles ${{ matrix.bundles }} ${{ matrix.target && format('--target {0}', matrix.target) || '' }}
 
       - name: Collect artefacts
         shell: bash
         run: |
           mkdir -p out
-          BUNDLE_DIR="apps/desktop/src-tauri/target/release/bundle"
+          # A --target build lands under target/<triple>/release; find covers both.
+          BUNDLE_DIR="apps/desktop/src-tauri/target"
           find "$BUNDLE_DIR" -name '*.dmg' -exec cp {} out/ \; 2>/dev/null || true
           find "$BUNDLE_DIR" -name '*-setup.exe' -exec cp {} out/ \; 2>/dev/null || true
           ls -la out/


### PR DESCRIPTION
The first `desktop-release` run told the truth about `macos-13`: the arm64 and Windows jobs finished — **the Windows installer built successfully on its first-ever attempt** — while the Intel job sat **queued for forty minutes**, because a retired runner label queues forever instead of failing.

## The fix is better than the problem

An arm64 runner cross-compiles x86_64 fine (same OS, second rustup target), and `--target universal-apple-darwin` lipos the two into the one artefact Mac users expect anyway: **a single .dmg that runs natively on both architectures**. The renderer is arch-neutral; only the ~16 MB binary doubles. One Mac job instead of two also halves the macOS CI minutes.

Artefact collection now searches the whole target tree, because a `--target` build lands under `target/<triple>/release` rather than `target/release`.

## Verified as far as this machine can

The matrix change passes the gated-workflow test (15 specs). The universal build itself only a runner can prove — same position the Windows job was in this morning, and that one passed first try. I'll trigger a run once this merges and report the actual result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)