### PR TITLE
feat(desktop): the installed app updates itself, and 0.1.1 is the last manual download

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -11,12 +11,24 @@
 # artefacts somebody will download, so it runs when a release is asked for:
 # a `desktop-v*` tag, or the Run-workflow button.
 #
-# SIGNING: deliberately absent for now. These artefacts are unsigned — macOS
-# users right-click → Open the first time; Windows shows SmartScreen's "more
-# info". Signing needs the owner's Developer ID certificate (macOS) and a
-# code-signing cert (Windows) added as repo secrets; the env hooks below are
-# where they will plug in (APPLE_CERTIFICATE / APPLE_SIGNING_IDENTITY /
-# APPLE_ID for notarisation — see Tauri's macOS signing guide). The repo is
+# SIGNING — TWO DIFFERENT SIGNATURES, AND ONLY ONE OF THEM EXISTS YET:
+#
+#   1. UPDATE signing (present since 0.1.1). Every updater archive is signed
+#      with the release keypair and the installed app verifies it against the
+#      public half in tauri.conf.json. This is what stops a hostile endpoint
+#      serving a payload that runs, and it is entirely separate from the OS's
+#      opinion of the binary.
+#
+#   2. OS code signing (still absent). The artefacts carry no Developer ID and
+#      no Windows code-signing certificate, so a first-run macOS download wants
+#      right-click → Open and Windows shows SmartScreen's "more info". The
+#      published .dmg is notarised BY HAND on the owner's Mac after the build;
+#      the macOS update archive is only ad-hoc signed.
+#
+# Adding the owner's Developer ID to Actions secrets (APPLE_CERTIFICATE /
+# APPLE_CERTIFICATE_PASSWORD / APPLE_SIGNING_IDENTITY / APPLE_ID /
+# APPLE_PASSWORD / APPLE_TEAM_ID — see Tauri's macOS signing guide) would sign
+# and notarise both artefacts here and retire the manual step. The repo is
 # PUBLIC: certificates and passwords go in Actions secrets, never in this file.
 name: Desktop installers
 
@@ -88,6 +100,16 @@ jobs:
         shell: bash
 
       - name: Build the installer
+        # The signing key is what makes the built app trust an update: the
+        # updater verifies every downloaded artefact against the public half in
+        # tauri.conf.json and refuses anything it cannot match, so a
+        # compromised endpoint cannot serve a payload that runs. Without these
+        # two variables `createUpdaterArtifacts` produces the archives and no
+        # .sig beside them, and the manifest job below fails rather than
+        # publishing an update nobody could install.
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm run --prefix apps/desktop tauri -- build --bundles ${{ matrix.bundles }} ${{ matrix.target && format('--target {0}', matrix.target) || '' }}
 
       - name: Collect artefacts
@@ -96,8 +118,16 @@ jobs:
           mkdir -p out
           # A --target build lands under target/<triple>/release; find covers both.
           BUNDLE_DIR="apps/desktop/src-tauri/target"
+          # What a person downloads.
           find "$BUNDLE_DIR" -name '*.dmg' -exec cp {} out/ \; 2>/dev/null || true
           find "$BUNDLE_DIR" -name '*-setup.exe' -exec cp {} out/ \; 2>/dev/null || true
+          # What an INSTALLED app downloads: the update archives and their
+          # signatures. Different files from the two above — an installer is
+          # not an update — and the manifest job needs both halves.
+          find "$BUNDLE_DIR" -name '*.app.tar.gz' -exec cp {} out/ \; 2>/dev/null || true
+          find "$BUNDLE_DIR" -name '*.app.tar.gz.sig' -exec cp {} out/ \; 2>/dev/null || true
+          find "$BUNDLE_DIR" -name '*-setup.nsis.zip' -exec cp {} out/ \; 2>/dev/null || true
+          find "$BUNDLE_DIR" -name '*-setup.nsis.zip.sig' -exec cp {} out/ \; 2>/dev/null || true
           ls -la out/
 
       - uses: actions/upload-artifact@v4
@@ -113,4 +143,87 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: out/*
+          draft: true
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # The manifest an INSTALLED app reads.
+  #
+  # It has to be its own job because it is the one artefact that needs BOTH
+  # platforms' output at once: one file naming the macOS archive and the
+  # Windows archive with their signatures. `needs: build` is that barrier.
+  #
+  # WHERE THE APP LOOKS: tauri.conf.json points at
+  # `releases/latest/download/latest.json`, and GitHub resolves "latest" to the
+  # newest PUBLISHED, non-draft release. The release this workflow creates is a
+  # DRAFT — so nothing is offered to anyone until the draft is published by
+  # hand. That is the intended safety catch: publishing the release IS the act
+  # of shipping the update, and it happens after the .dmg has been notarised
+  # and swapped in.
+  # ─────────────────────────────────────────────────────────────────────────
+  manifest:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/desktop-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artefacts
+
+      - name: Compose latest.json
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#desktop-v}"
+          BASE="https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}"
+
+          # A missing half is a HARD failure. The alternative — emitting a
+          # manifest naming only the platform that built — would tell every
+          # user of the other platform that they are up to date when they are
+          # not, which is worse than no manifest at all.
+          need() {
+            local found
+            found="$(find artefacts -name "$1" -print -quit)"
+            if [ -z "$found" ]; then
+              echo "desktop-release: no artefact matching '$1' — refusing to publish a partial manifest" >&2
+              exit 1
+            fi
+            printf '%s' "$found"
+          }
+
+          MAC_ARCHIVE="$(need '*.app.tar.gz')"
+          MAC_SIGNATURE="$(cat "$(need '*.app.tar.gz.sig')")"
+          WIN_ARCHIVE="$(need '*-setup.nsis.zip')"
+          WIN_SIGNATURE="$(cat "$(need '*-setup.nsis.zip.sig')")"
+
+          # The macOS build is universal, so both Apple architectures are
+          # served the one archive — that is what `universal-apple-darwin`
+          # buys, and the updater still has to be told twice because it keys
+          # on the running architecture.
+          jq -n \
+            --arg version "$VERSION" \
+            --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg mac_url "$BASE/$(basename "$MAC_ARCHIVE")" \
+            --arg mac_sig "$MAC_SIGNATURE" \
+            --arg win_url "$BASE/$(basename "$WIN_ARCHIVE")" \
+            --arg win_sig "$WIN_SIGNATURE" \
+            '{
+              version: $version,
+              pub_date: $pub_date,
+              notes: "See the release notes on GitHub.",
+              platforms: {
+                "darwin-aarch64": { signature: $mac_sig, url: $mac_url },
+                "darwin-x86_64":  { signature: $mac_sig, url: $mac_url },
+                "windows-x86_64": { signature: $win_sig, url: $win_url }
+              }
+            }' > latest.json
+
+          echo "--- latest.json (signatures elided) ---"
+          jq '.platforms |= map_values(.signature = "<signed>")' latest.json
+
+      - name: Attach the manifest to the release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: latest.json
           draft: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@
 | Desktop bundle | `npm run desktop:verify` | ✅ | Builds `src/desktop` → `apps/desktop/dist`, then PHASE3-PLAN §5’s two bundle greps, then the size ratchet. REFUSES rather than skips when there is no build |
 | Desktop size | `npm run bundle:check:desktop` | ✅ | ~4,090 KiB raw / ~1,244 KiB gz; budgets 4320 / 1335 KiB. **Raw** is the gate — nothing is downloaded, the bytes are embedded in the binary. Binary size recorded, never gated. (The 259 KiB figure this row used to quote was the chooser window, before the app's screens were mounted; the baseline was re-recorded 2026‑08‑12 and the header of `scripts/desktop-bundle-size.mjs` narrates every step since.) |
 | Desktop shell | `npm run desktop:check` | ✅ | clippy `-D warnings` + the shell crate's own 12 tests (`apps/desktop/src-tauri`) |
-| Desktop build | `npm run desktop:build` | ✅ | `vite` → `apps/desktop/dist`, then `cargo build --release` → 16.1 MB. The renderer must be built first: `generate_context!` embeds it |
+| Desktop build | `npm run desktop:build` | ✅ | `vite` → `apps/desktop/dist`, then `cargo build --release` → ~20 MB arm64 (was 16.1 MB; the 0.1.1 updater brings an HTTP/TLS stack with it). The renderer must be built first: `generate_context!` embeds it. Since 0.1.1 a release build also emits `WealthTracker.app.tar.gz` + `.sig` — what an INSTALLED copy downloads, which is not the installer |
 
 ### The local edition's lanes
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -119,6 +119,41 @@ typecheck:strict` is what catches it, via the root `tsconfig.json`'s reference
 to `tsconfig.desktop.json`, and that reference is now asserted by a test because
 it is the only thing standing between this renderer and being untyped.
 
+## How an installed copy gets fixes
+
+A desktop build is a **frozen** copy of the app: `frontendDist` embeds the
+renderer in the binary at compile time, so nothing about a download changes
+when the website changes. (The iOS shell is the opposite — it points a WebView
+at production, so a deploy IS its release. The two are not comparable and the
+difference catches people out.)
+
+Since **0.1.1** the app therefore updates itself:
+
+* on launch, `src-tauri/src/update.rs` asks the endpoint in `tauri.conf.json`
+  whether there is a newer release. Silent, off the main thread, and a failure
+  costs only the update — never a dialog;
+* if there is one, a native dialog offers it, saying what will happen (the
+  window closes and reopens) and what will not (the ledger file is untouched).
+  Declining is free; the next launch asks again;
+* the download is verified against the release public key before it is allowed
+  to run, so the endpoint is not trusted, only the signature is.
+
+It is driven from Rust rather than the renderer for the reason the file chooser
+is: the WebView must not be the part of the program that can replace the
+program. It also keeps the updater out of the size ratchet and out of the CSP.
+
+**The release is created as a DRAFT.** Nothing is offered to anyone until that
+draft is published by hand — publishing IS shipping the update, and it happens
+after the `.dmg` has been notarised and swapped in. Cutting a release is
+`git tag desktop-v<x.y.z> && git push origin desktop-v<x.y.z>`.
+
+**Still owed: OS code signing in CI.** Update signatures exist; Developer ID
+and Windows code-signing certificates do not, so first-run downloads still need
+right-click → Open (macOS) or "more info" (Windows), the published `.dmg` is
+notarised by hand, and the macOS update archive is only ad-hoc signed. The
+header of `.github/workflows/desktop-release.yml` names the secrets that would
+retire all of that.
+
 ## What has been verified, and what has not
 
 Verified on this machine, at this commit:

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wealthtracker-desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The desktop shell's own manifest. The web app's package.json deliberately carries no desktop dependencies (see README) — the Tauri CLI lives here instead, so `npm run tauri --prefix apps/desktop` works without the web install ever knowing about it.",
   "scripts": {
     "tauri": "tauri"

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -60,6 +60,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +570,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +782,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +826,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1342,6 +1382,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,6 +1699,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.20",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1785,6 +1870,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,6 +1927,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2086,6 +2183,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,10 +2258,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+]
 
 [[package]]
 name = "pango"
@@ -2529,15 +2658,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2574,6 +2708,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2603,6 +2751,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2615,6 +2849,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2673,6 +2916,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -2887,6 +3153,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2999,6 +3281,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3092,7 +3380,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -3126,6 +3414,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3148,7 +3447,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -3303,6 +3602,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.20",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3312,7 +3644,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -3335,7 +3667,7 @@ checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -3400,6 +3732,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.4+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3518,6 +3863,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3811,6 +4166,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4006,7 +4367,7 @@ dependencies = [
 
 [[package]]
 name = "wealthtracker-desktop"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rusqlite",
  "serde",
@@ -4014,6 +4375,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-updater",
  "uuid",
  "wealth-core",
 ]
@@ -4082,6 +4444,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4312,6 +4683,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4609,7 +4989,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -4654,6 +5034,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]
@@ -4721,6 +5111,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4751,6 +5147,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@
 
 [package]
 name = "wealthtracker-desktop"
-version = "0.1.0"
+version = "0.1.1"
 description = "WealthTracker local edition — the desktop shell."
 edition = "2021"
 rust-version = "1.89"
@@ -63,6 +63,12 @@ tauri = { version = "2", features = ["devtools"] }
 # The NATIVE file chooser, and the reason the shell has file commands at all: a
 # path is not a payload. See `src/main.rs`.
 tauri-plugin-dialog = "2"
+# Self-update. Driven entirely from Rust (see `main.rs`'s update section) for
+# the same reason the file chooser is: the WebView is not the part of this
+# program that should be able to replace the program. Keeping it out of the
+# renderer also keeps it out of the size ratchet and away from a CSP that
+# would otherwise have to admit an update host.
+tauri-plugin-updater = "2"
 
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -60,6 +60,7 @@
 
 mod document;
 mod lock;
+mod update;
 
 use std::sync::Mutex;
 
@@ -281,10 +282,14 @@ fn shell_build() -> ShellBuild {
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|app| {
             app.manage(Shell {
                 open: Mutex::new(None),
             });
+            // Returns at once; the look happens on the async runtime and can
+            // only ever cost the update. See `update.rs`.
+            update::offer_any_update(app.handle());
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/apps/desktop/src-tauri/src/update.rs
+++ b/apps/desktop/src-tauri/src/update.rs
@@ -1,0 +1,101 @@
+//! Self-update — asking, never assuming.
+//!
+//! # Why this is in Rust and not the renderer
+//!
+//! The same sentence `document.rs` opens with: the WebView is not the part of
+//! this program that should be able to replace the program. An update is the
+//! most privileged thing this binary ever does to itself, and the renderer —
+//! shared, cloud-edition code that happens to be running in a desktop window —
+//! has no business initiating it. Keeping it here has three further effects
+//! that each matter on their own:
+//!
+//!   * the renderer's size ratchet never sees it (`bundle:check:desktop`);
+//!   * the app's CSP does not have to admit an update host into `connect-src`,
+//!     because the download is not made by the WebView;
+//!   * `src/desktop/routes.ts` and the shared UI stay identical between the
+//!     two editions, which is the whole premise of `docs/edition-gating.md`.
+//!
+//! # Why it asks
+//!
+//! An accounts application may not restart itself under someone's hands. The
+//! check is silent, the offer is a native dialog, and declining is free — the
+//! next launch asks again. This is the house rule about saying the consequence
+//! before the remedy, applied to the one action whose consequence is "the
+//! window you are working in will close".
+//!
+//! # What a failed check must never do
+//!
+//! Interrupt. GitHub being unreachable, a rate limit, an aeroplane — none of
+//! them are the user's problem and none of them get a dialog. The error goes
+//! to stderr and the program carries on exactly as it would have. The only
+//! thing a broken update path may cost is the update.
+//!
+//! # The signature, and what is still owed
+//!
+//! Every artefact is signed with the release keypair; the public half lives in
+//! `tauri.conf.json` and the private half only in the repository's Actions
+//! secrets, so an endpoint that served a hostile payload would be refused by
+//! the updater before a byte of it ran. That is separate from APPLE
+//! notarisation: the `.dmg` on the release page is notarised by hand, but the
+//! macOS update artefact is only ad-hoc signed, because CI has no Developer ID
+//! certificate yet. Putting one in `.github/workflows/desktop-release.yml`
+//! would sign both and retire the manual step — see that file's SIGNING note.
+
+use tauri::AppHandle;
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
+use tauri_plugin_updater::UpdaterExt;
+
+/// Look for a newer release, and offer it if there is one.
+///
+/// Returns immediately: the work happens on the async runtime so that a slow
+/// or unreachable endpoint cannot hold up the window. Call it once, from
+/// `setup`.
+pub fn offer_any_update(app: &AppHandle) {
+    let handle = app.clone();
+    tauri::async_runtime::spawn(async move {
+        if let Err(error) = look(handle).await {
+            // Deliberately stderr and nothing else. See the module header.
+            eprintln!("wealthtracker-desktop: the update check did not complete: {error}");
+        }
+    });
+}
+
+/// The check itself, separated so that every failure above has one place to land.
+async fn look(app: AppHandle) -> Result<(), tauri_plugin_updater::Error> {
+    let Some(update) = app.updater()?.check().await? else {
+        // Already current. The overwhelmingly common case, and it says nothing.
+        return Ok(());
+    };
+
+    let installed = app.package_info().version.to_string();
+    let offered = update.version.clone();
+
+    let accepted = app
+        .dialog()
+        .message(format!(
+            "WealthTracker {offered} is available. You are running {installed}.\n\n\
+             Downloading takes a moment, and the app will close and reopen to \
+             finish. Your data is untouched — it stays in your ledger file."
+        ))
+        .title("An update is available")
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Update and restart".to_owned(),
+            "Not now".to_owned(),
+        ))
+        .blocking_show();
+
+    if !accepted {
+        // No nagging, no "are you sure", no deferral bookkeeping. The next
+        // launch will make the same offer, which is reminder enough.
+        return Ok(());
+    }
+
+    // The two closures are progress hooks. There is no progress bar to drive —
+    // a native dialog cannot host one — so they are empty by intent rather
+    // than by omission.
+    update.download_and_install(|_chunk, _total| {}, || {}).await?;
+
+    // Replaces the running process with the new build. Diverges, so nothing
+    // after it can run.
+    app.restart();
+}

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WealthTracker",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "com.wealthtracker.desktop",
   "build": {
     "frontendDist": "../dist",
@@ -22,12 +22,21 @@
       "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost"
     }
   },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDkzOThDRTdCNDJDNUIxRUYKUldUdnNjVkNlODZZa3puOENNV1hwV1FXUTQ0dUdyYkFHMXBodHdSamVWRXFXelc3ZkRURCtWZW8K",
+      "endpoints": [
+        "https://github.com/steveg1983/wealthtracker-pro/releases/latest/download/latest.json"
+      ]
+    }
+  },
   "bundle": {
     "active": true,
     "targets": [
       "app",
       "dmg"
     ],
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Why

A desktop build is a **frozen** copy of the app: `frontendDist` embeds the renderer at compile time, so nothing about an installed copy changes when the website changes. That is the exact opposite of the iOS shell, which points a WebView at production and is therefore released by deploying.

The consequence went unnoticed until the owner's first day of testing across three platforms. Of his eleven findings, the one he reported *from* the desktop build — a Bank Feeds menu the local edition can never honour — was the one fix that could never reach him: `0.1.0` will run August's code forever, and there was no mechanism by which it wouldn't.

## What it does now

On launch the shell checks the release endpoint, off the main thread. If there is a newer version, a native dialog offers it — saying what will happen (the window closes and reopens) and what will not (the ledger file is untouched). Declining is free; the next launch asks again, which is reminder enough. There is no nagging, no deferral bookkeeping, no "are you sure".

A check that fails — no network, a rate limit, an aeroplane — costs the update and nothing else. It goes to stderr and never to a dialog, because a broken update path is not the user's problem.

## Why it is in Rust and not the renderer

The same sentence `document.rs` opens with: the WebView is not the part of this program that should be able to replace the program. Three further effects each earn their keep:

- the renderer's size ratchet never sees it — **measured unchanged**, `bundle:check:desktop` passes;
- the app's CSP does not have to admit an update host into `connect-src`, because the download isn't made by the WebView;
- the shared UI stays byte-identical between editions, which is the premise of `docs/edition-gating.md`.

## Trust comes from the signature, not the endpoint

Every archive is signed in CI with the release keypair and verified against the public half committed in `tauri.conf.json`, so an endpoint serving a hostile payload produces something that will not run.

**Verified locally, end to end:** a signed release build emits `WealthTracker.app.tar.gz` alongside `WealthTracker.app.tar.gz.sig`, and the signature's key id (`vscVCe86Yk`) matches the committed public key. Not asserted — decoded and compared.

## The release pipeline

A new `manifest` job composes `latest.json` — the one artefact that needs both platforms at once — and **refuses to publish a partial manifest**, because telling half the users they are up to date when they are not is worse than telling nobody anything.

Releases remain **drafts**. Publishing one is the act of shipping the update, and it happens after the `.dmg` has been notarised and swapped in.

## Still owed, and now written where it will be found

OS code signing in CI. There are two different signatures here and only one exists: update signatures are done, but Developer ID (macOS) and a Windows code-signing certificate are not, so first-run downloads still need right-click → Open, the published `.dmg` is notarised by hand, and the macOS update archive is only ad-hoc signed. The workflow header names the secrets that would retire all of it.

## Verification

`cargo clippy --all-targets -- -D warnings` clean (including the money lints — `unwrap_used`, `panic`, `float_arithmetic` are `deny` in this crate); the shell's own 12 tests pass; `desktop:greps` and `bundle:check:desktop` pass; a full signed release build succeeds and produces the artefacts above. Binary grows 16.1 MB → ~20 MB arm64 (the updater's HTTP/TLS stack), recorded in `CLAUDE.md` where that figure lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)