### PR TITLE
fix(banking): a re-issued provider id no longer imports the same transaction twice

### DIFF
--- a/api/banking/sync-transactions.ts
+++ b/api/banking/sync-transactions.ts
@@ -22,6 +22,7 @@ import {
 import type { TrueLayerTransaction } from '../_lib/truelayer.js';
 import { fetchCardTransactions, fetchTransactions } from '../_lib/truelayer.js';
 import { cardAmountToAppSigned } from '../../src/services/banking/cardNormalization.js';
+import { resolveIdChurn, type ExistingBankRow } from '../../src/services/banking/idChurn.js';
 
 const coerceIsoDateTime = (value: string, endOfDay: boolean): string | null => {
   const trimmed = value.trim();
@@ -315,7 +316,71 @@ async function handler(req: VercelRequest, res: VercelResponse) {
       }
     }
 
-    const insertCandidates = uniquePrepared.filter((row) => !existingIds.has(row.external_transaction_id));
+    const unknownIdCandidates = uniquePrepared.filter((row) => !existingIds.has(row.external_transaction_id));
+
+    // Id churn (observed live, Aug 2026, a cheque deposit): the provider can re-issue the SAME
+    // transaction under a new external id between syncs, which sails past the
+    // exact-id dedup above and lands as a duplicate. An unknown id is only a
+    // new transaction if no existing row in the window matches it while its
+    // own id has VANISHED from this sync's feed — see resolveIdChurn's header
+    // for why the vanished id is what keeps two genuine identical cheques
+    // apart. Adopted rows get their id repointed in place (categorisation and
+    // reconciliation survive); nothing about the money changes, so this stays
+    // outside the atomic import RPC.
+    let insertCandidates = unknownIdCandidates;
+    let idChurnRepaired = 0;
+    if (unknownIdCandidates.length > 0) {
+      const windowRowsResult = await supabase
+        .from('transactions')
+        .select('id, external_transaction_id, account_id, date, amount, metadata')
+        .eq('connection_id', connection.id)
+        .eq('user_id', auth.userId)
+        .gte('date', dateRange.from.slice(0, 10))
+        .lte('date', dateRange.to.slice(0, 10))
+        .not('external_transaction_id', 'is', null);
+
+      if (windowRowsResult.error) {
+        throw new Error(`Failed to load window transactions for churn check: ${windowRowsResult.error.message}`);
+      }
+
+      const windowRows = (windowRowsResult.data ?? []) as Array<ExistingBankRow & {
+        metadata: Record<string, unknown> | null;
+      }>;
+      const metadataByRowId = new Map(windowRows.map((row) => [row.id, row.metadata]));
+      const fetchedExternalIds = new Set(prepared.map((row) => row.external_transaction_id));
+      const resolution = resolveIdChurn(unknownIdCandidates, windowRows, fetchedExternalIds);
+      insertCandidates = resolution.inserts;
+
+      for (const adoption of resolution.adoptions) {
+        const previousMetadata = metadataByRowId.get(adoption.existingRowId) ?? {};
+        const previousHistory = Array.isArray(previousMetadata['idChurnHistory'])
+          ? previousMetadata['idChurnHistory']
+          : [];
+        const updateResult = await supabase
+          .from('transactions')
+          .update({
+            external_transaction_id: adoption.candidate.external_transaction_id,
+            metadata: {
+              ...previousMetadata,
+              idChurnHistory: [
+                ...previousHistory,
+                {
+                  previousExternalId: adoption.previousExternalId,
+                  repairedAt: new Date().toISOString()
+                }
+              ]
+            }
+          })
+          .eq('id', adoption.existingRowId)
+          .eq('user_id', auth.userId);
+
+        if (updateResult.error) {
+          throw new Error(`Failed to repoint churned transaction id: ${updateResult.error.message}`);
+        }
+        idChurnRepaired += 1;
+      }
+    }
+
     let insertedCount = 0;
     for (const insertChunk of chunk(insertCandidates, 200)) {
       if (insertChunk.length === 0) {
@@ -365,7 +430,9 @@ async function handler(req: VercelRequest, res: VercelResponse) {
       insertedCount += summary?.inserted ?? 0;
     }
 
-    const duplicatesSkipped = prepared.length - insertedCount;
+    // Adopted rows are neither imports nor duplicates — they are the same
+    // transaction keeping its ledger row, so they leave both other counts.
+    const duplicatesSkipped = prepared.length - insertedCount - idChurnRepaired;
 
     await markConnectionSyncSuccess(supabase, connection.id, auth.userId);
     await supabase.from('sync_history').insert({
@@ -379,7 +446,8 @@ async function handler(req: VercelRequest, res: VercelResponse) {
     const response: SyncTransactionsResponse = {
       success: true,
       transactionsImported: insertedCount,
-      duplicatesSkipped
+      duplicatesSkipped,
+      ...(idChurnRepaired > 0 ? { idChurnRepaired } : {})
     };
     return res.status(200).json(response);
   } catch (error) {

--- a/src/services/banking/__tests__/idChurn.test.ts
+++ b/src/services/banking/__tests__/idChurn.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { resolveIdChurn, type ExistingBankRow } from '../idChurn';
+
+// Every figure in this file is invented. The SHAPE of the first case is the
+// real Aug 2026 incident (a cheque deposit re-issued under a new TrueLayer
+// id between a morning and an evening sync); the amounts are not.
+
+const candidate = (over: Partial<Parameters<typeof resolveIdChurn>[0][number]> = {}) => ({
+  external_transaction_id: 'txn-new',
+  account_id: 'acct-1',
+  date: '2026-08-25',
+  amount: 42,
+  ...over
+});
+
+const existing = (over: Partial<ExistingBankRow> = {}): ExistingBankRow => ({
+  id: 'row-1',
+  external_transaction_id: 'txn-old',
+  account_id: 'acct-1',
+  date: '2026-08-25',
+  amount: 42,
+  ...over
+});
+
+describe('resolveIdChurn — the same transaction under a new id', () => {
+  it('adopts when the old id vanished and account/date/amount agree — the churned cheque', () => {
+    const { adoptions, inserts } = resolveIdChurn(
+      [candidate()],
+      [existing()],
+      new Set(['txn-new']) // the feed no longer carries txn-old
+    );
+
+    expect(inserts).toEqual([]);
+    expect(adoptions).toEqual([
+      { existingRowId: 'row-1', previousExternalId: 'txn-old', candidate: candidate() }
+    ]);
+  });
+
+  it('does NOT adopt while the old id is still in the feed — two real identical cheques', () => {
+    // Both ids present means both transactions exist at the bank. The second
+    // one is genuinely new money and MUST insert; merging it would lose a
+    // transaction.
+    const { adoptions, inserts } = resolveIdChurn(
+      [candidate()],
+      [existing()],
+      new Set(['txn-new', 'txn-old'])
+    );
+
+    expect(adoptions).toEqual([]);
+    expect(inserts).toEqual([candidate()]);
+  });
+
+  it('inserts when any of account, date or amount differs', () => {
+    const vanished = new Set(['txn-new']);
+    for (const near of [
+      existing({ account_id: 'acct-2' }),
+      existing({ date: '2026-08-24' }), // settlement date shift: deliberately NOT repaired
+      existing({ amount: 42.01 })
+    ]) {
+      const { adoptions, inserts } = resolveIdChurn([candidate()], [near], vanished);
+      expect(adoptions).toEqual([]);
+      expect(inserts).toEqual([candidate()]);
+    }
+  });
+
+  it('consumes a vanished row at most once — one old row cannot be two cheques', () => {
+    const first = candidate({ external_transaction_id: 'txn-new-1' });
+    const second = candidate({ external_transaction_id: 'txn-new-2' });
+
+    const { adoptions, inserts } = resolveIdChurn(
+      [first, second],
+      [existing()],
+      new Set(['txn-new-1', 'txn-new-2'])
+    );
+
+    expect(adoptions.map((a) => a.candidate.external_transaction_id)).toEqual(['txn-new-1']);
+    expect(inserts).toEqual([second]);
+  });
+
+  it('pairs two vanished rows with two candidates', () => {
+    const rows = [existing(), existing({ id: 'row-2', external_transaction_id: 'txn-old-2' })];
+    const cands = [
+      candidate({ external_transaction_id: 'txn-new-1' }),
+      candidate({ external_transaction_id: 'txn-new-2' })
+    ];
+
+    const { adoptions, inserts } = resolveIdChurn(cands, rows, new Set(['txn-new-1', 'txn-new-2']));
+
+    expect(inserts).toEqual([]);
+    expect(adoptions.map((a) => a.previousExternalId).sort()).toEqual(['txn-old', 'txn-old-2']);
+  });
+
+  it('keys amounts by value, not representation', () => {
+    const { adoptions } = resolveIdChurn(
+      [candidate({ amount: 42.1 })],
+      [existing({ amount: 42.10 })],
+      new Set(['txn-new'])
+    );
+    expect(adoptions).toHaveLength(1);
+  });
+
+  it('is a no-op on empty inputs', () => {
+    expect(resolveIdChurn([], [], new Set())).toEqual({ adoptions: [], inserts: [] });
+    expect(resolveIdChurn([candidate()], [], new Set(['txn-new']))).toEqual({
+      adoptions: [],
+      inserts: [candidate()]
+    });
+  });
+});

--- a/src/services/banking/idChurn.ts
+++ b/src/services/banking/idChurn.ts
@@ -1,0 +1,117 @@
+/**
+ * Provider transaction-id churn: the same real-world transaction re-issued
+ * under a NEW external id between two syncs.
+ *
+ * Observed live in Aug 2026: a cheque deposited via a UK bank's mobile app
+ * arrived in the morning sync under one TrueLayer id and in the evening sync
+ * under a different one — same account, same date, same amount, same
+ * description. Deduplication keys on the external id, so the second sync
+ * inserted a duplicate. TrueLayer's `normalised_provider_transaction_id`
+ * exists precisely to be stable across this transition, but not every bank
+ * reliably honours it for cheque deposits.
+ *
+ * The repair: a candidate whose id is unknown is only a NEW transaction if
+ * the ledger has no matching row whose own id has VANISHED from the feed.
+ * The vanished id is the load-bearing condition — two genuinely identical
+ * transactions (two £50 cheques the same day) both keep their ids in the
+ * feed, so neither existing row is adoptable and the second one inserts as
+ * it should. Only when the provider stopped sending an id AND sent a
+ * look-alike under a new one do we treat it as the same transaction and
+ * repoint the existing row rather than insert.
+ *
+ * Matching is same account + same date + same amount, deliberately WITHOUT
+ * the description: banks routinely rewrite descriptions on settlement, and
+ * the vanished-id condition already carries the disambiguation weight. The
+ * date is NOT widened (settlement can shift a timestamp a day) — that class
+ * is left un-repaired rather than risk adopting a neighbour's transaction.
+ */
+
+export interface ChurnCandidate {
+  external_transaction_id: string;
+  account_id: string;
+  /** YYYY-MM-DD */
+  date: string;
+  /** App-signed, 2dp */
+  amount: number;
+}
+
+export interface ExistingBankRow {
+  id: string;
+  external_transaction_id: string;
+  account_id: string;
+  /** YYYY-MM-DD */
+  date: string;
+  amount: number;
+}
+
+export interface ChurnAdoption<C extends ChurnCandidate> {
+  /** The ledger row that keeps living under the new id. */
+  existingRowId: string;
+  /** The id the provider stopped sending. */
+  previousExternalId: string;
+  /** The feed row whose id the existing row adopts; it is NOT inserted. */
+  candidate: C;
+}
+
+export interface ChurnResolution<C extends ChurnCandidate> {
+  adoptions: ChurnAdoption<C>[];
+  /** Candidates that are genuinely new and should insert. */
+  inserts: C[];
+}
+
+const matchKey = (row: { account_id: string; date: string; amount: number }): string =>
+  // toFixed(2) so 88.1 and 88.10 key identically — amounts are already 2dp
+  // by the pipeline contract, this only guards representation.
+  `${row.account_id}|${row.date}|${row.amount.toFixed(2)}`;
+
+/**
+ * Decide, for each unknown-id candidate, whether it is a re-issued id for an
+ * existing row (adopt) or a genuinely new transaction (insert).
+ *
+ * @param candidates rows the feed carries whose external ids the ledger does
+ *   not know (the exact-id dedup has already run).
+ * @param existingRows bank-imported ledger rows inside the sync's date window
+ *   for the same connection.
+ * @param fetchedExternalIds every external id the provider sent THIS sync —
+ *   the full feed, not just the unknown ones.
+ */
+export function resolveIdChurn<C extends ChurnCandidate>(
+  candidates: readonly C[],
+  existingRows: readonly ExistingBankRow[],
+  fetchedExternalIds: ReadonlySet<string>
+): ChurnResolution<C> {
+  // Only rows whose id the provider no longer sends are adoptable, and each
+  // at most once — a second look-alike candidate is a genuinely new
+  // transaction (one old row cannot be two cheques).
+  const adoptable = new Map<string, ExistingBankRow[]>();
+  for (const row of existingRows) {
+    if (fetchedExternalIds.has(row.external_transaction_id)) {
+      continue;
+    }
+    const key = matchKey(row);
+    const bucket = adoptable.get(key);
+    if (bucket) {
+      bucket.push(row);
+    } else {
+      adoptable.set(key, [row]);
+    }
+  }
+
+  const adoptions: ChurnAdoption<C>[] = [];
+  const inserts: C[] = [];
+  for (const candidate of candidates) {
+    const bucket = adoptable.get(matchKey(candidate));
+    const row = bucket?.shift();
+    if (row) {
+      adoptions.push({
+        existingRowId: row.id,
+        previousExternalId: row.external_transaction_id,
+        candidate
+      });
+    } else {
+      inserts.push(candidate);
+    }
+  }
+
+  return { adoptions, inserts };
+}

--- a/src/types/banking-api.ts
+++ b/src/types/banking-api.ts
@@ -147,6 +147,12 @@ export interface SyncTransactionsResponse {
   success: boolean;
   transactionsImported: number;
   duplicatesSkipped: number;
+  /**
+   * Existing rows repointed to a re-issued provider id (same transaction,
+   * new external id — the Aug 2026 churned-cheque class). Neither imported
+   * nor a duplicate; present only when non-zero.
+   */
+  idChurnRepaired?: number;
   error?: string;
 }
 


### PR DESCRIPTION
Item 8 of the 26 Aug testing harvest, diagnosed on the live ledger: a cheque deposited via a bank's mobile app arrived in the morning sync under one TrueLayer id and in the evening sync under a different one — same account, same date, same amount, same description. Deduplication keys on the external id, so the second sync inserted a duplicate. TrueLayer's `normalised_provider_transaction_id` exists precisely to be stable across this transition; not every bank honours it for cheque deposits. With the 90-day default sync window the churned day is re-fetched for months, so the duplicate would have kept coming back.

**The repair** — a pure module, [idChurn.ts](src/services/banking/idChurn.ts), wired by the handler to the database: an unknown external id is only a *new* transaction if no existing row in the window matches it on account + date + amount **while its own id has vanished from this sync's feed**. The vanished id is the load-bearing condition: two genuinely identical cheques both keep their ids in the feed, so neither existing row is adoptable and the second one inserts as it must.

An adopted row keeps its ledger identity — categorisation and reconciliation survive — and is repointed to the new id in place, with the previous id recorded in `metadata.idChurnHistory`. Nothing about the money changes, which is why the repointing stays outside the atomic import RPC. Description is deliberately not matched (banks rewrite it on settlement); the date is deliberately not widened (better to leave a shifted-date churn un-repaired than adopt a neighbour's transaction).

The response now reports `idChurnRepaired`, distinct from `transactionsImported` and `duplicatesSkipped` — an adoption is neither.

Seven specs on the pure module (every figure invented; the first is the incident's shape): adoption on vanished id, refusal while the old id is still in the feed, mismatch on any of account/date/amount, at-most-once consumption of a vanished row, two-for-two pairing, representation-independent amount keying, and empty-input no-ops. `typecheck:strict` and lint clean; full pre-commit and pre-push gates run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)