### PR TITLE
build(desktop): the lockfile follows the version, so a build stops dirtying the tree

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4367,7 +4367,7 @@ dependencies = [
 
 [[package]]
 name = "wealthtracker-desktop"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "rusqlite",
  "serde",


### PR DESCRIPTION
The 0.1.2 bump changed `Cargo.toml` and left `Cargo.lock` naming 0.1.1. Cargo rewrites the lock to agree on the next command that touches the workspace, so every desktop build produced a modified file nobody had asked for — noise that hides a real change and, on a release build, invites committing whatever else happens to be in the tree.

Found by the release itself: after building and notarising 0.1.2, the worktree came back dirty with exactly this one line.

**The shipped 0.1.2 is unaffected** — the local build regenerated the lock before compiling, so the binary was always stamped 0.1.2. This is the repository catching up with what was already true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)