### PR TITLE
feat(onboarding): the tips audit, and a first-steps card that derives its own ticks

### DIFF
--- a/src/components/OnboardingModal.tsx
+++ b/src/components/OnboardingModal.tsx
@@ -4,19 +4,16 @@ import { supportedCurrencies } from '../utils/currency';
 
 interface OnboardingModalProps {
   isOpen: boolean;
-  onComplete: (name: string, currency: string) => void;
+  onComplete: (currency: string) => void;
 }
 
 export default function OnboardingModal({ isOpen, onComplete }: OnboardingModalProps): React.JSX.Element | null {
-  const [firstName, setFirstName] = useState('');
   const [baseCurrency, setBaseCurrency] = useState('GBP');
   const modalRef = useRef<HTMLDivElement>(null);
 
   const handleSubmit = (e: React.FormEvent): void => {
     e.preventDefault();
-    if (firstName.trim()) {
-      onComplete(firstName.trim(), baseCurrency);
-    }
+    onComplete(baseCurrency);
   };
 
   // The comment that used to sit here said "no scroll prevention — the modal
@@ -133,36 +130,28 @@ export default function OnboardingModal({ isOpen, onComplete }: OnboardingModalP
         {/* Purpose before manner (Design, 17 Aug §3): a reader learns what
             the app is FOR before how it feels to use. Same length. */}
         <p className="text-gray-600 dark:text-gray-400 mb-6">
-          Two answers and you're in. WealthTracker is a ledger, not an
+          One answer and you're in. WealthTracker is a ledger, not an
           estimator — every figure traces to something you entered or
           imported, and every report says what it leaves out.
         </p>
 
         <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-              What's your first name?
-            </label>
-            <input
-              type="text"
-              value={firstName}
-              onChange={(e) => setFirstName(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-lg"
-              placeholder="Enter your first name"
-              required
-              autoFocus
-            />
-            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              It greets you on the dashboard. That is all it is used for.
-            </p>
-          </div>
-
+          {/* THE NAME FIELD IS GONE (owner, 26 Aug). Its caption claimed "it
+              greets you on the dashboard" — the dashboard greeting had already
+              been retired, leaving one marginal "Welcome back" on the landing
+              page as the only reader, and the cloud edition learns a name from
+              sign-up anyway. A required field whose stated purpose does not
+              exist is a small lie at the front door; the modal now asks the
+              one question the app actually uses. A name can still be set in
+              Settings → App Settings, which is where the landing greeting
+              looks. */}
           <div>
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
               Preferred base currency
             </label>
             <select
               aria-label="Preferred base currency"
+              autoFocus
               value={baseCurrency}
               onChange={(e) => setBaseCurrency(e.target.value)}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-lg"
@@ -196,7 +185,7 @@ export default function OnboardingModal({ isOpen, onComplete }: OnboardingModalP
             hairline and a quiet grey separate it from the form just as well,
             and cost nothing that is needed later. */}
         <p className="mt-6 border-t border-line dark:border-gray-700 pt-4 text-xs text-gray-500 dark:text-gray-400">
-          Both can be changed later in Settings → App Settings.
+          It can be changed later in Settings → App Settings.
         </p>
       </div>
     </>,

--- a/src/components/dashboard/FirstSteps.tsx
+++ b/src/components/dashboard/FirstSteps.tsx
@@ -1,0 +1,160 @@
+import React, { useMemo, useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { useApp } from '../../contexts/AppContextSupabase';
+import { computeIncomeExpense } from '../../utils/incomeExpense';
+import { preserveDemoParam } from '../../utils/navigation';
+import { preferences } from '../../services/preferencesService';
+import { CheckCircleIcon, XIcon } from '../icons';
+
+/**
+ * FIRST STEPS — the thread between the empty states (owner, 26 Aug: "more
+ * of a walk through?").
+ *
+ * Each page already handles its own emptiness well: an empty Accounts page
+ * says what is absent, the consequence, and carries the Add Account button
+ * in the message. What nothing did was walk the JOURNEY — account →
+ * transactions → categories → reports — so a new user finished each remedy
+ * with no pointer to the next.
+ *
+ * This is a checklist, not a tour. The house rulings would not wear coach
+ * marks (floating pointers are attention-demands, and motion answers to the
+ * same rule as colour), and a tour narrates the app instead of letting the
+ * app speak. A checklist states the three things a ledger needs before its
+ * reports mean anything, and links each to the page where it is done.
+ *
+ * ─ EVERY TICK IS DERIVED, NEVER STORED ─────────────────────────────────
+ * A step is complete when the DATA says so — an account exists, a
+ * transaction exists, nothing is left unfiled — the same rule as the
+ * save-as-default tick and for the same reason: stored progress can lie,
+ * derived progress cannot. It also means no "new user" flag exists
+ * anywhere: a seasoned ledger derives all three ticks and the card stands
+ * down by itself, and restoring a backup onto a fresh browser is
+ * recognised as the seasoned ledger it is.
+ *
+ * The one stored bit is the DISMISSAL, because a dismissal is a choice,
+ * not a fact about the ledger (the PageTip rule). In preferences rather
+ * than localStorage so the choice travels with the user.
+ *
+ * The categorise step reads `uncategorizedRows.length` and no money figure
+ * — the census's 'counts-only' state, recorded in its ledger.
+ */
+
+const DISMISSED_KEY = 'firstStepsDismissed';
+
+export default function FirstSteps(): React.JSX.Element | null {
+  const { accounts, transactions, transactionSplits, categories } = useApp();
+  const location = useLocation();
+  const [dismissed, setDismissed] = useState(
+    () => preferences.getItem(DISMISSED_KEY) === 'true'
+  );
+
+  const hasAccount = accounts.length > 0;
+  const hasTransactions = transactions.length > 0;
+
+  // Counts only — see the header. Skipped entirely until there is anything
+  // to count, so an empty ledger pays nothing for this.
+  const allFiled = useMemo(() => {
+    if (!hasTransactions) return false;
+    return computeIncomeExpense(transactions, transactionSplits, categories)
+      .uncategorizedRows.length === 0;
+  }, [hasTransactions, transactions, transactionSplits, categories]);
+
+  const steps = [
+    {
+      done: hasAccount,
+      label: 'Add your first account',
+      detail: 'Everything is built up from accounts.',
+      to: '/accounts?action=add',
+    },
+    {
+      done: hasTransactions,
+      label: 'Add or import transactions',
+      detail: 'Type them in, or bring history from Microsoft Money, CSV, QIF or OFX.',
+      to: '/import',
+    },
+    {
+      done: allFiled,
+      label: 'Categorise them',
+      detail: 'A transaction with no category is left out of every total.',
+      to: '/categorisation',
+    },
+  ];
+
+  // Stands down by itself the moment the ledger is under way — no flag,
+  // no memory, just the data. Hidden while dismissed, obviously.
+  if (dismissed || steps.every(step => step.done)) return null;
+
+  const handleDismiss = (): void => {
+    preferences.setItem(DISMISSED_KEY, 'true');
+    setDismissed(true);
+  };
+
+  return (
+    <section
+      aria-labelledby="first-steps-heading"
+      data-testid="first-steps"
+      className="bg-white dark:bg-gray-800 rounded-2xl border border-line dark:border-gray-700 p-4 sm:p-5"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <h2 id="first-steps-heading" className="text-card font-semibold text-gray-900 dark:text-white">
+          First steps
+        </h2>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss first steps"
+          className="p-1 -m-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded"
+        >
+          <XIcon size={16} />
+        </button>
+      </div>
+
+      <ol className="mt-3 space-y-2.5">
+        {steps.map(step => (
+          <li key={step.label} className="flex items-start gap-2.5">
+            {/* A settled step is settled, not celebrated: the tick is quiet
+                (colour marks what needs attention, and a done step needs
+                none). The NEXT undone step carries the link. */}
+            <CheckCircleIcon
+              size={18}
+              aria-hidden="true"
+              className={`mt-0.5 shrink-0 ${
+                step.done ? 'text-gray-400 dark:text-gray-500' : 'text-gray-200 dark:text-gray-600'
+              }`}
+            />
+            <div className="min-w-0">
+              {step.done ? (
+                <span className="text-body text-gray-400 dark:text-gray-500 line-through decoration-1">
+                  {step.label}
+                </span>
+              ) : (
+                <>
+                  <Link
+                    to={preserveDemoParam(step.to, location.search)}
+                    className="text-body font-medium text-gray-900 dark:text-white hover:text-blue-700 dark:hover:text-blue-400 hover:underline rounded"
+                  >
+                    {step.label}
+                  </Link>
+                  <span className="block text-dense text-gray-500 dark:text-gray-400">
+                    {step.detail}
+                  </span>
+                </>
+              )}
+            </div>
+          </li>
+        ))}
+      </ol>
+
+      <p className="mt-3 pt-3 border-t border-line dark:border-gray-700 text-dense text-gray-500 dark:text-gray-400">
+        Then the{' '}
+        <Link
+          to={preserveDemoParam('/reports', location.search)}
+          className="underline underline-offset-2 hover:text-gray-700 dark:hover:text-gray-200 rounded"
+        >
+          reports
+        </Link>{' '}
+        are yours — every figure traceable to a line you entered.
+      </p>
+    </section>
+  );
+}

--- a/src/components/dashboard/ImprovedDashboard.periodPin.test.tsx
+++ b/src/components/dashboard/ImprovedDashboard.periodPin.test.tsx
@@ -74,6 +74,12 @@ vi.mock('react-router-dom', async () => {
     ...actual,
     useNavigate: () => mocks.navigate,
     useLocation: () => ({ pathname: '/dashboard', search: '', hash: '', state: null, key: 'test' }),
+    // Same stub, same reason as ImprovedDashboard.test.tsx: the FirstSteps
+    // card renders real <Link>s, which need router context these hook mocks
+    // do not provide.
+    Link: ({ to, children, ...rest }: { to: string; children: React.ReactNode }) => (
+      <a href={to} {...rest}>{children}</a>
+    ),
   };
 });
 

--- a/src/components/dashboard/ImprovedDashboard.test.tsx
+++ b/src/components/dashboard/ImprovedDashboard.test.tsx
@@ -10,6 +10,7 @@
  *
  * Every account name, figure and institution here is invented.
  */
+import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import type { ReactNode } from 'react';
@@ -64,6 +65,12 @@ vi.mock('react-router-dom', async () => {
     ...actual,
     useNavigate: () => mocks.navigate,
     useLocation: () => ({ pathname: '/dashboard', search: '', hash: '', state: null, key: 'test' }),
+    // The FirstSteps card (26 Aug) renders real <Link>s, which need router
+    // CONTEXT the hook mocks above do not provide. A stub that renders the
+    // anchor keeps this harness router-free while the hrefs stay assertable.
+    Link: ({ to, children, ...rest }: { to: string; children: React.ReactNode }) => (
+      <a href={to} {...rest}>{children}</a>
+    ),
   };
 });
 

--- a/src/components/dashboard/ImprovedDashboard.tsx
+++ b/src/components/dashboard/ImprovedDashboard.tsx
@@ -34,6 +34,7 @@ import { Modal, ModalBody } from '../common/Modal';
 import PeriodBar from '../../components/PeriodBar';
 import { WholePoundsToggle } from '../../contexts/WholePoundsContext';
 import NetWorthSummary from '../../components/NetWorthSummary';
+import FirstSteps from './FirstSteps';
 import AccountBreakdownModal, { type AccountBreakdownView } from '../../components/AccountBreakdownModal';
 import { PERIOD_LABELS, usePeriod } from '../../hooks/usePeriod';
 import { cardPeriodKey, useCardPeriod } from '../../hooks/useCardPeriod';
@@ -775,6 +776,10 @@ export function ImprovedDashboard() {
           unconverted={spansCurrencies ? convertedNetWorth.unconverted : []}
           displayCurrency={displayCurrency}
         />
+
+        {/* The walk from nothing to a working ledger — derives its own ticks
+            and stands down by itself; see the component header. */}
+        <FirstSteps />
       </section>
 
       {/* WHAT CAME IN AND WHAT WENT OUT, over the chosen period.

--- a/src/components/dashboard/__tests__/FirstSteps.test.tsx
+++ b/src/components/dashboard/__tests__/FirstSteps.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import FirstSteps from '../FirstSteps';
+import { __setAppContextValue, __resetAppContextValue } from '../../../test/mocks/AppContextSupabase';
+import { preferences } from '../../../services/preferencesService';
+import type { Account, Category, Transaction } from '../../../types';
+
+/**
+ * THE FIRST-STEPS CARD DERIVES EVERY TICK AND STANDS DOWN BY ITSELF.
+ *
+ * The owner asked for "more of a walk through" (26 Aug); the house answer
+ * is a checklist whose state is DERIVED from the ledger, never stored — a
+ * stored tick can lie, a derived one cannot, and a seasoned ledger (or a
+ * restored backup on a fresh browser) hides the card with no flag anywhere.
+ *
+ * Every figure below is invented; this repo is public.
+ */
+
+const account: Account = {
+  id: 'acc-1', name: 'Synthetic Current', type: 'current', balance: 0,
+  currency: 'GBP', lastUpdated: new Date(2026, 0, 1),
+};
+
+const CATEGORIES: Category[] = [
+  { id: 'type-expense', name: 'Expenses', type: 'expense', level: 'type' },
+  { id: 'det-food', name: 'Food', type: 'expense', level: 'detail', parentId: 'type-expense' },
+];
+
+const txn = (id: string, category: string): Transaction => ({
+  id, date: new Date(2026, 1, 1), description: 'Payment ' + id, amount: -10,
+  type: 'expense', accountId: 'acc-1', category,
+});
+
+const renderCard = () =>
+  render(
+    <MemoryRouter>
+      <FirstSteps />
+    </MemoryRouter>
+  );
+
+const setLedger = (over: { accounts?: Account[]; transactions?: Transaction[] }) => {
+  __setAppContextValue({
+    accounts: over.accounts ?? [],
+    transactions: over.transactions ?? [],
+    transactionSplits: [],
+    categories: CATEGORIES,
+  });
+};
+
+beforeEach(() => {
+  preferences.removeItem('firstStepsDismissed');
+});
+
+afterEach(() => {
+  cleanup();
+  __resetAppContextValue();
+});
+
+describe('the first-steps card', () => {
+  it('walks an empty ledger from the first step, with the remedy as the link', () => {
+    setLedger({});
+    renderCard();
+    expect(screen.getByTestId('first-steps')).toBeInTheDocument();
+    // The undone step is a link to where it is done.
+    expect(screen.getByRole('link', { name: 'Add your first account' }))
+      .toHaveAttribute('href', '/accounts?action=add');
+    expect(screen.getByRole('link', { name: 'Add or import transactions' }))
+      .toHaveAttribute('href', '/import');
+  });
+
+  it('derives a tick the moment the data proves the step', () => {
+    setLedger({ accounts: [account] });
+    renderCard();
+    // Done steps stop being links — nothing to do there any more.
+    expect(screen.queryByRole('link', { name: 'Add your first account' })).toBeNull();
+    expect(screen.getByText('Add your first account')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Add or import transactions' })).toBeInTheDocument();
+  });
+
+  it('counts an unfiled transaction against the categorise step', () => {
+    setLedger({ accounts: [account], transactions: [txn('t1', 'det-food'), txn('t2', '')] });
+    renderCard();
+    expect(screen.getByRole('link', { name: 'Categorise them' }))
+      .toHaveAttribute('href', '/categorisation');
+  });
+
+  it('stands down by itself when the ledger is under way — no stored flag', () => {
+    setLedger({ accounts: [account], transactions: [txn('t1', 'det-food')] });
+    renderCard();
+    expect(screen.queryByTestId('first-steps')).toBeNull();
+  });
+
+  it('dismissal is a choice, stored, and honoured', () => {
+    setLedger({});
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss first steps' }));
+    expect(screen.queryByTestId('first-steps')).toBeNull();
+    cleanup();
+    renderCard();
+    expect(screen.queryByTestId('first-steps')).toBeNull();
+  });
+});

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -4248,7 +4248,7 @@ export default function AccountTransactions() {
       <PageTip
         id="register-keyboard"
         title="This register runs on the keyboard"
-        description="Click any row and the row itself becomes the editor: its Date, Description and Category turn into boxes where they already sit, with the buttons on a strip underneath. Enter accepts what you typed, and the Enter after it saves and moves you to the next transaction with the cursor back in the same field. Esc stops editing. The arrow keys move the highlight (and the editor with it), Enter on the list opens the full editor, Space reconciles and Delete removes. Press ? for the whole list — or find it under View ▸ Keyboard shortcuts."
+        description="Click a row and it becomes the editor, right where it sits; Enter saves and moves to the next transaction. Press ? for every shortcut — or find them under View ▸ Keyboard shortcuts."
       />
     </div>
   );

--- a/src/pages/Budget.tsx
+++ b/src/pages/Budget.tsx
@@ -576,10 +576,14 @@ function BudgetView() {
         onEditExisting={setEditingBudget}
       />
 
+      {/* id bumped from `budget-intro`: the old copy recommended envelope
+          and zero-based budgeting, both retired in #393 — a tip pointing at
+          deleted features is wrong, not stale, so past dismissers see the
+          correction once. */}
       <PageTip
-        id="budget-intro"
+        id="budget-intro-2"
         title="Track your spending with budgets"
-        description="Set monthly, weekly, or yearly budgets for each category. The progress bars show how much you've spent versus your limit. Try envelope budgeting or zero-based budgeting for different approaches."
+        description="Give a category a limit for its period — weekly, monthly or yearly — and the bar shows what you've spent against it. Templates, rollover and alerts are in the folds below the list."
       />
     </PageWrapper>
   );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -18,7 +18,7 @@ const ImprovedDashboard = lazyWithRecovery(() => import('../components/dashboard
 
 
 export default function Dashboard() {
-  const { firstName, setFirstName, setCurrency } = usePreferences();
+  const { firstName, setCurrency } = usePreferences();
   const [showOnboarding, setShowOnboarding] = useState(false);
 
   // Retired 2026-08-10: the Supabase "connection check".
@@ -47,8 +47,7 @@ export default function Dashboard() {
   }, [firstName]);
 
   // Handle onboarding completion
-  const handleOnboardingComplete = (name: string, currency: string) => {
-    setFirstName(name);
+  const handleOnboardingComplete = (currency: string) => {
     setCurrency(currency);
     localStorage.setItem('onboardingCompleted', 'true');
     setShowOnboarding(false);

--- a/src/utils/__tests__/currencyAggregationCensus.test.ts
+++ b/src/utils/__tests__/currencyAggregationCensus.test.ts
@@ -95,6 +95,9 @@ const LEDGER: Record<string, Partial<Record<(typeof PRIMITIVES)[number], Status>
   // `uncategorizedRows.length` — never a total. Its answer is a rung name,
   // so no exchange rate could change it.
   'src/hooks/useAttentionLadder.ts': { computeIncomeExpense: 'counts-only' },
+  // First-steps checklist: reads uncategorizedRows.length to derive its
+  // "categorise them" tick — a count, never a total.
+  'src/components/dashboard/FirstSteps.tsx': { computeIncomeExpense: 'counts-only' },
 };
 
 const SRC = join(process.cwd(), 'src');


### PR DESCRIPTION
Steve's two asks, 26 Aug: audit every tip for clarity and truth, and give a new user *"more of a walk through"*.

## The audit (nine tips)

| tip | action |
|---|---|
| **Budget** | **Corrected, id bumped** — it recommended envelope and zero-based budgeting, both retired in #393. A tip pointing at deleted features is wrong, not stale; past dismissers see the correction once. |
| **Register** | **Trimmed to two sentences, same id** — the claim is unchanged (keyboard-driven, `?` shows the list); the key-by-key detail lives behind `?` where it always did. |
| **Calendar** | Audited and **verified** — greens and parentheses both real. No change. |
| the other six | Accurate and current. |

## The onboarding name field is gone

Steve: *"is it even used anywhere?"* — its own caption said "it greets you on the dashboard; that is all it is used for", and the dashboard greeting had already been retired. One marginal "Welcome back" on the landing page was the only reader, and the cloud edition learns a name from sign-up anyway. **A required field whose stated purpose does not exist is a small lie at the front door.** The modal now asks the one question the app uses — base currency — and a name remains settable in Settings, which is where the landing greeting looks.

## First steps — the walk-through, the house way

Not coach marks (floating pointers are attention-demands, and a tour narrates the app instead of letting it speak). A dashboard checklist: **add an account → add or import transactions → categorise them → then the reports are yours**. Each undone step is a *link* to where it's done, with its consequence beneath; each done step is a quiet strike-through.

**Every tick is derived, never stored** — an account exists, a transaction exists, nothing left unfiled. No "new user" flag exists anywhere: a seasoned ledger (or a restored backup on a fresh browser) derives all three ticks and the card stands down by itself. The one stored bit is the dismissal, because a dismissal is a choice, not a fact about the ledger. The categorise tick reads `uncategorizedRows.length` and no money figure — the census's `counts-only` state, recorded in its ledger.

## The gate earned its keep on this one

Three attempts: the **currency census** blocked the first (FirstSteps on disk without a classification while an earlier gate ran); the full suite caught **two dashboard harnesses** whose router-hook mocks had never needed `<Link>` context before. Both now carry a stub that renders the anchor, so hrefs stay assertable and the harnesses stay router-free.

Verified live in the browser (mixed state renders; demo's complete data naturally proves the stand-down). Five rendered-DOM specs; 35 across the dashboard suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)