### PR TITLE
feat(investments): a price has a date

### DIFF
--- a/src/services/api/__tests__/investmentService.test.ts
+++ b/src/services/api/__tests__/investmentService.test.ts
@@ -16,13 +16,15 @@ import { toDecimal } from '../../../utils/decimal';
  */
 
 type Outcome = { data: unknown; error: { message: string; code?: string } | null };
-type Operation = 'select' | 'insert' | 'update' | 'delete';
+type Operation = 'select' | 'insert' | 'update' | 'delete' | 'upsert';
 
 interface Recorded {
   table: string;
   op: Operation;
   columns?: string;
-  payload?: Record<string, unknown>;
+  payload?: Record<string, unknown> | Array<Record<string, unknown>>;
+  /** upsert only: the onConflict option, so a spec can pin the conflict key. */
+  onConflict?: string;
   filters: Array<[string, unknown]>;
 }
 
@@ -76,8 +78,14 @@ const nextOutcome = (op: Operation): Outcome => {
   return queue.length === 1 ? queue[0] : (queue.shift() as Outcome);
 };
 
-const build = (table: string, op: Operation, payload?: Record<string, unknown>): QueryDouble => {
+const build = (
+  table: string,
+  op: Operation,
+  payload?: Record<string, unknown> | Array<Record<string, unknown>>,
+  onConflict?: string
+): QueryDouble => {
   const record: Recorded = { table, op, payload, filters: [] };
+  if (onConflict !== undefined) record.onConflict = onConflict;
   calls.push(record);
   return new QueryDouble(nextOutcome(op), record);
 };
@@ -87,6 +95,8 @@ const supabaseDouble = {
     select: (columns: string) => build(table, 'select', undefined).select(columns),
     insert: (payload: Record<string, unknown>) => build(table, 'insert', payload),
     update: (payload: Record<string, unknown>) => build(table, 'update', payload),
+    upsert: (payload: Array<Record<string, unknown>>, options?: { onConflict?: string }) =>
+      build(table, 'upsert', payload, options?.onConflict),
     delete: () => build(table, 'delete')
   })
 };
@@ -372,6 +382,62 @@ describe('applyQuotes', () => {
     // Counted, not assumed: a symbol that matched nothing must not read as
     // success.
     expect(updated).toBe(2);
+  });
+
+  it('files the day\'s price as history, in the holding\'s own currency', async () => {
+    // current_price is a snapshot that every refresh overwrites — which is
+    // why the app could never answer "what was this worth on the 3rd of
+    // June?". Every refresh now also lands one row per (user, symbol, day)
+    // in investment_prices, the table the owner's Microsoft Money file
+    // models (SP — measured 27 Aug 2026). Same-day refreshes REPLACE via
+    // onConflict, because the day's price is one fact.
+    outcomes = { update: [ok([{ id: 'inv-1', currency: 'USD' }])] };
+
+    await InvestmentService.applyQuotes(USER, [
+      { symbol: 'AAPL', price: '232.50', asOf: '2026-08-27T14:30:00.000Z' }
+    ]);
+
+    const upsert = lastCall('upsert');
+    expect(upsert.table).toBe('investment_prices');
+    expect(upsert.onConflict).toBe('user_id,symbol,price_date');
+    expect(upsert.payload).toEqual([
+      {
+        user_id: USER,
+        symbol: 'AAPL',
+        price_date: '2026-08-27',
+        price: '232.50',
+        // The HOLDING row's currency, not a guess: prices live in the
+        // security's currency, exactly as Money stored a measured sale in
+        // the security's USD against a GBP register.
+        currency: 'USD',
+        source: 'quote'
+      }
+    ]);
+  });
+
+  it('records no history for a quote that matched no holding', async () => {
+    // A stray quote for something the user no longer holds is not their
+    // history.
+    outcomes = { update: [ok([])] };
+
+    await InvestmentService.applyQuotes(USER, [
+      { symbol: 'GONE.L', price: '1.00', asOf: '2026-08-27T14:30:00.000Z' }
+    ]);
+
+    expect(calls.filter(c => c.op === 'upsert')).toHaveLength(0);
+  });
+
+  it('throws when the history write fails — the gap would surface months later', async () => {
+    outcomes = {
+      update: [ok([{ id: 'inv-1', currency: 'GBP' }])],
+      upsert: [fails('permission denied')]
+    };
+
+    await expect(
+      InvestmentService.applyQuotes(USER, [
+        { symbol: 'SHEL.L', price: '32.775', asOf: '2026-08-27T14:30:00.000Z' }
+      ])
+    ).rejects.toThrow();
   });
 
   it('does nothing, and asks nothing, for an empty list', async () => {

--- a/src/services/api/investmentService.ts
+++ b/src/services/api/investmentService.ts
@@ -229,6 +229,14 @@ export class InvestmentService {
     const client = requireClient('these prices');
 
     let updated = 0;
+    const priceHistory: Array<{
+      user_id: string;
+      symbol: string;
+      price_date: string;
+      price: string;
+      currency: string;
+      source: 'quote';
+    }> = [];
     for (const quote of quotes) {
       const { data, error } = await client
         .from('investments')
@@ -239,13 +247,53 @@ export class InvestmentService {
         })
         .eq('user_id', userId)
         .eq('symbol', quote.symbol)
-        .select('id');
+        // currency too: the history row below records the price in the
+        // SECURITY's currency, and the holding row is the authority on what
+        // that is — the quote reply is not asked, so the two cannot disagree.
+        .select('id, currency');
 
       if (error) {
         this.logger.error('Failed to store price', error);
         throw new Error(handleSupabaseError(error));
       }
       updated += data?.length ?? 0;
+
+      // ── The price becomes HISTORY, not just the current snapshot ──────────
+      // current_price above is overwritten on every refresh, which is why the
+      // app could never answer "what was this worth on the 3rd of June?".
+      // Each refresh now also files the day's price in investment_prices —
+      // the table the owner's own Microsoft Money file models (SP: 249 price
+      // rows against 140 security transactions; value is shares × price-as-at
+      // -date, measured 27 Aug 2026). One row per (user, symbol, day); a
+      // second refresh the same day REPLACES, because the day's price is one
+      // fact. Only symbols that matched a holding are recorded — a stray
+      // quote for something the user no longer holds is not their history.
+      const currency = data?.[0]?.currency;
+      if ((data?.length ?? 0) > 0) {
+        priceHistory.push({
+          user_id: userId,
+          symbol: quote.symbol,
+          // The UTC date of the quote. asOf is full ISO 8601; the date part
+          // is what a price series keys on, exactly as Money's SP.dt did.
+          price_date: quote.asOf.slice(0, 10),
+          price: quote.price,
+          currency: typeof currency === 'string' && currency.trim() !== '' ? currency : 'GBP',
+          source: 'quote'
+        });
+      }
+    }
+
+    if (priceHistory.length > 0) {
+      const { error } = await client
+        .from('investment_prices')
+        .upsert(priceHistory, { onConflict: 'user_id,symbol,price_date' });
+      if (error) {
+        // Loud, not silent: the snapshots above already landed, so a retry is
+        // safe and idempotent — but a history that quietly failed to record
+        // would surface months later as a gap nobody can explain.
+        this.logger.error('Failed to record price history', error);
+        throw new Error(handleSupabaseError(error));
+      }
     }
     return updated;
   }

--- a/supabase/migrations/20260827120000_a_price_has_a_date.sql
+++ b/supabase/migrations/20260827120000_a_price_has_a_date.sql
@@ -1,0 +1,99 @@
+-- ============================================================================
+-- A PRICE HAS A DATE — investment price history
+-- ============================================================================
+-- IMPORTANT: apply with `npm run db:migrate` (see supabase/migrations/README.md
+-- rule 1 — never the SQL editor).
+--
+-- ── WHY ─────────────────────────────────────────────────────────────────────
+--
+-- The app has exactly one price per holding: investments.current_price, a
+-- snapshot with no date. Every refresh OVERWRITES it, so the question net
+-- worth actually asks — "what was this holding worth on the 3rd of June?" —
+-- is unanswerable. A net worth that cannot value investments over time is not
+-- tracking wealth, which is the name over the door (owner, 27 Aug).
+--
+-- Microsoft Money answered it with a price table, and the owner's own .mny
+-- file is the measured precedent (probed 27 Aug 2026):
+--
+--   * SP table: 249 rows of (security, date, price, source) against only 140
+--     security-carrying transactions in 51,768 — Money stored PRICES, and
+--     computed value as shares × price-as-at-date. It did not write
+--     revaluation transactions.
+--   * 88 distinct price dates across eight years — a person pressing refresh
+--     roughly monthly, not a nightly job. History is sparse BY NATURE, and
+--     every consumer must read "the last price on or before the date", never
+--     expect a row per day.
+--   * Prices live in the SECURITY's currency, not the account's: a sale in
+--     the file appears in SP converted from the GBP register figure into the
+--     security's own USD. Hence the currency column here, per row.
+--
+-- ── THE MODEL ───────────────────────────────────────────────────────────────
+--
+-- One row per (user, symbol, day); a same-day refresh replaces rather than
+-- accumulates — the day's price is a fact with one value, and the upsert path
+-- carries ON CONFLICT accordingly. Keyed by SYMBOL, not by holding id,
+-- exactly as Money keyed SP by security: two accounts holding the same share
+-- share one price series, and a holding sold and re-bought later re-attaches
+-- to its history by name.
+--
+-- This table is the SOURCE OF TRUTH the register derives from (owner's
+-- ruling, 27 Aug): revaluation lines in a holding's register are computed
+-- from consecutive prices, not stored, so correcting a bad price corrects
+-- history in one row and the two can never drift apart.
+--
+-- `source` says who asserted the figure:
+--   'quote'   a live quote fetch (the refresh button)
+--   'manual'  the owner typed it (the local edition's only path, by design)
+--   'trade'   implied by a buy or sell at a known price
+--   'import'  carried in from another program's file (e.g. Money's SP table)
+--
+-- numeric(20,8) matches investments.current_price after 20260809120000
+-- ("a share price is not a money amount") — LSE quotes in pence carry real
+-- sub-penny precision and numeric(10,2) silently rounded it away.
+
+CREATE TABLE IF NOT EXISTS public.investment_prices (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  symbol text NOT NULL CHECK (btrim(symbol) <> ''),
+  price_date date NOT NULL,
+  price numeric(20,8) NOT NULL CHECK (price >= 0),
+  -- The SECURITY's currency — see the header.
+  currency text NOT NULL DEFAULT 'GBP',
+  source text NOT NULL CHECK (source IN ('quote', 'manual', 'trade', 'import')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT investment_prices_one_per_day UNIQUE (user_id, symbol, price_date)
+);
+
+-- The one query every consumer runs: this user's series for a symbol, newest
+-- first, or "last on or before a date". The UNIQUE above already provides the
+-- (user_id, symbol, price_date) btree; no second index needed.
+
+-- ── RLS — the custom_reports pattern exactly ────────────────────────────────
+
+ALTER TABLE public.investment_prices ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS investment_prices_select_own ON public.investment_prices;
+CREATE POLICY investment_prices_select_own ON public.investment_prices
+  FOR SELECT TO authenticated
+  USING (user_id = public.requesting_user_id());
+
+DROP POLICY IF EXISTS investment_prices_insert_own ON public.investment_prices;
+CREATE POLICY investment_prices_insert_own ON public.investment_prices
+  FOR INSERT TO authenticated
+  WITH CHECK (user_id = public.requesting_user_id());
+
+DROP POLICY IF EXISTS investment_prices_update_own ON public.investment_prices;
+CREATE POLICY investment_prices_update_own ON public.investment_prices
+  FOR UPDATE TO authenticated
+  USING (user_id = public.requesting_user_id())
+  WITH CHECK (user_id = public.requesting_user_id());
+
+DROP POLICY IF EXISTS investment_prices_delete_own ON public.investment_prices;
+CREATE POLICY investment_prices_delete_own ON public.investment_prices
+  FOR DELETE TO authenticated
+  USING (user_id = public.requesting_user_id());
+
+REVOKE ALL ON TABLE public.investment_prices FROM PUBLIC, anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.investment_prices TO authenticated;
+GRANT ALL ON TABLE public.investment_prices TO service_role;


### PR DESCRIPTION
Slice 1 of the investments arc the owner specified this morning: price history as the source of truth, with revaluation lines later **derived** from it, never stored beside it.

## The question the app could not answer

The app holds exactly one price per holding — `current_price`, a snapshot with no date, overwritten on every refresh. So the question net worth actually asks, *"what was this holding worth on the 3rd of June?"*, is unanswerable. An app named WealthTracker that cannot value investments over time is not tracking wealth — the owner's words, and he is right.

## The measured precedent

Microsoft Money answered it with a price table, and the owner's own `.mny` file was probed directly this morning rather than argued from memory:

- **SP holds 249 rows** of (security, date, price, source) against only **140 security-carrying transactions in 51,768**. Money stored *prices* and computed value as shares × price-as-at-date; it never wrote revaluation transactions.
- **88 distinct price dates across eight years** — a person pressing refresh roughly monthly. Price history is sparse **by nature**; every consumer must read "the last price on or before the date", never expect a row per day.
- **Prices live in the security's currency** — a sale in the file appears in SP converted from the GBP register figure into the security's own USD.
- One correction made before anything was built on it: the first cadence probe sorted dates as *strings* and its median came off garbage ordering (its own output held a negative gap). Re-measured properly: median 27 days for the busiest security.

## This slice

**`public.investment_prices`** — one row per (user, symbol, day), keyed by **symbol** exactly as Money keyed SP by security, so two accounts holding the same share share one series and a holding sold and re-bought re-attaches to its history. `numeric(20,8)` matching the below-the-penny ruling; RLS is the `custom_reports` pattern verbatim; `source ∈ quote | manual | trade | import`.

**`applyQuotes` becomes the first writer.** Every refresh now files the day's price as history in the holding's **own** currency — the holding row is asked, not the quote reply, so the two cannot disagree — replacing on same-day conflict because the day's price is one fact. A quote matching no holding records nothing: a stray symbol is not this user's history. A failed history write throws; the snapshot already landed, so a retry is idempotent, and a quiet gap would surface months later as a hole nobody can explain.

Two of the three new guards fail with the writeback reverted — proven before commit.

## Owner action

`npm run db:migrate` before refreshed prices start recording.

## Coming slices

2. The Money SP importer (the owner's 249 rows, 2009–2017, as `source: 'import'`).
3. The derived holding register + net worth as-at-date.
4. Buy/sell flows: the sale split (reversal + transfer, realised gain as income), funding through the linked cash account with a confirm-on-change guard, and the offer to create the cash account alongside a new investment account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)