### PR TITLE
build(desktop): 0.1.2 — the release 0.1.1 should have been

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wealthtracker-desktop",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "The desktop shell's own manifest. The web app's package.json deliberately carries no desktop dependencies (see README) — the Tauri CLI lives here instead, so `npm run tauri --prefix apps/desktop` works without the web install ever knowing about it.",
   "scripts": {
     "tauri": "tauri"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@
 
 [package]
 name = "wealthtracker-desktop"
-version = "0.1.1"
+version = "0.1.2"
 description = "WealthTracker local edition — the desktop shell."
 edition = "2021"
 rust-version = "1.89"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WealthTracker",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "com.wealthtracker.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
0.1.1 was tagged at `cc190e8d`, and the settings sweep merged **after** it as `dce477f6`. The owner downloaded 0.1.1, opened Settings, and found the two things he had reported that morning still sitting there — the Sync Status card that measures nothing, and a region picker that will not move off the machine's locale. He reasonably concluded the work had not been done.

It had. It was simply not in the build he was given. Verified against the tag: `SyncStatusIndicator.tsx` still exists there, and its `LocaleSelector` contains no `flush` call.

This is the frozen-desktop property written up in `apps/desktop/README.md` and `apps/mobile/README.md` on the same day: a desktop build embeds the renderer at compile time, so tagging a release **before** the fixes land ships them nowhere. Cutting the tag from `main` after the merge is the whole discipline, and it was not followed.

## What 0.1.2 carries that 0.1.1 missed

- Sync Status deleted — it read `navigator.onLine`, its refresh button awaited a 1.5s timer and called no service, and nothing in the codebase dispatches the event that would mark work pending
- The locale write flushed before the reload — the desktop edition lost that race *every* time, which is why the region always snapped back to the OS setting
- Page Visibility and Personal Information retired
- The drawer's redundant Home removed
- The ops console gated behind an actual admin rather than shown to everyone and withdrawn on a 403
- The category picker no longer stealing the keyboard on every Save & Next after the first

## Why this one matters beyond its contents

0.1.1 shipped the updater, so **0.1.2 is the first release an installed copy can fetch by itself** — offered on launch rather than downloaded by hand. That is the point at which this class of ordering mistake stops needing a person to go and get a file to recover from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)