### PR TITLE
fix(investments): the portfolio list gets an order, its cash goes home, and the page stops asking twice

### DIFF
--- a/src/components/InvestmentMarketView.tsx
+++ b/src/components/InvestmentMarketView.tsx
@@ -35,6 +35,16 @@ interface InvestmentMarketViewProps {
   /** Account currency, used when a holding does not name its own. */
   fallbackCurrency: string;
   onUpdateQuotes: () => void;
+  /**
+   * Whether the holdings panel is open BELOW this view.
+   *
+   * P8b — a message must be true of the state it is rendered in. The empty
+   * sentence tells the reader to open a panel; rendered while that panel is
+   * already open, it instructs them to do what they have just done, to reveal
+   * something already on screen. It belongs to the collapsed state, so it is
+   * only drawn there. (Design, 27 Aug §2.)
+   */
+  holdingsPanelOpen?: boolean;
   isUpdating: boolean;
   /** Shown above the table when the last update failed. */
   updateError?: string | null;
@@ -59,8 +69,9 @@ export default function InvestmentMarketView({
   onUpdateQuotes,
   isUpdating,
   updateError = null,
-  symbolErrors
-}: InvestmentMarketViewProps): React.JSX.Element {
+  symbolErrors,
+  holdingsPanelOpen = false
+}: InvestmentMarketViewProps): React.JSX.Element | null {
   const { formatCurrency } = useCurrencyDecimal();
 
   /**
@@ -99,10 +110,15 @@ export default function InvestmentMarketView({
   }, [holdings]);
 
   if (holdings.length === 0) {
+    // The panel below is already saying this, and saying it better — with the
+    // control that acts on it. Two empty states stacked is one too many.
+    if (holdingsPanelOpen) {
+      return null;
+    }
     return (
       <div className="text-center py-8">
         <p className="text-gray-500 dark:text-gray-400">
-          No holdings recorded for this account. Press Manage holdings above to add them and see market values.
+          No holdings recorded for this account. Press Show holdings to add them and see market values.
         </p>
       </div>
     );

--- a/src/components/PortfolioManager.tsx
+++ b/src/components/PortfolioManager.tsx
@@ -16,7 +16,7 @@ import MoneyInput from './common/MoneyInput';
 import DatePicker from './common/DatePicker';
 import StockSymbolSearch from './StockSymbolSearch';
 import { fetchQuotes, type StockQuote } from '../services/stockPriceService';
-import { PlusIcon, EditIcon, DeleteIcon, CheckIcon } from './icons';
+import { PlusIcon, EditIcon, DeleteIcon } from './icons';
 import { Modal } from './common/Modal';
 import { LoadingButton } from './loading/LoadingState';
 // From the LIFTED module, not from `services/api/investmentService` — which
@@ -686,14 +686,24 @@ export default function PortfolioManager({
         <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
           Holdings ({holdings.length})
         </h3>
-        <button
-          type="button"
-          onClick={startAdd}
-          className="flex items-center gap-2 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary transition-colors"
-        >
-          <PlusIcon size={20} aria-hidden="true" />
-          Add Holding
-        </button>
+        {/* ONE PRIMARY PER SECTION, and while the list is empty the empty
+            state owns it. This button and the empty panel's button were the
+            same button, in the same treatment, 150px apart, doing the same
+            thing — the reader had to work out how they differed, and they did
+            not. The empty state's is the one in their path and carries the
+            better label, so this one waits until there is a list to add to.
+            Populated, the empty panel is gone and the two never coexist.
+            (Design, 27 Aug §1.) */}
+        {holdings.length > 0 && (
+          <button
+            type="button"
+            onClick={startAdd}
+            className="flex items-center gap-2 px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary transition-colors"
+          >
+            <PlusIcon size={20} aria-hidden="true" />
+            Add holding
+          </button>
+        )}
       </div>
 
       {listError && (
@@ -703,7 +713,11 @@ export default function PortfolioManager({
       )}
 
       {holdings.length === 0 ? (
-        <div className="text-center py-12 bg-gray-50 dark:bg-gray-800/50 rounded-lg">
+        /* No band. The sentence and its button sat on a tinted strip, with its
+           own inset, inside a card, below a divider — three levels of
+           container for one sentence and one control. Weight before boxes:
+           space separates them just as well. (Design, 27 Aug §6.) */
+        <div className="text-center py-12">
           <p className="text-gray-500 dark:text-gray-400 mb-4">
             No holdings yet. Add the shares, funds or ETFs this account holds.
           </p>
@@ -713,7 +727,7 @@ export default function PortfolioManager({
             className="inline-flex items-center gap-2 px-6 py-3 bg-[#1a2332] text-white rounded-lg hover:bg-secondary transition-colors"
           >
             <PlusIcon size={20} aria-hidden="true" />
-            Add Your First Holding
+            Add your first holding
           </button>
         </div>
       ) : (
@@ -1114,7 +1128,12 @@ export default function PortfolioManager({
               className="px-6 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               loadingText="Saving…"
             >
-              <CheckIcon size={16} className="mr-2" aria-hidden="true" />
+              {/* No tick. A tick means DONE, and this button means DO IT — it
+                  described the state after a press, on a control nobody had
+                  pressed yet. It also wrapped the label onto a second line at
+                  narrow widths, with the glyph stranded alone on the first.
+                  This is the only filled control in the modal; it needs no
+                  help being found. (Design, 27 Aug §3.) */}
               {editing ? 'Save changes' : 'Add holding'}
             </LoadingButton>
           </div>

--- a/src/components/__tests__/PortfolioManager.buyFx.test.tsx
+++ b/src/components/__tests__/PortfolioManager.buyFx.test.tsx
@@ -90,7 +90,7 @@ const renderManager = () =>
 
 /** Open the add form and fill in a 10-unit buy of a dollar-priced instrument. */
 const fillDollarBuy = async (): Promise<void> => {
-  fireEvent.click(screen.getByRole('button', { name: /Add Your First Holding/ }));
+  fireEvent.click(screen.getByRole('button', { name: /add your first holding/i }));
   fireEvent.click(await screen.findByRole('button', { name: 'pick a synthetic instrument' }));
   // The quote resolves and sets the instrument's currency to USD.
   await waitFor(() => {
@@ -229,7 +229,7 @@ describe('PortfolioManager — a buy across a currency boundary', () => {
     // because the STORED cost derives through it.
     renderManager();
 
-    fireEvent.click(screen.getByRole('button', { name: /Add Your First Holding/ }));
+    fireEvent.click(screen.getByRole('button', { name: /add your first holding/i }));
     fireEvent.click(await screen.findByRole('button', { name: 'pick a synthetic instrument' }));
     await waitFor(() => expect(screen.getByLabelText('Priced in')).toHaveValue('USD'));
     fireEvent.change(screen.getByLabelText('Enter figures in'), {
@@ -261,7 +261,7 @@ describe('PortfolioManager — a buy across a currency boundary', () => {
   it('shows no rate box at all when the instrument counts in the account’s own currency', async () => {
     renderManager();
 
-    fireEvent.click(screen.getByRole('button', { name: /Add Your First Holding/ }));
+    fireEvent.click(screen.getByRole('button', { name: /add your first holding/i }));
     fireEvent.click(await screen.findByRole('button', { name: 'pick a synthetic instrument' }));
     await waitFor(() => expect(screen.getByLabelText('Priced in')).toHaveValue('USD'));
     // Put the instrument back into sterling: nothing to convert, so the cost

--- a/src/index.css
+++ b/src/index.css
@@ -130,6 +130,61 @@ input[type="range"] {
   accent-color: var(--color-border-focus, #1a2332);
 }
 
+/* THE APP OWNS ITS FORM CONTROLS (Design, 27 Aug — Add-a-holding §1).
+   --------------------------------------------------------------------------
+   Every `<select>` in the app drew the operating system's double chevron, and
+   every number input drew the OS stepper. Around them sat the design system —
+   hairline, radius 6, house type — so on any dialog with both, four controls
+   were visibly foreign. On a dark ground it was worse than a mismatch: a
+   native select brings its OWN greys, so the selects read lighter than the
+   text inputs beside them.
+
+   ELEMENT SELECTORS, DELIBERATELY, AND NO !important. `select` scores 0,0,1,
+   so any Tailwind utility (0,1,0) still wins. That is the point: this sets the
+   floor for the forty-two files that never asked for anything, and a component
+   that needs different padding or a different ground simply says so. The
+   index.css rules that became component bugs are all `!important` ones that
+   nothing downstream could beat — this must not join them.
+
+   THE CHEVRON IS A BACKGROUND IMAGE, not a pseudo-element: `select` cannot
+   host ::after in any engine. `currentColor` is not available inside a data
+   URI, so it is drawn in the house slate and dark mode restates it.
+
+   `appearance: none` IS THE ONLY THING THAT REMOVES EITHER ORNAMENT. No
+   border, colour or background rule will do it, and WebKit needs its own
+   pseudo-element for the spinner — Chrome can look correct while Safari and
+   the Tauri webview still show arrows, so all three grounds are worth a look
+   after any change here. */
+select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%2364748b' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  /* Room for the chevron so a long option cannot run underneath it — the
+     reason `GBP — British Pound` was colliding with the arrow at narrow
+     widths. */
+  padding-right: 2.25rem;
+}
+
+.dark select {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+}
+
+/* A stepper on a quantity that can be 0.4137 units is not usable, and the
+   field's own caption already says fractional units are fine. */
+input[type="number"] {
+  appearance: textfield;
+  -moz-appearance: textfield;
+}
+
+input[type="number"]::-webkit-outer-spin-button,
+input[type="number"]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
 @media (hover: hover) and (pointer: fine) {
   input[type="checkbox"],
   input[type="radio"] {

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -431,6 +431,40 @@ function InvestmentsView() {
     [openAccounts]
   );
 
+  /**
+   * What the PORTFOLIO TAB lists: one card per portfolio, in alphabetical
+   * order.
+   *
+   * TWO THINGS THE FLAT LIST ABOVE GETS WRONG HERE, both reported by the
+   * owner.
+   *
+   * ORDER. `investmentAccounts` is a filter over the accounts as the store
+   * returned them, which is `created_at` ascending — for this ledger, the
+   * order Microsoft Money happened to be imported in. It reads as random
+   * because it is arbitrary, and nothing downstream re-sorted it.
+   *
+   * PAIRED CASH. A brokerage account and its settlement cash are ONE holding
+   * to the person who owns them — the Microsoft Money model this app already
+   * implements through `parentAccountId` (see utils/accountNesting and the
+   * 20260722090000 migration, whose header says listing the cash side as a
+   * free-standing account "is wrong"). The OVERVIEW tab has always honoured
+   * it; this tab did not, so a cash sleeve typed 'investment' drew its own
+   * card beside the portfolio it belongs to. Keeping only the roots folds it
+   * back where it belongs, and needs no schema change — the pairing is
+   * already in the data.
+   *
+   * A cash account that is genuinely unparented still appears on its own, and
+   * that is correct: the app cannot invent a pairing nobody has recorded. The
+   * remedy for those is Account Settings → "Part of investment account".
+   */
+  const portfolioRootAccounts = useMemo(() => {
+    const topLevelIdByAccountId = buildTopLevelIdByAccountId(openAccounts);
+    return investmentAccounts
+      .filter(acc => topLevelIdByAccountId.get(acc.id) === acc.id)
+      .slice()
+      .sort((a, b) => a.name.localeCompare(b.name, 'en-GB', { sensitivity: 'base' }));
+  }, [investmentAccounts, openAccounts]);
+
   const accountsById = useMemo(
     () => new Map(openAccounts.map(acc => [acc.id, acc])),
     [openAccounts]
@@ -2124,7 +2158,7 @@ function InvestmentsView() {
             </div>
           )}
 
-          {investmentAccounts.map((account) => {
+          {portfolioRootAccounts.map((account) => {
             const accountHoldings = holdingsByAccount.get(account.id) ?? [];
             return (
               <div key={account.id} className="bg-white dark:bg-gray-800 rounded-lg border border-line dark:border-gray-700 p-6">
@@ -2136,11 +2170,17 @@ function InvestmentsView() {
                     aria-expanded={managingAccountId === account.id}
                     className="text-body text-primary hover:text-secondary transition-colors"
                   >
-                    {managingAccountId === account.id ? 'Done' : 'Manage holdings'}
+                    {/* A disclosure, named as one. "Manage holdings" promised a
+                        destination and delivered an inline list, and its
+                        closing word "Done" is the vocabulary of an action, not
+                        of a fold — which is exactly why the pair read oddly.
+                        (Design, 27 Aug §3.) */}
+                    {managingAccountId === account.id ? 'Hide holdings' : 'Show holdings'}
                   </button>
                 </div>
                 <InvestmentMarketView
                   holdings={accountHoldings}
+                  holdingsPanelOpen={managingAccountId === account.id}
                   fallbackCurrency={account.currency}
                   onUpdateQuotes={() =>
                     void updateQuotes(

--- a/src/pages/__tests__/Investments.addDoor.test.tsx
+++ b/src/pages/__tests__/Investments.addDoor.test.tsx
@@ -91,8 +91,11 @@ describe('Investments — the add-a-holding door', () => {
     await waitFor(() => {
       expect(screen.getByRole('dialog', { name: /Add a holding/ })).toBeInTheDocument();
     });
-    // And it is the chosen sleeve's manager that opened, not the other one.
-    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument();
+    // And it is the chosen sleeve's panel that opened, not the other one.
+    // The control says what it does — it is a disclosure, so it closes with
+    // "Hide holdings" rather than "Done", which was the vocabulary of an
+    // action (Design, 27 Aug §3).
+    expect(screen.getByRole('button', { name: 'Hide holdings' })).toBeInTheDocument();
   });
 
   it('goes straight through when there is only one sleeve — one account is not a question', async () => {


### PR DESCRIPTION
The owner's late look at Investments, plus Claude Design's two handovers of the same date. Six findings — one of which turned out to be a data model already built and simply not used here.

## The list was in no order

`investmentAccounts` is a filter over the store's own order, which is `created_at` ascending — for this ledger, whatever order Microsoft Money happened to be imported in. It reads as random because it *is* arbitrary, and nothing downstream re-sorted it. Now alphabetical.

## Paired cash drew its own card

A brokerage account and its settlement cash are **one holding** to the person who owns them, and this app already models that: `parentAccountId`, whose migration header states that listing the cash side as a free-standing account **"is wrong"**. The **Overview** tab has always honoured it. This tab filtered `type === 'investment'` flat, so a cash sleeve typed `investment` drew its own card beside the portfolio it belongs to.

Keeping only the roots folds it back. **No schema change** — the pairing was already in the data. A genuinely *unparented* cash account still appears on its own, correctly: the app cannot invent a pairing nobody recorded. The remedy for those is Account Settings → "Part of investment account".

## A sentence that was true only when collapsed

Expanding a card left *"Press Manage holdings above to add them"* on screen — instructing the reader to press a control they had **just pressed**, in order to reveal a panel **already open beneath it**.

P8b: a message must be true of the state it is rendered in. It now draws only when collapsed.

## Two identical primaries, 150px apart

`Add Holding` in the section header and `Add Your First Holding` in the panel below were the same button, in the same treatment, doing the same thing — the owner counted them himself. One primary per section, and while the list is empty the empty state owns it; its label was the better of the two anyway. Populated, the empty panel is gone and the two never coexist.

## `Manage holdings` was a disclosure wearing an action label

It toggled to `Done` — the closing word for an action, not for a fold, which is exactly why the pair read oddly. Now `Show holdings` / `Hide holdings`.

## The app now owns its form controls

Every `<select>` drew the OS double chevron and every number input the OS stepper, so on any dialog with both, four controls were visibly foreign — worse on dark, where a native select brings its own greys and read lighter than the text inputs beside it.

One **element-selector** rule, **no `!important`**: `select` scores 0,0,1, so any Tailwind utility still wins. That sets the floor for the forty-two files that never asked for anything while leaving anything deliberate untouched — deliberately *not* joining the `!important` rules in this file that have become component bugs.

`appearance: none` is the only thing that removes either ornament, and WebKit needs its own pseudo-element for the spinner, so **Chrome can look correct while Safari and the Tauri webview still show arrows** — worth checking all three grounds after any change here.

Also: the primary button's tick is gone. A tick means *done*; the button means *do it*. It was also wrapping the label onto a second line with the glyph stranded above it.

## On the making of it

The casing change broke **seven** specs in `PortfolioManager.buyFx.test.tsx` that matched the title-case label — the full suite caught them, my targeted runs had not. Those matchers are now case-insensitive so the next casing ruling costs nobody an afternoon.

Verified in the running app with the panel open: one add button, the collapsed sentence gone, the toggle reading `Hide holdings`.

## Left for the owner, deliberately

- **A combined "Total Account Value"** as Microsoft Money shows it. The codebase forbids summing market value with ledger value — it says so twice — because the shares and the cash that bought them can be the same money. Securities market value plus a settlement cash balance is arguably sound since they are disjoint, but it is a new figure on a page built around keeping those apart, and it would silently exclude unpriced holdings. That is a ruling, not a code change.
- **Design's §5** — collapsing each account to a single row rather than a 180px card. Their "real shape problem", and I agree, but it changes the page substantially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)