### PR TITLE
fix: the 26 Aug testing harvest — nine findings from the owner's first day on three platforms

### DIFF
--- a/src/components/BankConnections.tsx
+++ b/src/components/BankConnections.tsx
@@ -79,6 +79,8 @@ export default function BankConnections({
    */
   const [connectionsLoaded, setConnectionsLoaded] = useState(false);
   const [configChecked, setConfigChecked] = useState(false);
+  /** False when the last health check FAILED — verdict unknown, not a config fact. */
+  const [configKnown, setConfigKnown] = useState(true);
   const [linkingConnectionId, setLinkingConnectionId] = useState<string | null>(null);
   const [oauthError, setOauthError] = useState<string | null>(null);
   // What an incomplete sync could not do. It used to go to the console only,
@@ -190,6 +192,7 @@ export default function BankConnections({
     try {
       await bankConnectionService.refreshConfigStatus();
       setConfigStatus(bankConnectionService.getConfigStatus());
+      setConfigKnown(bankConnectionService.isConfigStatusKnown());
     } catch (error) {
       logger.error('Failed to check bank provider configuration', error as Error);
     } finally {
@@ -320,8 +323,29 @@ export default function BankConnections({
 
   return (
     <div className="space-y-6">
-      {/* Configuration Warning */}
-      {configChecked && !configStatus.plaid && !configStatus.trueLayer && (
+      {/* Configuration warning — ONLY when the server actually answered
+          'degraded'. A failed check is a different sentence: it happened on
+          the owner's TestFlight install, where the health call lost a race
+          with the freshly-booting session and this banner told him his
+          working backend was unconfigured (26 Aug, item 6). Consequence,
+          then remedy, and never a server fact the client never learned. */}
+      {configChecked && !configKnown && (
+        <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-xl p-4">
+          <div className="flex items-start gap-3">
+            <AlertCircleIcon className="text-yellow-600 dark:text-yellow-400 mt-0.5" size={20} />
+            <div>
+              <p className="font-medium text-yellow-800 dark:text-yellow-200">
+                Couldn&rsquo;t check whether bank feeds are available
+              </p>
+              <p className="text-sm text-yellow-700 dark:text-yellow-300 mt-1">
+                The status check didn&rsquo;t get an answer, so connecting a bank may
+                not work right now. Close this and try again in a moment.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+      {configChecked && configKnown && !configStatus.plaid && !configStatus.trueLayer && (
         <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-xl p-4">
           <div className="flex items-start gap-3">
             <AlertCircleIcon className="text-yellow-600 dark:text-yellow-400 mt-0.5" size={20} />

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -19,7 +19,8 @@ import {
   OfflineQueueIndicator,
   QuickAddTransaction,
   RealtimeDot,
-  type GlobalSearchHandle
+  CHROME_HAS_BANK_FEEDS,
+  type GlobalSearchHandle,
 } from '@chrome';
 import { HomeIcon, CreditCardIcon, WalletIcon, TrendingUpIcon, SettingsIcon, MenuIcon, XIcon, ArrowRightLeftIcon, BarChart3Icon, ChevronRightIcon, ClockIcon, DatabaseIcon, TagIcon, Settings2Icon, TargetIcon, HashIcon, SearchIcon, PieChartIcon, ShieldIcon, UploadIcon, DownloadIcon, FolderIcon, BankIcon, CalendarIcon, UsersIcon } from '../components/icons';
 import { SidebarLink, TopNavItem, TopNavDropdown } from './layout/NavComponents';
@@ -373,7 +374,13 @@ export default function Layout(): React.JSX.Element {
                 { to: '/investments', icon: TrendingUpIcon, label: 'Investments' },
                 { to: '/reconciliation', icon: ArrowRightLeftIcon, label: 'Reconciliation' },
                 { to: '/categorisation', icon: TagIcon, label: 'Categorisation' },
-                { to: '/open-banking', icon: BankIcon, label: 'Bank Feeds' },
+                // A ledger-in-a-file has no server to hold a bank token, so
+                // the device edition does not print the menu item at all
+                // (owner, 26 Aug — the first desktop install offered a page
+                // that could only apologise). @chrome resolves the fact.
+                ...(CHROME_HAS_BANK_FEEDS
+                  ? [{ to: '/open-banking', icon: BankIcon, label: 'Bank Feeds' }]
+                  : []),
               ]}
               // The highlight follows the menu: on /investments it is Accounts
               // that lights up now, not Manage.
@@ -708,7 +715,9 @@ export default function Layout(): React.JSX.Element {
                       )}
                       <SidebarLink to="/reconciliation" icon={ArrowRightLeftIcon} label="Reconciliation" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
                       <SidebarLink to="/categorisation" icon={TagIcon} label="Categorisation" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
-                      <SidebarLink to="/open-banking" icon={BankIcon} label="Bank Feeds" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
+                      {CHROME_HAS_BANK_FEEDS && (
+                        <SidebarLink to="/open-banking" icon={BankIcon} label="Bank Feeds" isCollapsed={false} isSubItem={true} onNavigate={toggleMobileMenu} />
+                      )}
                     </div>
                   )}
                 </div>

--- a/src/components/VirtualizedTable.tsx
+++ b/src/components/VirtualizedTable.tsx
@@ -460,7 +460,16 @@ const VirtualizedTableComponent = memo(function VirtualizedTable<T>({
     // Only apply hover effects if not selected. No scale: these rows sit in
     // an overflow-clipped table, and a 1.01 scale pushed the rightmost
     // column's digits past the edge — the shadow and z-lift suffice.
-    const hoverClass = onRowClick && !isSelected ? 'hover:shadow-[0_-6px_10px_-2px_rgba(0,0,0,0.15),0_6px_10px_-2px_rgba(0,0,0,0.15)] hover:z-10 hover:bg-gray-50 dark:hover:bg-gray-800' : '';
+    //
+    // And NOT while an editor row is open anywhere in the table: Save & Next
+    // is keyboard work, the mouse sits parked wherever the session started,
+    // and the row under it held its hover band for the whole session —
+    // reading as a second "selected" row rows above the real one (owner,
+    // 26 Aug, item 11). While the editor is open the pointer is not the
+    // instrument, so its effects stand down; they return the moment the
+    // editor closes.
+    const editorOpenSomewhere = !!rowDetail && detailIndex !== -1;
+    const hoverClass = onRowClick && !isSelected && !editorOpenSomewhere ? 'hover:shadow-[0_-6px_10px_-2px_rgba(0,0,0,0.15),0_6px_10px_-2px_rgba(0,0,0,0.15)] hover:z-10 hover:bg-gray-50 dark:hover:bg-gray-800' : '';
     // Don't apply stripe classes to selected rows. Unstriped, every unselected
     // row wears the plain background the even ones already wore — the stripe
     // is what goes, not the surface.

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -216,12 +216,19 @@ export function Modal({
       >
         <div
           ref={modalRef}
+          // 100dvh AFTER 100vh, deliberately: on iOS 100vh is the LARGE
+          // viewport, taller than the glass, so a modal sized by it hangs its
+          // last row of buttons below the screen with the page scroll-locked —
+          // the owner's "only Delete, no Save" on the phone edit sheet
+          // (26 Aug, item 10). dvh tracks what is actually visible; a browser
+          // without it drops the invalid declaration and keeps the vh line.
           className={`
             bg-white dark:bg-gray-900
             rounded-2xl
             shadow-2xl
             w-full
             max-h-[calc(100vh-5.5rem)]
+            max-h-[calc(100dvh-5.5rem)]
             ${sizeClasses[size]}
             overflow-hidden
             flex

--- a/src/components/layout/Breadcrumbs.tsx
+++ b/src/components/layout/Breadcrumbs.tsx
@@ -62,6 +62,17 @@ const routeLabels: Record<string, string> = {
  * `/settings/tags`, "‹ Accounts" from an account register — so it no longer
  * repeats the title of the page it sits on, which was the finding.
  */
+/**
+ * Nested pages that draw their OWN back control ("← Back to Accounts" on an
+ * account register, "← All reports" on a report) — rendering this row above
+ * them put two back buttons in the first 120px of a phone screen, saying the
+ * same thing in different words (owner, 26 Aug, item 7). The page's own
+ * control wins: it can say more (provenance-aware labels like "Back to
+ * report") than a path segment ever could. Keyed by PARENT segment, so
+ * /settings/* — whose subpages have no back of their own — keeps this row.
+ */
+const PARENTS_WITH_OWN_BACK = new Set(['accounts', 'reports']);
+
 export function MobileBreadcrumb() {
   const location = useLocation();
   const { accounts } = useApp();
@@ -74,6 +85,10 @@ export function MobileBreadcrumb() {
 
   const parentPath = `/${pathSegments.slice(0, -1).join('/')}`;
   const parentSegment = pathSegments[pathSegments.length - 2];
+
+  if (PARENTS_WITH_OWN_BACK.has(parentSegment)) {
+    return null;
+  }
   // A route nested under a single account names that account, not its id.
   const matchedAccount = accounts.find(a => a.id === parentSegment);
   const label = matchedAccount

--- a/src/desktop/editions/chrome.tsx
+++ b/src/desktop/editions/chrome.tsx
@@ -54,6 +54,7 @@
 import { forwardRef, useImperativeHandle, type ReactElement } from 'react';
 import { currentDeviceIdentity } from '../../services/local/deviceIdentity';
 import type {
+  ChromeHasBankFeeds,
   ChromeGlobalSearch,
   ChromeOrnament,
   ChromeQuickAddTransaction
@@ -62,6 +63,7 @@ import type {
 // The same list the cloud half re-exports, for the same reason: a specifier is
 // only a substitution if both sides answer for the same vocabulary.
 export type {
+  ChromeHasBankFeeds,
   ChromeGlobalSearch,
   ChromeOrnament,
   ChromeQuickAddTransaction,
@@ -136,3 +138,6 @@ export const OfflineQueueIndicator: ChromeOrnament = () => null;
 
 /** …and nothing to add to the queue that is not there. */
 export const OfflineQuickAdd: ChromeOrnament = () => null;
+
+/** No server, no tokens, no sync — see editions/chrome.ts. */
+export const CHROME_HAS_BANK_FEEDS: ChromeHasBankFeeds = false;

--- a/src/editions/__tests__/editionAliases.test.ts
+++ b/src/editions/__tests__/editionAliases.test.ts
@@ -197,10 +197,15 @@ describe('the edition seams', () => {
     // the big one: ten pieces of furniture — eight from the mount's first half
     // and two the BUNDLE GREP added in its second, when a PWA offline queue in
     // the frame turned out to be keeping writes for a server that does not
-    // exist. `RealtimeDot` is certainly one of them.
+    // exist. `RealtimeDot` is certainly one of them. Plus one FACT:
+    // CHROME_HAS_BANK_FEEDS (26 Aug) — not furniture but a boolean the
+    // callers use to decide whether to draw their own bank-feed controls,
+    // after the first desktop install offered a nav item that could only
+    // apologise.
     const chrome = valueExportsOf('src/editions/cloud/chrome.tsx');
-    expect(chrome.length).toBe(10);
+    expect(chrome.length).toBe(11);
     expect(chrome).toContain('RealtimeDot');
+    expect(chrome).toContain('CHROME_HAS_BANK_FEEDS');
     expect(typeExportsOf('src/editions/cloud/chrome.tsx')).toContain('GlobalSearchHandle');
     expect(valueExportsOf('src/desktop/editions/telemetry.ts')).toEqual([
       'captureException',

--- a/src/editions/chrome.ts
+++ b/src/editions/chrome.ts
@@ -102,3 +102,21 @@ export interface QuickAddTransactionProps {
  * chunk of its own should not have to pretend otherwise.
  */
 export type ChromeQuickAddTransaction = ComponentType<QuickAddTransactionProps>;
+
+/**
+ * WHETHER THIS EDITION HAS BANK FEEDS AT ALL — a fact, not furniture.
+ *
+ * The device edition's ledger is a file; there is no server to hold a bank
+ * token, no cron to sync one, and never will be (the "NEVER_ON_A_DESKTOP"
+ * class above). Yet the shared chrome offered "Bank Feeds" in its nav and
+ * the Accounts page offered a "Bank connections" button, both opening
+ * surfaces that could only apologise (owner, 26 Aug, item 4, from the first
+ * real install). A control whose action cannot exist in this edition is not
+ * furniture to stub — it is a menu item to NOT PRINT.
+ *
+ * A boolean rather than a stubbed component because the callers are not
+ * mounting a thing, they are deciding whether to draw their OWN things (a
+ * nav row, a toolbar button). The cloud half answers true, the device half
+ * false, and the compiler holds both to this declaration.
+ */
+export type ChromeHasBankFeeds = boolean;

--- a/src/editions/cloud/chrome.tsx
+++ b/src/editions/cloud/chrome.tsx
@@ -33,6 +33,7 @@ import { OfflineIndicator as PWAOfflineIndicatorComponent } from '../../componen
 import { QuickAddOfflineButton as QuickAddOfflineButtonComponent } from '../../components/pwa/QuickAddOfflineButton';
 import { useAutoBankSync } from '../../hooks/useAutoBankSync';
 import type {
+  ChromeHasBankFeeds,
   ChromeGlobalSearch,
   ChromeOrnament,
   ChromeQuickAddTransaction
@@ -45,6 +46,7 @@ import type {
 // `editions/__tests__/editionAliases.test.ts` requires both halves to answer
 // for the same list.
 export type {
+  ChromeHasBankFeeds,
   ChromeGlobalSearch,
   ChromeOrnament,
   ChromeQuickAddTransaction,
@@ -108,3 +110,6 @@ export const OfflineQueueIndicator: ChromeOrnament = PWAOfflineIndicatorComponen
 
 /** Write a transaction into that queue without a connection. */
 export const OfflineQuickAdd: ChromeOrnament = QuickAddOfflineButtonComponent;
+
+/** The cloud has the server, the tokens and the cron — see editions/chrome.ts. */
+export const CHROME_HAS_BANK_FEEDS: ChromeHasBankFeeds = true;

--- a/src/pages/AccountTransactions.tsx
+++ b/src/pages/AccountTransactions.tsx
@@ -487,6 +487,14 @@ export default function AccountTransactions() {
   const [showFilters, setShowFilters] = useState(false);
   const [tableExpanded, setTableExpanded] = useState(false);
   const [sortField, setSortField] = useState<TransactionSortField>('date');
+  /**
+   * Has the PHONE's Order control been used? The phone reverses the default
+   * chronology (newest first — see phoneListRows), and that reversal must
+   * stand down the moment the order is CHOSEN, or "oldest first" would be
+   * unreachable: choosing date-ascending would be flipped right back to
+   * newest-first by the default's own courtesy.
+   */
+  const [phoneSortChosen, setPhoneSortChosen] = useState(false);
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   // The table's height is MEASURED (viewport minus everything above it and a
   // reserve for the bottom dock) so the whole page always fits one screen,
@@ -1278,10 +1286,10 @@ export default function AccountTransactions() {
    * dashboard perf pass existed to remove.
    */
   const phoneListRows = useMemo(
-    () => (sortField === 'date' && sortDirection === 'asc'
+    () => (sortField === 'date' && sortDirection === 'asc' && !phoneSortChosen
       ? [...transactionsWithBalance].reverse()
       : transactionsWithBalance),
-    [transactionsWithBalance, sortField, sortDirection]
+    [transactionsWithBalance, sortField, sortDirection, phoneSortChosen]
   );
 
   // ── Opening at the foot of the register ────────────────────────────────────
@@ -3291,7 +3299,9 @@ export default function AccountTransactions() {
           wrapped inside the buttons and gave each a different height — and a
           fourth wraps to the next line, exactly as Show archived already
           does. */}
-      <div className="grid grid-cols-3 items-stretch gap-2 sm:flex sm:flex-wrap sm:items-center sm:justify-between">
+      {/* relative: the View panel spans THIS row edge to edge on a phone —
+          see its own comment. Positioning context only; nothing else moves. */}
+      <div className="relative grid grid-cols-3 items-stretch gap-2 sm:flex sm:flex-wrap sm:items-center sm:justify-between">
         {/* display:contents on phones dissolves this wrapper so every button
             inside it is an equal grid cell of the row above; from sm it is the
             left cluster again. */}
@@ -3337,7 +3347,7 @@ export default function AccountTransactions() {
         )}
 
         {/* View: choose which columns to show, and how far back to list */}
-        <div className="relative flex" ref={viewRef}>
+        <div className="static sm:relative flex" ref={viewRef}>
           <button
             onClick={() => setShowView(prev => !prev)}
             className={`${TOOLBAR_QUIET_BUTTON} ${TOOLBAR_QUIET_IDLE}`}
@@ -3349,8 +3359,15 @@ export default function AccountTransactions() {
             )}
             {showView ? <ChevronUpIcon size={14} /> : <ChevronDownIcon size={14} />}
           </button>
+          {/* FULL TOOLBAR WIDTH on a phone: the button's place in the row
+              depends on how the toolbar wrapped, so anchoring 256px to either
+              of its edges clips one way or the other (measured both: 150px
+              off the right, then 14px off the left). The wrapper goes static
+              below sm, the panel anchors to the toolbar row and spans it —
+              found adding the Order section (owner item 9). Desktop keeps
+              the anchored w-64 it always had. */}
           {showView && (
-            <div className="absolute z-50 mt-1 left-0 w-64 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-xl shadow-lg p-3">
+            <div className="absolute z-50 mt-1 left-0 right-0 w-auto top-full sm:top-auto sm:right-auto sm:w-64 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-xl shadow-lg p-3">
               <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1.5">Columns</p>
               <div className="max-h-52 overflow-y-auto -mx-1 px-1">
                 {baseColumns.map(col => (
@@ -3362,6 +3379,46 @@ export default function AccountTransactions() {
                       className="rounded border-gray-300 dark:border-gray-600"
                     />
                     {COLUMN_LABELS[col.key] ?? col.header}
+                  </label>
+                ))}
+              </div>
+              {/* ORDER — phone only (owner, 26 Aug, item 9): the desktop
+                  sorts by clicking column headers, which a card list does not
+                  have. Six orders, each named by what ARRIVES FIRST, because
+                  "descending" makes a thumb stop and think. Picking any of
+                  them marks the order as CHOSEN, which stands the phone's
+                  newest-first default reversal down — see phoneSortChosen. */}
+              <div className="sm:hidden mt-2 pt-2 border-t border-gray-100 dark:border-gray-700">
+                <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1.5">Order</p>
+                {([
+                  { label: 'Date — newest first', field: 'date', direction: 'desc' },
+                  { label: 'Date — oldest first', field: 'date', direction: 'asc' },
+                  { label: 'Description — A to Z', field: 'description', direction: 'asc' },
+                  { label: 'Description — Z to A', field: 'description', direction: 'desc' },
+                  { label: 'Amount — largest first', field: 'amount', direction: 'desc' },
+                  { label: 'Amount — smallest first', field: 'amount', direction: 'asc' },
+                ] as const).map(option => (
+                  <label key={option.label} className="flex items-center gap-2 py-1 text-sm text-gray-700 dark:text-gray-200 cursor-pointer">
+                    <input
+                      type="radio"
+                      name="phone-order"
+                      checked={
+                        sortField === option.field &&
+                        (phoneSortChosen
+                          ? sortDirection === option.direction
+                          // The unchosen default (date ascending, reversed for
+                          // the phone) DISPLAYS newest first, so that is the
+                          // radio it honestly matches.
+                          : option.direction === 'desc' && option.field === 'date')
+                      }
+                      onChange={() => {
+                        setSortField(option.field);
+                        setSortDirection(option.direction);
+                        setPhoneSortChosen(true);
+                      }}
+                      className="border-gray-300 dark:border-gray-600"
+                    />
+                    {option.label}
                   </label>
                 ))}
               </div>

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -6,6 +6,7 @@ import { dataPort } from '@data';
 import { preserveDemoParam } from '../utils/navigation';
 import { DEPTH_LEVEL_1, DEPTH_LEVEL_2 } from '../styles/depthShading';
 import { WholePoundsScope, WholePoundsToggle } from '../contexts/WholePoundsContext';
+import { CHROME_HAS_BANK_FEEDS } from '@chrome';
 import AddAccountModal from '../components/AddAccountModal';
 import AccountSettingsModal from '../components/AccountSettingsModal';
 import AccountBreakdownModal, { type AccountBreakdownView } from '../components/AccountBreakdownModal';
@@ -2506,10 +2507,17 @@ function AccountsList() {
 
       {/* On the RIGHT, between the summary boxes and the controls — the same
           side every page keeps this choice on (owner, 20 Aug: "the location
-          on each page should be similar, as in on the right hand side"). */}
-      <div className="-mt-4 mb-2 flex justify-end">
-        <WholePoundsToggle />
-      </div>
+          on each page should be similar, as in on the right hand side").
+
+          Only while there are figures to hide: with no accounts the summary
+          above does not render, the -mt-4 that tucks this under it grabbed
+          the Add Account button instead (owner, 26 Aug, on the desktop
+          build), and a decimals toggle over an empty page governs nothing. */}
+      {accounts.length > 0 && (
+        <div className="-mt-4 mb-2 flex justify-end">
+          <WholePoundsToggle />
+        </div>
+      )}
 
       {/* Group + sort controls, with bank connections on the right.
           ─ WHICH LABEL GOES WITH WHICH CONTROL ────────────────────────────
@@ -2911,6 +2919,7 @@ function AccountsList() {
                 asks rather than assumes. The LABEL and the count are
                 unchanged either way: standing down surrenders the colour,
                 never the facts. */}
+            {CHROME_HAS_BANK_FEEDS && (
             <button
               onClick={() => setBankConnectionsView('plain')}
               className={`w-full sm:w-auto justify-center px-3 py-1.5 text-sm font-medium rounded-lg border transition-colors flex items-center gap-2 ${
@@ -2924,6 +2933,7 @@ function AccountsList() {
                 ? `Bank connections — ${feedsNeedingAttention} need${feedsNeedingAttention === 1 ? 's' : ''} attention`
                 : 'Bank connections'}
             </button>
+            )}
             {/* ─ THE TRAVELLING AMBER ─────────────────────────────────────────
                 See `focusMode` for the whole argument. In short: one control
                 naming the next job, which MOVES to the next one as each is

--- a/src/pages/Categorisation.tsx
+++ b/src/pages/Categorisation.tsx
@@ -189,7 +189,19 @@ export default function Categorisation(): React.JSX.Element {
         </p>
       </div>
 
-      {count === 0 ? (
+      {count === 0 && transactions.length === 0 ? (
+        // AN EMPTY LEDGER IS NOT A FILED LEDGER (owner, 26 Aug, from the
+        // desktop build's first open). "Everything is filed" congratulated a
+        // ledger with nothing in it — a claim that happened to be vacuously
+        // true and read as a lie. Zero transactions is a different state
+        // with a different remedy, and the remedy lives on other pages.
+        <div className="bg-white dark:bg-gray-800 rounded-xl border-2 border-gray-200 dark:border-gray-700">
+          <EmptyState
+            title="No transactions to categorise yet"
+            description="Once you add or import transactions, this is where you file anything the app could not place — so every report counts all of your money."
+          />
+        </div>
+      ) : count === 0 ? (
         // The hand-rolled centred copy this page carried since batch 7 is what
         // exposed the inconsistency — and it was the one that was right. Now
         // the shared component, which the owner centred app-wide on 15 August.

--- a/src/pages/__tests__/AccountTransactions.inlineEdit.test.tsx
+++ b/src/pages/__tests__/AccountTransactions.inlineEdit.test.tsx
@@ -282,18 +282,31 @@ describe('Account register — the row itself becomes the editor', () => {
     expect(rows.indexOf(stripRow as HTMLElement)).toBe(rows.indexOf(editorRow()) + 1);
   });
 
-  it('draws every other row exactly as it drew it before', async () => {
+  it('draws every other row exactly as it drew it before — hover aside', async () => {
     await openRegister();
 
     // Byte for byte: opening an editor on one row must not so much as re-space
     // a neighbour. Anything that changes here changes it for eleven thousand
     // rows at once.
+    //
+    // ONE licensed exception since 26 Aug: the hover classes. While an editor
+    // row is open the pointer is not the instrument, so every row's hover
+    // lift stands down — the parked mouse's row had been wearing its hover
+    // band through whole Save & Next sessions, reading as a second selection
+    // (owner, item 11). The comparison strips exactly that delta and no
+    // other, so this spec still catches any real re-spacing.
+    const withoutHover = (html: string | undefined): string | undefined =>
+      html?.replace(/[^\s"]*hover:[^\s"]+/g, '').replace(/\s+/g, ' ');
     const before = within(grid()).getByText('Thistledown Books').closest('[role="row"]')?.outerHTML;
 
     clickRow('Sandpiper Foods');
 
     const after = within(grid()).getByText('Thistledown Books').closest('[role="row"]')?.outerHTML;
-    expect(after).toBe(before);
+    expect(withoutHover(after)).toBe(withoutHover(before));
+    // And the licensed delta is REAL — the hover classes were there before
+    // and are gone while the editor is open, or the item-11 fix regressed.
+    expect(before).toContain('hover:bg-gray-50');
+    expect(after).not.toContain('hover:bg-gray-50');
   });
 
   it('leaves the add bar exactly where it was', async () => {

--- a/src/services/bankConnectionService.ts
+++ b/src/services/bankConnectionService.ts
@@ -100,6 +100,7 @@ export class BankConnectionService {
   private connections: BankConnection[] = [];
   private connectionListeners = new Set<() => void>();
   private configStatus = { plaid: false, trueLayer: false };
+  private configStatusKnown = true;
   private fetcher: FetchLike | null;
   private logger: Logger;
   private apiBaseUrl: string;
@@ -552,12 +553,27 @@ export class BankConnectionService {
         plaid: false,
         trueLayer: data.status === 'ok'
       };
+      this.configStatusKnown = true;
     } catch (error) {
+      // A FAILED check is not a 'degraded' verdict, and folding it into one
+      // told the owner's TestFlight install "bank connections not configured
+      // — add provider credentials" while the very same backend was serving
+      // his live feeds (26 Aug, item 6). A health call can fail for reasons
+      // that say nothing about configuration — the auth token not yet
+      // minted in a freshly-booted WebView is the likely one there — so the
+      // answer is "unknown", and the UI says it could not check rather than
+      // asserting a server fact it never learned.
       this.logger.warn('Failed to load banking config status', error as Error);
       this.configStatus = { plaid: false, trueLayer: false };
+      this.configStatusKnown = false;
     }
 
     return this.configStatus;
+  }
+
+  /** False when the last health check FAILED (verdict unknown), true when it answered. */
+  isConfigStatusKnown(): boolean {
+    return this.configStatusKnown;
   }
 
   getConfigStatus(): { plaid: boolean; trueLayer: boolean } {


### PR DESCRIPTION
The desktop build, the TestFlight build and the web build each reached the owner for the first time this week, and he came back with a numbered list of eleven findings. Nine are fixed here; item 2 was answered in conversation (the ≈ marks convention), item 8 (a duplicated bank import) awaits a diagnostic query on the live ledger, and item 5 (notification sync) was parked by choice.

**1 — Empty Accounts page.** With no accounts, the hide-decimals toggle's `-mt-4` sat it on top of the Add Account button. A toggle whose effect cannot be seen reads as broken anyway; it now waits until an account exists.

**3 — Categorisation on an empty ledger.** "Everything is filed" is a claim, and an empty ledger is not a filed ledger. A new first branch says there is nothing to categorise yet and what the page is for.

**4 — Bank Feeds on the desktop edition.** The local edition offered a Bank Feeds nav item and a Bank connections button that could only apologise when chosen. New seam fact `CHROME_HAS_BANK_FEEDS` (cloud `true`, device `false`); `Layout` and `Accounts` ask it before drawing. The seam census now counts eleven exports and names the fact.

**6 — "Not configured" on TestFlight.** The banking config check had *failed* (the phone couldn't reach it), and the failure wore the verdict's banner while his feeds were demonstrably running. `bankConnectionService` now distinguishes a failed check from an answered "no"; the UI says it couldn't check and offers another go.

**7 — Two back buttons on the phone register.** The mobile breadcrumb's "< Accounts" duplicated the page's own "Back to Accounts". Parents that draw their own way back (`accounts`, `reports`) are listed; the breadcrumb stands down for them.

**9 — No sort on the phone register.** The View dropdown gains a phone-only Order section — date, description, amount, each both ways. Choosing one stands down the newest-first default reversal (`phoneSortChosen`). The panel anchors to the full toolbar width below `sm` so it can't clip off-screen.

**10 — Save button below the glass on iOS.** The shared Modal was sized by `100vh` — the *large* viewport, which extends under Safari's chrome. A `100dvh` cap now follows it as the modern override; every dialog inherits the fix.

**11 — Two lit rows during Save & Next.** Not a selection bug: the parked mouse's hover band. Hover stands down on every row while an editor row is open. The byte-for-byte neighbour spec licenses exactly that delta and proves it real in both directions.

Verified live in the browser pane at 375px (Order menu drives the list, panel fully on-screen) and by the hover audit (one lit row through a Save & Next run). Desktop bundle greps pass with the seam fact. 54 targeted specs green, lint and `typecheck:strict` clean, full pre-commit and pre-push gates run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)