### PR TITLE
fix(desktop): the Windows update artefact is the installer itself, not a zip

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -121,13 +121,19 @@ jobs:
           # What a person downloads.
           find "$BUNDLE_DIR" -name '*.dmg' -exec cp {} out/ \; 2>/dev/null || true
           find "$BUNDLE_DIR" -name '*-setup.exe' -exec cp {} out/ \; 2>/dev/null || true
-          # What an INSTALLED app downloads: the update archives and their
-          # signatures. Different files from the two above — an installer is
-          # not an update — and the manifest job needs both halves.
+          # What an INSTALLED app downloads, and the two platforms do NOT
+          # agree on its shape:
+          #
+          #   macOS   a SEPARATE archive, WealthTracker.app.tar.gz, beside the
+          #           .dmg a person downloads;
+          #   Windows the SAME -setup.exe a person downloads, with a .sig next
+          #           to it. (Tauri v1 produced a -setup.nsis.zip here and v2
+          #           does not — measured on the 0.1.1 build, where asking for
+          #           the v1 name found nothing and the manifest job below
+          #           correctly refused to publish half a manifest.)
           find "$BUNDLE_DIR" -name '*.app.tar.gz' -exec cp {} out/ \; 2>/dev/null || true
           find "$BUNDLE_DIR" -name '*.app.tar.gz.sig' -exec cp {} out/ \; 2>/dev/null || true
-          find "$BUNDLE_DIR" -name '*-setup.nsis.zip' -exec cp {} out/ \; 2>/dev/null || true
-          find "$BUNDLE_DIR" -name '*-setup.nsis.zip.sig' -exec cp {} out/ \; 2>/dev/null || true
+          find "$BUNDLE_DIR" -name '*-setup.exe.sig' -exec cp {} out/ \; 2>/dev/null || true
           ls -la out/
 
       - uses: actions/upload-artifact@v4
@@ -194,8 +200,9 @@ jobs:
 
           MAC_ARCHIVE="$(need '*.app.tar.gz')"
           MAC_SIGNATURE="$(cat "$(need '*.app.tar.gz.sig')")"
-          WIN_ARCHIVE="$(need '*-setup.nsis.zip')"
-          WIN_SIGNATURE="$(cat "$(need '*-setup.nsis.zip.sig')")"
+          # Windows updates FROM the installer itself — see the collect step.
+          WIN_ARCHIVE="$(need '*-setup.exe')"
+          WIN_SIGNATURE="$(cat "$(need '*-setup.exe.sig')")"
 
           # The macOS build is universal, so both Apple architectures are
           # served the one archive — that is what `universal-apple-darwin`


### PR DESCRIPTION
The 0.1.1 release build produced both installers and then **refused to publish its manifest** — which is exactly what it was built to do. The Windows updater artefact could not be found under the name the manifest job asked for, and a manifest naming only macOS would have told every Windows user they were up to date when they were not.

**The name was wrong, not the artefact.** Tauri v1 produced a `-setup.nsis.zip` for the NSIS updater; v2 signs the `-setup.exe` a person downloads and drops a `.sig` beside it. Measured on the failed run, whose log names the file outright:

```
Finished 1 updater signature at:
  ...\bundle\nsis\WealthTracker_0.1.1_x64-setup.exe.sig
```

So the two platforms genuinely disagree about the shape of an update: macOS gets a **separate** archive next to its `.dmg`, Windows **re-uses** its installer. Both the collect step and the manifest job now say that in those words, so the next person doesn't have to re-derive it from a build log.

**Nothing shipped.** The release was still a draft and no manifest ever existed, so no installed copy was ever offered a half-update. The incomplete draft is being deleted and the tag recut against this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)