### PR TITLE
fix(banking): stop asking Revolut for a protected resource, and stop claiming confirms that did not happen

### DIFF
--- a/api/_lib/banking-sync.ts
+++ b/api/_lib/banking-sync.ts
@@ -18,6 +18,14 @@ export interface BankConnectionRow {
   institution_name: string;
   access_token_encrypted: string;
   refresh_token_encrypted: string | null;
+  /**
+   * When this connection last synced successfully, or null if it never has.
+   *
+   * Carried because it decides HOW FAR BACK a sync may ask. See
+   * `getDateRange` in api/banking/sync-transactions.ts: the long window is
+   * only lawful while authentication is fresh.
+   */
+  last_sync?: string | null;
 }
 
 /**
@@ -88,7 +96,7 @@ export const getUserBankConnection = async (
 ): Promise<BankConnectionRow | null> => {
   const { data, error } = await supabase
     .from('bank_connections')
-    .select('id, user_id, provider, institution_id, institution_name, access_token_encrypted, refresh_token_encrypted')
+    .select('id, user_id, provider, institution_id, institution_name, access_token_encrypted, refresh_token_encrypted, last_sync')
     .eq('id', connectionId)
     .eq('user_id', userId)
     .single();

--- a/api/banking/sync-transactions.ts
+++ b/api/banking/sync-transactions.ts
@@ -23,6 +23,7 @@ import type { TrueLayerTransaction } from '../_lib/truelayer.js';
 import { fetchCardTransactions, fetchTransactions } from '../_lib/truelayer.js';
 import { cardAmountToAppSigned } from '../../src/services/banking/cardNormalization.js';
 import { resolveIdChurn, type ExistingBankRow } from '../../src/services/banking/idChurn.js';
+import { syncWindowStart } from '../../src/services/banking/syncWindow.js';
 
 const coerceIsoDateTime = (value: string, endOfDay: boolean): string | null => {
   const trimmed = value.trim();
@@ -43,9 +44,22 @@ const coerceIsoDateTime = (value: string, endOfDay: boolean): string | null => {
   return parsed.toISOString();
 };
 
-const getDateRange = (body: SyncTransactionsRequest): { from: string; to: string } => {
+/**
+ * The range this sync asks the provider for.
+ *
+ * The FROM is decided by `syncWindowStart`, which is where the PSD2 reasoning
+ * lives — asking for the full ninety days on an unattended run is asking for
+ * a protected resource, and a strict provider refuses the whole call.
+ *
+ * An explicit startDate still wins: a caller naming a range has a reason, and
+ * the deliberate backfill right after a reauthorization is one.
+ */
+const getDateRange = (
+  body: SyncTransactionsRequest,
+  lastSync: string | null | undefined
+): { from: string; to: string } => {
   const now = new Date();
-  const defaultFrom = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000).toISOString();
+  const defaultFrom = syncWindowStart(lastSync, now).toISOString();
   const defaultTo = now.toISOString();
 
   const from = typeof body.startDate === 'string'
@@ -147,7 +161,7 @@ async function handler(req: VercelRequest, res: VercelResponse) {
       return createErrorResponse(res, 404, 'Connection not found', 'not_found');
     }
 
-    const dateRange = getDateRange(body);
+    const dateRange = getDateRange(body, connection.last_sync);
 
     const linkedAccountsResult = await supabase
       .from('linked_accounts')

--- a/src/components/QuickEditRow.provenance.test.tsx
+++ b/src/components/QuickEditRow.provenance.test.tsx
@@ -142,6 +142,23 @@ describe('The register row editor — suggested categories', () => {
     expect(mocks.showSuccess).toHaveBeenCalled();
   });
 
+  it('does not claim a confirmation the store did not make', async () => {
+    // The owner's report: confirm a suggestion, go back to the register, and
+    // the row is still bold with the "Suggested" badge — having been told it
+    // was confirmed. The store had matched no rows; every layer between the
+    // RPC and the message reported success anyway, so nothing could notice.
+    // A zero count now says so instead of congratulating the user.
+    mocks.confirmTransactionCategories.mockResolvedValueOnce(0);
+
+    render(<RowEditor transaction={suggested} onDismiss={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(mocks.showError).toHaveBeenCalled();
+    });
+    expect(mocks.showSuccess).not.toHaveBeenCalled();
+  });
+
   it('shows neither the badge nor the confirm button once the user has vouched', () => {
     render(
       <RowEditor

--- a/src/components/QuickEditRow.tsx
+++ b/src/components/QuickEditRow.tsx
@@ -772,8 +772,18 @@ export function QuickEditRowProvider({
     restoreFocusRef.current = true;
     void (async (): Promise<void> => {
       try {
-        await confirmTransactionCategories([id]);
-        showSuccess('Category confirmed.');
+        const confirmed = await confirmTransactionCategories([id]);
+        if (confirmed === 0) {
+          // The store did not confirm this row, and saying so is the whole
+          // point: the alternative — the message this used to show every time
+          // — sent the owner back to a register where the row was still bold
+          // and still badged, with nothing to explain the disagreement.
+          showError(new Error(
+            'That row could not be confirmed — it may have changed since this list was loaded. It has been reloaded; try again.'
+          ));
+        } else {
+          showSuccess('Category confirmed.');
+        }
       } catch (error) {
         showError(error);
       } finally {

--- a/src/contexts/AppContextSupabase.tsx
+++ b/src/contexts/AppContextSupabase.tsx
@@ -1245,18 +1245,35 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     }
     try {
       const count = await dataPort.confirmTransactionCategories(ids);
-      const idSet = new Set(ids);
-      setTransactions(prev => prev.map(t =>
-        idSet.has(t.id) && t.categoryConfirmed === false
-          ? { ...t, categoryConfirmed: true, needsReview: false }
-          : t
-      ));
+
+      // PAINT ONLY WHAT THE SERVER ACTUALLY CONFIRMED.
+      //
+      // This used to patch every id regardless of the count, so a call that
+      // matched NOTHING looked identical to one that matched everything — the
+      // rows went un-bold, the pill vanished, and the next read from the store
+      // put them straight back. That is the owner's report: confirm on the
+      // review page, return to the register, still bold, still "Suggested".
+      //
+      // A short count is not necessarily a failure — the RPC skips rows it
+      // finds already confirmed — but it does mean this client's picture and
+      // the store's disagree, and the store is the one that is right. So stop
+      // guessing and go and read it.
+      if (count === ids.length) {
+        const idSet = new Set(ids);
+        setTransactions(prev => prev.map(t =>
+          idSet.has(t.id) && t.categoryConfirmed === false
+            ? { ...t, categoryConfirmed: true, needsReview: false }
+            : t
+        ));
+      } else {
+        await refreshAccountsAndTransactions();
+      }
       return count;
     } catch (error) {
       appLogger.error('Failed to confirm categories', error);
       throw error;
     }
-  }, []);
+  }, [refreshAccountsAndTransactions]);
 
   const renameTransactionDescriptions = useCallback(async (
     ids: string[],

--- a/src/services/api/transactionService.ts
+++ b/src/services/api/transactionService.ts
@@ -1167,7 +1167,18 @@ class TransactionServiceImpl {
         throw new Error(handleSupabaseError(error));
       }
 
-      return typeof data === 'number' ? data : ids.length;
+      // NEVER `: ids.length`. The RPC is declared RETURNS integer, so a
+      // non-number is a broken contract — and answering it with "all of them"
+      // is the most expensive possible guess: it reports a full success for a
+      // call that may have written nothing, and every caller downstream then
+      // paints rows confirmed on the strength of it. The owner's symptom was
+      // exactly that shape — a Confirm that announced itself and left the row
+      // bold and badged, because nothing between the RPC and the screen could
+      // notice a no-op.
+      if (typeof data !== 'number') {
+        throw new Error('confirm_transaction_categories did not return a count');
+      }
+      return data;
     } catch (error) {
       this.logger.error('TransactionService.confirmTransactionCategories error:', error as Error);
       throw error;

--- a/src/services/banking/__tests__/syncWindow.test.ts
+++ b/src/services/banking/__tests__/syncWindow.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import {
+  syncWindowStart,
+  FIRST_SYNC_WINDOW_DAYS,
+  ROUTINE_SYNC_OVERLAP_DAYS
+} from '../syncWindow';
+
+// Every date here is invented. The SHAPE is the Aug 2026 incident: a feed that
+// died about a day after every reauthorization because each unattended sync
+// asked for the full ninety days — a PSD2-protected resource readable only
+// within ~5 minutes of authentication.
+
+const NOW = new Date('2026-08-26T12:00:00.000Z');
+const DAY_MS = 24 * 60 * 60 * 1000;
+const daysBefore = (from: Date, days: number): Date => new Date(from.getTime() - days * DAY_MS);
+
+describe('syncWindowStart — the long window only while authentication is fresh', () => {
+  it('asks for the full history when the connection has never synced', () => {
+    // Moments after linking: SCA is fresh, and this is the one chance to
+    // collect history at all.
+    expect(syncWindowStart(null, NOW)).toEqual(daysBefore(NOW, FIRST_SYNC_WINDOW_DAYS));
+    expect(syncWindowStart(undefined, NOW)).toEqual(daysBefore(NOW, FIRST_SYNC_WINDOW_DAYS));
+  });
+
+  it('asks only for what is new once it has synced before', () => {
+    const lastSync = daysBefore(NOW, 1).toISOString();
+
+    const start = syncWindowStart(lastSync, NOW);
+
+    expect(start).toEqual(daysBefore(new Date(lastSync), ROUTINE_SYNC_OVERLAP_DAYS));
+    // The point of the fix: a routine run must NOT reach the protected edge.
+    expect(start.getTime()).toBeGreaterThan(daysBefore(NOW, FIRST_SYNC_WINDOW_DAYS).getTime());
+  });
+
+  it('overlaps its last success rather than resuming exactly at it', () => {
+    // A card transaction can settle days later, and a bank can backdate a row.
+    const lastSync = daysBefore(NOW, 3);
+
+    const start = syncWindowStart(lastSync.toISOString(), NOW);
+
+    // "Earlier than the last success" alone is satisfied by the ninety-day
+    // window this fix removed, so it is not enough to assert — measured: that
+    // form of the check passed against the bug. Pin the SIZE of the overlap.
+    expect(start.getTime()).toBeLessThan(lastSync.getTime());
+    expect(lastSync.getTime() - start.getTime()).toBe(ROUTINE_SYNC_OVERLAP_DAYS * DAY_MS);
+  });
+
+  it('never reaches further back than the long window, however stale', () => {
+    // A connection dormant for a year must not quietly turn a routine sync
+    // back into a protected-resource request and restart the whole cycle.
+    const start = syncWindowStart(daysBefore(NOW, 365).toISOString(), NOW);
+
+    expect(start).toEqual(daysBefore(NOW, FIRST_SYNC_WINDOW_DAYS));
+  });
+
+  it('treats an unreadable stored value as never synced rather than guessing', () => {
+    expect(syncWindowStart('not a date', NOW)).toEqual(daysBefore(NOW, FIRST_SYNC_WINDOW_DAYS));
+  });
+});

--- a/src/services/banking/syncWindow.ts
+++ b/src/services/banking/syncWindow.ts
@@ -1,0 +1,61 @@
+/**
+ * How far back a sync may ask, and why it is not always ninety days.
+ *
+ * A bank may serve ninety days of history to an unattended job. Anything
+ * OLDER — and at some providers the ninetieth day itself — is a "protected
+ * resource" readable only within about five minutes of the customer
+ * authenticating. That is Strong Customer Authentication under PSD2:
+ * regulation, not a provider's preference.
+ *
+ * The sync used to ask for the full ninety days on EVERY run. Lenient
+ * providers served it. A strict one refused with
+ *
+ *     ...expired. This resource is protected and should be accessed
+ *     within 5 minutes...
+ *
+ * which the app then classified — reasonably, on the words available — as
+ * "this connection needs reauthorizing". So the owner reauthorized, the sync
+ * inside the next five minutes worked, and every sync after it failed again.
+ * A daily ritual caused entirely by asking for something the app had no fresh
+ * authentication to read. The connection was never broken.
+ *
+ * Hence: the window depends on whether authentication is fresh.
+ */
+
+/** The long window, lawful only while authentication is fresh. */
+export const FIRST_SYNC_WINDOW_DAYS = 90;
+
+/**
+ * How far back a ROUTINE sync re-reads behind its last success.
+ *
+ * Not zero: a card transaction can settle days after it is made, and a bank
+ * can backdate a row after the fact. Re-reading a week and letting dedup
+ * discard the repeats is far cheaper than missing them.
+ */
+export const ROUTINE_SYNC_OVERLAP_DAYS = 7;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The earliest instant this sync may ask for.
+ *
+ * @param lastSync when the connection last synced successfully, or null/absent
+ *   if it never has — the moments just after linking, when SCA is fresh and
+ *   the provider will serve history. That is the one chance to collect it.
+ * @param now the clock, passed in so this is testable and never surprises.
+ */
+export function syncWindowStart(lastSync: string | null | undefined, now: Date): Date {
+  const longWindowStart = now.getTime() - FIRST_SYNC_WINDOW_DAYS * DAY_MS;
+
+  const lastSyncedAt = typeof lastSync === 'string' ? new Date(lastSync) : null;
+  if (lastSyncedAt === null || Number.isNaN(lastSyncedAt.getTime())) {
+    // Never synced — or a stored value nobody can read, which is treated the
+    // same way rather than being guessed at.
+    return new Date(longWindowStart);
+  }
+
+  // Never reach further back than the long window even so: a connection that
+  // has not run for a year must not quietly turn a routine sync into a
+  // protected-resource request and start the whole cycle again.
+  return new Date(Math.max(lastSyncedAt.getTime() - ROUTINE_SYNC_OVERLAP_DAYS * DAY_MS, longWindowStart));
+}


### PR DESCRIPTION
Two owner reports, one shape: something announcing a success it had not earned.

## The feed that died every day

Revolut needed reauthorizing roughly a day after each reauthorization. **The connection was never broken.** The error, read to the end, is TrueLayer's SCA refusal:

> …expired. This resource is protected and should be accessed within 5 minutes…

Under PSD2 a bank may serve ninety days of history to an unattended job; anything older — and at a strict provider the ninetieth day itself — requires Strong Customer Authentication within about five minutes. This sync asked for the **full ninety days on every run**. Lenient providers served it; Revolut refused, and the app classified the refusal — reasonably, on the words available — as "needs reauthorizing". So the owner reauthorized, the sync inside the next five minutes worked, and the one after it failed again. A daily ritual entirely of our own making, and the reason only one of his three banks did it.

The window now depends on whether authentication is fresh:

- **never synced** → the long window. This runs moments after linking, when SCA is fresh and the provider will serve history — the one chance to collect it.
- **synced before** → only what is new, plus a week's overlap for rows that settle late or are backdated.
- never further back than ninety days however dormant, or a stale connection would restart the cycle.

It lives in `src/services/banking/syncWindow.ts` rather than the handler because `api/**` is excluded from the test run, and a regulatory boundary computed in an untested file is the wrong thing to leave unguarded.

**One of the five guards passed against the bug on its first draft** — it asserted only "earlier than the last success", which a ninety-day window also satisfies. It now pins the *size* of the overlap; two guards fail when the fix is reverted.

## The confirm that confirmed nothing

Confirming a suggested category left the row bold and badged in the register, having just said "Category confirmed."

The RPC reports how many rows it changed, and that number was discarded three times over: the service answered a non-numeric response with `ids.length` ("all of them"), the context painted every id confirmed regardless of the count, and the row editor congratulated the user unconditionally. **A call that matched nothing was indistinguishable from one that matched everything** — so the rows went un-bold, and the next read from the store put them straight back.

All three now tell the truth. The service throws rather than invent a count; the context only un-bolds what the server actually confirmed and re-reads the store when the two disagree (a short count is not necessarily failure — the RPC skips rows already confirmed — but it does mean this client's picture is wrong); and a zero count says so instead of congratulating anyone.

## One note on the making of it

The first draft of that service change edited the **wrong function** — `setTransactionsCleared` ends with an identical line and came first in the file. The existing suite caught it immediately. `setTransactionsCleared` is untouched here and the net diff to that file is a single line, verified rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)