### PR TITLE
build(desktop): 0.1.3, cut to find out whether CI can sign and notarise alone

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wealthtracker-desktop",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "The desktop shell's own manifest. The web app's package.json deliberately carries no desktop dependencies (see README) — the Tauri CLI lives here instead, so `npm run tauri --prefix apps/desktop` works without the web install ever knowing about it.",
   "scripts": {
     "tauri": "tauri"

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4367,7 +4367,7 @@ dependencies = [
 
 [[package]]
 name = "wealthtracker-desktop"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "rusqlite",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@
 
 [package]
 name = "wealthtracker-desktop"
-version = "0.1.2"
+version = "0.1.3"
 description = "WealthTracker local edition — the desktop shell."
 edition = "2021"
 rust-version = "1.89"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WealthTracker",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "identifier": "com.wealthtracker.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Not a feature release.

0.1.1 and 0.1.2 were both finished by hand on the owner's Mac, because a CI-built binary is unsigned — and an unsigned binary cannot be notarised at all. Apple's log on 0.1.1 said so three ways: *the binary is not signed*, *the signature does not include a secure timestamp*, *the executable does not have the hardened runtime enabled*.

The certificate and an App Store Connect key are now in Actions secrets. The only way to find out whether that is sufficient is to ask for a release and look at what comes back.

**What would prove it:** a dmg on the release page that `spctl` already calls `accepted, source=Notarized Developer ID`, with nothing built locally.

All four version strings move together this time — `tauri.conf.json`, `Cargo.toml`, `package.json` **and** `Cargo.lock`. The 0.1.2 bump left the lock behind, so every subsequent build rewrote it and dirtied the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)