### PR TITLE
fix(hosting): the legacy vercel.app host redirects to the domain

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -30,6 +30,19 @@
       "schedule": "20 4 * * 2-6"
     }
   ],
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [
+        {
+          "type": "host",
+          "value": "wealthtracker-web.vercel.app"
+        }
+      ],
+      "destination": "https://www.wealthtrackerpro.co.uk/:path*",
+      "permanent": false
+    }
+  ],
   "rewrites": [
     {
       "source": "/api/(.*)",


### PR DESCRIPTION
Found by Steve at 01:10, trying his old bookmark: the vercel.app host serves the production build, the production build carries the `pk_live` key, and the production Clerk instance answers only its own domain — so every request from the old host gets a 400 from `/v1/client` and the app hangs at **"Authenticating…"** forever.

Nothing broken — but the old address stopped being a valid front door the moment the keys flipped, and every existing bookmark and **home-screen install** (Steve's and Danielle's) points at it.

One host-matched redirect, path and query preserved, so `?demo=true` and deep links carry across. Deliberately **temporary (307)** rather than permanent: browsers cache a 308 forever, and this wants to be reversible until the new domain has weeks behind it.

Preview deployments are untouched — they match no host rule, keep `pk_test`, and the dev Clerk instance accepts any origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)