### PR TITLE
ci(apple): CI signs and notarises its own builds, and iOS uploads without a GUI

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -11,25 +11,33 @@
 # artefacts somebody will download, so it runs when a release is asked for:
 # a `desktop-v*` tag, or the Run-workflow button.
 #
-# SIGNING — TWO DIFFERENT SIGNATURES, AND ONLY ONE OF THEM EXISTS YET:
+# SIGNING — THREE SIGNATURES, ANSWERING THREE DIFFERENT QUESTIONS:
 #
-#   1. UPDATE signing (present since 0.1.1). Every updater archive is signed
-#      with the release keypair and the installed app verifies it against the
-#      public half in tauri.conf.json. This is what stops a hostile endpoint
-#      serving a payload that runs, and it is entirely separate from the OS's
-#      opinion of the binary.
+#   1. UPDATE signing (since 0.1.1). Every updater archive is signed with the
+#      release keypair, and the installed app verifies it against the public
+#      half in tauri.conf.json. Stops a hostile endpoint serving a payload
+#      that runs. Nothing to do with Apple.
 #
-#   2. OS code signing (still absent). The artefacts carry no Developer ID and
-#      no Windows code-signing certificate, so a first-run macOS download wants
-#      right-click → Open and Windows shows SmartScreen's "more info". The
-#      published .dmg is notarised BY HAND on the owner's Mac after the build;
-#      the macOS update archive is only ad-hoc signed.
+#   2. macOS CODE signing (APPLE_CERTIFICATE). Without it the binary is
+#      unsigned — and an unsigned binary CANNOT BE NOTARISED. Measured on
+#      0.1.1: Apple refused it for "the binary is not signed", no secure
+#      timestamp and no hardened runtime, which is why 0.1.1 and 0.1.2 both had
+#      to be rebuilt by hand on the owner's Mac.
 #
-# Adding the owner's Developer ID to Actions secrets (APPLE_CERTIFICATE /
-# APPLE_CERTIFICATE_PASSWORD / APPLE_SIGNING_IDENTITY / APPLE_ID /
-# APPLE_PASSWORD / APPLE_TEAM_ID — see Tauri's macOS signing guide) would sign
-# and notarise both artefacts here and retire the manual step. The repo is
-# PUBLIC: certificates and passwords go in Actions secrets, never in this file.
+#   3. NOTARISATION (APPLE_API_*). Apple's opinion that the signed thing is not
+#      malware. An App Store Connect key rather than an app-specific password,
+#      because the same key also uploads the iOS build.
+#
+# WINDOWS code signing is still absent, so the .exe shows SmartScreen's "more
+# info" on first run. That needs a separate certificate from a commercial CA.
+#
+# Each of the three degrades quietly when its secret is missing — an unsigned
+# build, or a signed one that is not notarised — so this file works before the
+# secrets exist and keeps working if one is rotated away. It never claims
+# otherwise: the collect step publishes whatever was actually produced.
+#
+# The repo is PUBLIC: certificates, passwords and keys live in Actions
+# secrets, never in this file.
 name: Desktop installers
 
 on:
@@ -99,17 +107,62 @@ jobs:
           npm run bundle:check:desktop
         shell: bash
 
+      # The App Store Connect key, written to a file because that is the only
+      # form the bundler accepts (APPLE_API_KEY_PATH). Runner-local, and the
+      # runner is destroyed with the job.
+      - name: Provide the App Store Connect key
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          # The absence check is in the SCRIPT, not in an `if:`. The secrets
+          # context is not dependable in a step condition, and a workflow that
+          # silently stopped running this step would produce an unsigned build
+          # while looking exactly like a signed one.
+          if [ -z "${APPLE_API_KEY_P8:-}" ]; then
+            echo "No APPLE_API_KEY_P8 configured — this build will not be notarised."
+            exit 0
+          fi
+          printf '%s' "$APPLE_API_KEY_P8" > "$RUNNER_TEMP/AuthKey.p8"
+          chmod 600 "$RUNNER_TEMP/AuthKey.p8"
+          echo "App Store Connect key staged."
+
       - name: Build the installer
-        # The signing key is what makes the built app trust an update: the
-        # updater verifies every downloaded artefact against the public half in
-        # tauri.conf.json and refuses anything it cannot match, so a
-        # compromised endpoint cannot serve a payload that runs. Without these
-        # two variables `createUpdaterArtifacts` produces the archives and no
-        # .sig beside them, and the manifest job below fails rather than
-        # publishing an update nobody could install.
+        # THREE DIFFERENT SIGNATURES MEET HERE, and they answer different
+        # questions. Keeping them straight is most of the difficulty:
+        #
+        #  TAURI_SIGNING_*   the UPDATE signature. The installed app verifies
+        #                    every downloaded archive against the public half
+        #                    in tauri.conf.json, so a compromised endpoint
+        #                    cannot serve a payload that runs. Nothing to do
+        #                    with Apple.
+        #  APPLE_CERTIFICATE the OS signature. Without it the binary is
+        #                    unsigned, and an unsigned binary CANNOT BE
+        #                    NOTARISED — Apple rejects it outright for "the
+        #                    binary is not signed", no secure timestamp and no
+        #                    hardened runtime. Measured on 0.1.1, which is why
+        #                    both 0.1.1 and 0.1.2 had to be rebuilt by hand on
+        #                    the owner's Mac and notarised there.
+        #  APPLE_API_*       notarisation itself: Apple's opinion that the
+        #                    signed thing is not malware. The same key also
+        #                    uploads the iOS build, which is why it is a key
+        #                    rather than an app-specific password.
+        #
+        # Every one of them degrades quietly when its secret is absent — an
+        # unsigned build, or a signed one that is not notarised — so this file
+        # keeps working before the secrets exist. What it must never do is
+        # claim otherwise, and it does not: the collect step publishes whatever
+        # was actually produced.
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY_PATH: ${{ runner.temp }}/AuthKey.p8
         run: npm run --prefix apps/desktop tauri -- build --bundles ${{ matrix.bundles }} ${{ matrix.target && format('--target {0}', matrix.target) || '' }}
 
       - name: Collect artefacts

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -62,8 +62,31 @@ build.
 
 ## Releasing to TestFlight
 
-`xcodebuild archive` then `-exportArchive` with an export options plist naming
-`method: app-store-connect` and `destination: upload`. Team `VT6W829WRX`.
+`scripts/ios-release.sh [build-number]` — archives, checks the entitlement
+survived into the signed binary, exports and uploads. No Xcode, no GUI.
+
+**Why a script and not two xcodebuild commands.** Build 2 could not be
+uploaded headlessly. The first failure said App Store Connect access was
+required; the second said the plain truth:
+
+> Provisioning profile "iOS Team Store Provisioning Profile:
+> com.wealthtracker.mobile" doesn't include the
+> com.apple.developer.associated-domains entitlement.
+
+Adding a capability in Xcode regenerates the **development** profile — the
+**distribution** profile is a separate object and does not follow. Only
+something holding an App Store Connect session can regenerate it, so the
+upload went through Xcode's Organizer.
+
+An **App Store Connect API key** is that session. With
+`-authenticationKeyPath/-ID/-IssuerID`, `-allowProvisioningUpdates` regenerates
+the distribution profile itself. The key lives in
+`~/Documents/WealthTracker-signing/` and Apple allows it to be downloaded
+**once** — back that folder up.
+
+A build number already on App Store Connect is rejected *after* the upload
+rather than before, so the script sets it deliberately and refuses to let
+Xcode renumber.
 
 App Store icons must carry **no alpha channel** — the upload is rejected for
 it, and the fix is a JPEG round-trip through `sips`.

--- a/scripts/ios-release.sh
+++ b/scripts/ios-release.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Build the iOS shell and upload it to TestFlight, without Xcode's GUI.
+#
+# WHY THIS EXISTS. On 26 Aug 2026 a headless `xcodebuild -exportArchive`
+# failed twice over: first "App Store Connect access for VT6W829WRX is
+# required", then — more revealingly — 
+#
+#     Provisioning profile "iOS Team Store Provisioning Profile:
+#     com.wealthtracker.mobile" doesn't include the
+#     com.apple.developer.associated-domains entitlement.
+#
+# Adding a capability in Xcode regenerates the DEVELOPMENT profile; the
+# DISTRIBUTION profile is a separate object and does not follow. Regenerating
+# it needs App Store Connect access, which a shell does not have — so the
+# upload had to go through Xcode's Organizer, which holds the session.
+#
+# An App Store Connect API key IS that access. With the three
+# -authentication* flags below, `-allowProvisioningUpdates` can regenerate the
+# distribution profile itself, and the upload needs no GUI and no human.
+#
+# Usage:  scripts/ios-release.sh [build-number]
+#         (build number defaults to the CURRENT_PROJECT_VERSION already set)
+#
+# Needs, in ~/Documents/WealthTracker-signing (or ASC_KEY_DIR):
+#   AuthKey_<KEYID>.p8   downloadable from Apple exactly once — back it up
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IOS_DIR="$REPO_ROOT/apps/mobile/ios/App"
+KEY_DIR="${ASC_KEY_DIR:-$HOME/Documents/WealthTracker-signing}"
+KEY_ID="${ASC_KEY_ID:-K3X6D83JFR}"
+ISSUER_ID="${ASC_ISSUER_ID:-5eefcc4c-7800-4c5f-b6ac-3ffb9c88655a}"
+KEY_PATH="$KEY_DIR/AuthKey_${KEY_ID}.p8"
+ARCHIVE="${TMPDIR:-/tmp}/wt-ios-$(date +%s).xcarchive"
+
+if [ ! -f "$KEY_PATH" ]; then
+  echo "No App Store Connect key at $KEY_PATH" >&2
+  echo "Apple allows the .p8 to be downloaded ONCE; if it is lost, revoke the" >&2
+  echo "key in App Store Connect and generate a new one." >&2
+  exit 1
+fi
+
+# A build number already on App Store Connect is rejected, and the rejection
+# arrives after the upload rather than before it — so it is worth setting
+# deliberately rather than discovering.
+if [ "${1:-}" != "" ]; then
+  echo "==> Setting build number to $1"
+  /usr/bin/sed -i '' "s/CURRENT_PROJECT_VERSION = [0-9][0-9]*;/CURRENT_PROJECT_VERSION = $1;/g" \
+    "$IOS_DIR/App.xcodeproj/project.pbxproj"
+fi
+
+echo "==> Syncing Capacitor (config and entitlements)"
+npm --prefix "$REPO_ROOT/apps/mobile" exec cap sync ios
+
+echo "==> Archiving"
+xcodebuild archive \
+  -project "$IOS_DIR/App.xcodeproj" \
+  -scheme App \
+  -configuration Release \
+  -destination 'generic/platform=iOS' \
+  -archivePath "$ARCHIVE" \
+  -allowProvisioningUpdates \
+  -authenticationKeyPath "$KEY_PATH" \
+  -authenticationKeyID "$KEY_ID" \
+  -authenticationKeyIssuerID "$ISSUER_ID" \
+  DEVELOPMENT_TEAM=VT6W829WRX
+
+# Prove the entitlement survived into the SIGNED BINARY rather than trusting
+# the project file. This is the whole point of the build, and it is cheap.
+APP="$ARCHIVE/Products/Applications/App.app"
+if ! codesign -d --entitlements :- "$APP" 2>/dev/null | grep -q "webcredentials:"; then
+  echo "The archive does not carry the associated-domains entitlement — refusing to upload." >&2
+  exit 1
+fi
+echo "==> Entitlement present: $(codesign -d --entitlements :- "$APP" 2>/dev/null | grep -o 'webcredentials:[^<]*')"
+
+EXPORT_PLIST="${TMPDIR:-/tmp}/wt-export-options.plist"
+cat > "$EXPORT_PLIST" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key><string>app-store-connect</string>
+	<key>destination</key><string>upload</string>
+	<key>teamID</key><string>VT6W829WRX</string>
+	<key>signingStyle</key><string>automatic</string>
+	<key>uploadSymbols</key><true/>
+	<!-- Never true: the build number is chosen above, deliberately. Letting
+	     Xcode renumber invites a collision with something already uploaded. -->
+	<key>manageAppVersionAndBuildNumber</key><false/>
+</dict>
+</plist>
+PLIST
+
+echo "==> Exporting and uploading to App Store Connect"
+xcodebuild -exportArchive \
+  -archivePath "$ARCHIVE" \
+  -exportOptionsPlist "$EXPORT_PLIST" \
+  -exportPath "${TMPDIR:-/tmp}/wt-ios-export" \
+  -allowProvisioningUpdates \
+  -authenticationKeyPath "$KEY_PATH" \
+  -authenticationKeyID "$KEY_ID" \
+  -authenticationKeyIssuerID "$ISSUER_ID"
+
+echo "==> Uploaded. It appears in TestFlight once Apple finishes processing."


### PR DESCRIPTION
Both desktop releases so far were finished by hand on the owner's Mac: rebuild signed locally, submit to `notarytool`, staple, re-upload, regenerate the manifest. The iOS build needed Xcode's Organizer. None of that was a choice — it was the absence of two credentials.

## Why a CI dmg could never be notarised

Notarisation requires a Developer ID signature, a secure timestamp and hardened runtime. An unsigned binary has none of the three, and Apple refuses it outright — measured on 0.1.1, whose log said *"The binary is not signed"*, *"does not include a secure timestamp"* and *"does not have the hardened runtime enabled"*. So the workflow could produce an installer, and that installer could never be made openable without a manual rebuild. `APPLE_CERTIFICATE` closes that.

## Why the iOS upload needed a human

A headless `exportArchive` failed with:

> Provisioning profile "iOS Team Store Provisioning Profile: com.wealthtracker.mobile" doesn't include the com.apple.developer.associated-domains entitlement.

Adding a capability in Xcode regenerates the **development** profile; the **distribution** profile is a separate object and does not follow, and only something holding an App Store Connect session can regenerate it. Organizer holds one; a shell does not. An API key *is* one — so `-allowProvisioningUpdates` can now do it unattended, via `scripts/ios-release.sh`.

Scope note: this makes iOS uploads headless. It does **not** move iOS *building* into CI, which would additionally need the distribution certificate and profiles managed there.

## Three signatures, three questions

They are easy to conflate, and conflating them is what made this take two days:

| | answers |
|---|---|
| `TAURI_SIGNING_*` | does this archive come from us? (the updater checks it) |
| `APPLE_CERTIFICATE` | is this binary signed at all? (without it, notarisation is impossible) |
| `APPLE_API_*` | does Apple think it is safe? (and the same key uploads iOS) |

Each degrades quietly when its secret is absent — an unsigned build, or a signed one that is not notarised — so the workflow kept working before the secrets existed and keeps working if one is rotated away. **The absence check for the API key is in the script, not in an `if:`**, because the secrets context is not dependable in a step condition and a silently-skipped step would produce an unsigned build that looked exactly like a signed one.

Windows code signing is still absent, and now says so in one place rather than being implied by silence.

## Proof

A throwaway `desktop-v0.1.3` follows this merge. The question it answers: does CI produce a dmg that is already notarised, with nothing touching the owner's Mac?

🤖 Generated with [Claude Code](https://claude.com/claude-code)