### PR TITLE
fix(desktop): the chooser stops speaking two dark-mode languages at once

### DIFF
--- a/src/desktop/__tests__/chooserSpeaksOneColorScheme.test.ts
+++ b/src/desktop/__tests__/chooserSpeaksOneColorScheme.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * THE CHOOSER SPEAKS THE SAME DARK-MODE LANGUAGE AS THE GROUND IT SITS ON.
+ *
+ * Two mechanisms exist: `color-scheme` (the PLATFORM decides, and with it the
+ * UA's default ink) and the app's `html.dark` class (a PREFERENCE, stored in
+ * the ledger file). The desktop window loads index.css, whose ground is
+ * class-based — light until `html.dark` — while nothing before a ledger opens
+ * can set that class. So a `color-scheme` that lets the platform choose dark
+ * puts the UA's white default ink on the app's light ground: white-on-white,
+ * which is how the owner's first Windows run read as "just a white screen"
+ * (25 Aug 2026) while every element was in fact rendered and clickable.
+ *
+ * jsdom computes no UA colours, so this pins the SOURCE: the declaration must
+ * commit to the state the ground is actually in.
+ */
+describe('the desktop window declares one colour scheme', () => {
+  it('desktop.css pins color-scheme to light, matching the unclassed ground', () => {
+    // Comments stripped FIRST — the file's own comment explains this very
+    // rule and would otherwise satisfy or trip the match. Third instance of
+    // that census hole today; see buttonsStackTheirOwnRows and the
+    // touch-target census, which both had to close it.
+    const css = readFileSync(join(process.cwd(), 'src/desktop/desktop.css'), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, ' ');
+    const declarations = css.match(/color-scheme\s*:\s*([^;]+);/g) ?? [];
+    expect(declarations, 'the chooser must declare a colour scheme').not.toHaveLength(0);
+    for (const declaration of declarations) {
+      expect(
+        declaration,
+        'a platform-decides colour scheme reintroduces white-on-white on any ' +
+        'dark-mode OS — the ground under this window is class-based and light ' +
+        'until a ledger opens'
+      ).not.toMatch(/light\s+dark|dark\s+light|\bnormal\b/);
+    }
+  });
+});

--- a/src/desktop/desktop.css
+++ b/src/desktop/desktop.css
@@ -7,14 +7,21 @@
  * here they will bring their stylesheet with them, and this file's job will be
  * over — it is not a second design system, it is the chrome of a chooser.
  *
- * `color-scheme: light dark` is the whole of the dark-mode story for now, and
- * deliberately: the app's theme is a PREFERENCE, kept in the ledger file, and a
- * window that read it would need the preferences service this build cannot yet
- * import. Letting the platform decide is the honest default until it can.
+ * `color-scheme: light` — ONE dark-mode mechanism, not two. This window used
+ * to say `light dark` ("let the platform decide") while the app stylesheet it
+ * now loads beside (index.css, since the mount slice) paints the ground
+ * CLASS-based: #f8f9fb always, dark only once `html.dark` is set — and before
+ * a ledger opens nothing can set it, because the theme preference lives IN
+ * the ledger file. On any OS in dark mode those two mechanisms disagreed:
+ * the UA painted its default ink white, the app painted the ground light,
+ * and the chooser rendered white-on-white — found by the owner on a Windows
+ * 11 VM, 25 Aug 2026, reported as "installs ok, then just a white screen".
+ * The window declares the SAME state the ground is actually in; when the app
+ * mounts and applies the stored theme, its own stylesheet takes over.
  */
 
 :root {
-  color-scheme: light dark;
+  color-scheme: light;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
 }
 


### PR DESCRIPTION
Steve's first Windows test (Parallels, Windows 11): *"installs ok, but then just a white screen."* His screenshot shows more than that — every element of the chooser rendered and clickable, in near-white ink on a white ground. **The app worked; the ink was invisible.**

## Two mechanisms disagreed

- `desktop.css`: `color-scheme: light dark` — *the platform decides*, and with it the UA's default ink.
- `index.css` (loaded beside it since the mount slice): the ground is **class-based** — `#f8f9fb` always, dark only once `html.dark` is set. And before a ledger opens, nothing can set that class, because the theme preference lives *inside the ledger file*.

On any OS in dark mode: UA ink white, app ground light → white-on-white. The VM was in dark mode; the Mac this shell was verified on was not — which is the whole reason it shipped.

The window now declares the state the ground is actually in (`color-scheme: light`). When a ledger opens and the app applies the stored theme, its own stylesheet takes over exactly as before.

## The guard, and its own confession

jsdom computes no UA colours, so the guard pins the source: `desktop.css` may not declare a platform-decides scheme. Its first draft was defeated by the file's own explanatory comment — the **third** census today caught by prose describing the rule it enforces. Comments are stripped before matching, and the probe runs both directions: `light dark` fails, `light` passes.

After merge: trigger `desktop-release`, replace the Windows installer on the release page and in Steve's folder with a build that is legible in both OS themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)