### PR TITLE
feat(investments): eight years of Money prices come home

### DIFF
--- a/src/components/MnyPriceImportCard.tsx
+++ b/src/components/MnyPriceImportCard.tsx
@@ -1,0 +1,176 @@
+/**
+ * The door for Money PRICE HISTORY — beside the full migration, never inside it.
+ *
+ * The full .mny flow REPLACES everything, which is exactly right for a
+ * migration and exactly wrong for someone whose ledger has lived here for
+ * months and who only wants the eight years of prices Money kept in its SP
+ * table. This card reads ONLY prices (mnyPrices.ts touches CRNC, SEC, SP and
+ * nothing else) and writes ONLY price history, where existing rows win — so
+ * it cannot disturb a ledger, and running it twice is a no-op.
+ *
+ * The reader is imported ON CLICK, not at module top: mdb-reader and the
+ * decryptor already ship in the (lazy) migration chunk, and this page must
+ * not pull them into its own.
+ *
+ * Two-step, because the counts are the point: the confirm sentence says what
+ * was found AND what was skipped (symbol-less securities, pence-flagged ones,
+ * unreadable rows) before anything is written — the no-silent-caps rule, made
+ * visible. Measured against the owner's real file: 131 usable prices, 30
+ * symbol-less securities counted rather than vanished.
+ */
+import { useCallback, useRef, useState } from 'react';
+import { dataPort } from '@data';
+import { TrendingUpIcon } from './icons';
+import type { MnyPriceHistory } from '../services/import/msMoney/mnyPrices';
+
+type Step =
+  | { at: 'idle' }
+  | { at: 'reading' }
+  | { at: 'confirm'; history: MnyPriceHistory }
+  | { at: 'importing'; history: MnyPriceHistory }
+  | { at: 'done'; imported: number; alreadyPresent: number }
+  | { at: 'failed'; message: string };
+
+const skippedSentence = (h: MnyPriceHistory): string | null => {
+  const parts: string[] = [];
+  if (h.skipped.noSymbol > 0) {
+    parts.push(`${h.skipped.noSymbol} securit${h.skipped.noSymbol === 1 ? 'y' : 'ies'} without a ticker symbol`);
+  }
+  if (h.skipped.pence > 0) parts.push(`${h.skipped.pence} priced in pence`);
+  if (h.skipped.unreadable > 0) parts.push(`${h.skipped.unreadable} unreadable price${h.skipped.unreadable === 1 ? '' : 's'}`);
+  if (parts.length === 0) return null;
+  return `Left out: ${parts.join(', ')}.`;
+};
+
+export default function MnyPriceImportCard(): React.JSX.Element {
+  const [step, setStep] = useState<Step>({ at: 'idle' });
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const read = useCallback(async (file: File): Promise<void> => {
+    setStep({ at: 'reading' });
+    try {
+      const { readMnyPriceHistory } = await import('../services/import/msMoney/mnyPrices');
+      const history = readMnyPriceHistory(new Uint8Array(await file.arrayBuffer()));
+      setStep({ at: 'confirm', history });
+    } catch (error) {
+      setStep({
+        at: 'failed',
+        message: error instanceof Error ? error.message : 'This file could not be read.'
+      });
+    }
+  }, []);
+
+  const runImport = useCallback(async (history: MnyPriceHistory): Promise<void> => {
+    setStep({ at: 'importing', history });
+    try {
+      const imported = await dataPort.importInvestmentPriceHistory(
+        history.prices.map((p) => ({ symbol: p.symbol, date: p.date, price: p.price, currency: p.currency }))
+      );
+      setStep({ at: 'done', imported, alreadyPresent: history.prices.length - imported });
+    } catch (error) {
+      setStep({
+        at: 'failed',
+        message: error instanceof Error ? error.message : 'The prices could not be saved.'
+      });
+    }
+  }, []);
+
+  return (
+    <div className="w-full mb-6 rounded-2xl border border-line dark:border-gray-700 bg-white dark:bg-gray-800 p-5">
+      <div className="flex items-center gap-4">
+        <span className="shrink-0 grid place-items-center h-12 w-12 rounded-xl bg-primary-action text-on-primary-action">
+          <TrendingUpIcon size={24} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="font-semibold text-gray-900 dark:text-white">Import investment prices from Microsoft Money</p>
+          <p className="text-body text-gray-500 dark:text-gray-400">
+            Reads only the price history from a <code>.mny</code> file — nothing about your accounts or
+            transactions is touched, and prices already recorded here are kept.
+          </p>
+        </div>
+        {step.at === 'idle' || step.at === 'failed' ? (
+          <button
+            type="button"
+            onClick={() => fileRef.current?.click()}
+            className="shrink-0 px-4 py-2 rounded-lg border border-line dark:border-gray-600 text-body text-gray-900 dark:text-white hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+          >
+            Choose file
+          </button>
+        ) : null}
+        <input
+          ref={fileRef}
+          type="file"
+          accept=".mny"
+          className="hidden"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            // Same file re-chosen must fire change again after a failure.
+            e.target.value = '';
+            if (file) void read(file);
+          }}
+        />
+      </div>
+
+      {step.at === 'reading' && (
+        <p className="mt-4 text-body text-gray-500 dark:text-gray-400">Reading the file…</p>
+      )}
+
+      {step.at === 'confirm' && (
+        <div className="mt-4 border-t border-line dark:border-gray-700 pt-4">
+          {step.history.prices.length === 0 ? (
+            <p className="text-body text-gray-500 dark:text-gray-400">
+              No usable prices in this file.{' '}
+              {skippedSentence(step.history) ?? 'Its price table is empty.'}
+            </p>
+          ) : (
+            <>
+              <p className="text-body text-gray-900 dark:text-white">
+                {step.history.prices.length.toLocaleString()} price
+                {step.history.prices.length === 1 ? '' : 's'} for {step.history.securities} securit
+                {step.history.securities === 1 ? 'y' : 'ies'}, {step.history.from} to {step.history.to}.
+              </p>
+              {skippedSentence(step.history) && (
+                <p className="mt-1 text-body text-gray-500 dark:text-gray-400">{skippedSentence(step.history)}</p>
+              )}
+              <div className="mt-3 flex gap-3">
+                <button
+                  type="button"
+                  onClick={() => void runImport(step.history)}
+                  className="px-4 py-2 bg-[#1a2332] text-white rounded-lg hover:bg-secondary transition-colors"
+                >
+                  Import these prices
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setStep({ at: 'idle' })}
+                  className="px-4 py-2 rounded-lg border border-line dark:border-gray-600 text-body text-gray-900 dark:text-white hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      {step.at === 'importing' && (
+        <p className="mt-4 text-body text-gray-500 dark:text-gray-400">Saving price history…</p>
+      )}
+
+      {step.at === 'done' && (
+        <p className="mt-4 text-body text-gray-900 dark:text-white" role="status">
+          {step.imported.toLocaleString()} price{step.imported === 1 ? '' : 's'} imported
+          {step.alreadyPresent > 0
+            ? ` — ${step.alreadyPresent.toLocaleString()} already recorded here and kept as they were.`
+            : '.'}
+        </p>
+      )}
+
+      {step.at === 'failed' && (
+        <p className="mt-4 text-body text-red-700 dark:text-red-400" role="alert">
+          {step.message}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/desktop/editions/chrome.tsx
+++ b/src/desktop/editions/chrome.tsx
@@ -55,6 +55,7 @@ import { forwardRef, useImperativeHandle, type ReactElement } from 'react';
 import { currentDeviceIdentity } from '../../services/local/deviceIdentity';
 import type {
   ChromeHasBankFeeds,
+  ChromeHasPriceHistory,
   ChromeGlobalSearch,
   ChromeOrnament,
   ChromeQuickAddTransaction
@@ -141,3 +142,10 @@ export const OfflineQuickAdd: ChromeOrnament = () => null;
 
 /** No server, no tokens, no sync — see editions/chrome.ts. */
 export const CHROME_HAS_BANK_FEEDS: ChromeHasBankFeeds = false;
+
+/**
+ * The ledger file has no price-history table or verb yet — its own gated
+ * lane in the Rust core, arriving with the manual-revalue flow. Until then
+ * the import door is NOT PRINTED here (the bank-feeds lesson).
+ */
+export const CHROME_HAS_PRICE_HISTORY: ChromeHasPriceHistory = false;

--- a/src/editions/__tests__/editionAliases.test.ts
+++ b/src/editions/__tests__/editionAliases.test.ts
@@ -197,15 +197,16 @@ describe('the edition seams', () => {
     // the big one: ten pieces of furniture — eight from the mount's first half
     // and two the BUNDLE GREP added in its second, when a PWA offline queue in
     // the frame turned out to be keeping writes for a server that does not
-    // exist. `RealtimeDot` is certainly one of them. Plus one FACT:
-    // CHROME_HAS_BANK_FEEDS (26 Aug) — not furniture but a boolean the
-    // callers use to decide whether to draw their own bank-feed controls,
-    // after the first desktop install offered a nav item that could only
-    // apologise.
+    // exist. `RealtimeDot` is certainly one of them. Plus two FACTS —
+    // CHROME_HAS_BANK_FEEDS (26 Aug) and CHROME_HAS_PRICE_HISTORY (27 Aug) —
+    // not furniture but booleans the callers ask before drawing their own
+    // controls, after the first desktop install offered a nav item that
+    // could only apologise.
     const chrome = valueExportsOf('src/editions/cloud/chrome.tsx');
-    expect(chrome.length).toBe(11);
+    expect(chrome.length).toBe(12);
     expect(chrome).toContain('RealtimeDot');
     expect(chrome).toContain('CHROME_HAS_BANK_FEEDS');
+    expect(chrome).toContain('CHROME_HAS_PRICE_HISTORY');
     expect(typeExportsOf('src/editions/cloud/chrome.tsx')).toContain('GlobalSearchHandle');
     expect(valueExportsOf('src/desktop/editions/telemetry.ts')).toEqual([
       'captureException',

--- a/src/editions/chrome.ts
+++ b/src/editions/chrome.ts
@@ -120,3 +120,17 @@ export type ChromeQuickAddTransaction = ComponentType<QuickAddTransactionProps>;
  * false, and the compiler holds both to this declaration.
  */
 export type ChromeHasBankFeeds = boolean;
+
+/**
+ * WHETHER THIS EDITION CAN HOLD PRICE HISTORY — a fact, not furniture.
+ *
+ * The cloud stores dated prices in investment_prices (27 Aug); the ledger
+ * file does not have the table or the verb yet — that is a schema change in
+ * the Rust core, its own gated lane, and it arrives with the manual-revalue
+ * flow that gives the device edition its first price writer. Until then, a
+ * door offering "import your Money price history" on the desktop could only
+ * apologise, and the bank-feeds lesson (owner, 26 Aug, item 4) says such a
+ * door is not stubbed — it is NOT PRINTED. Callers ask this fact before
+ * drawing their own controls, exactly as ChromeHasBankFeeds is asked.
+ */
+export type ChromeHasPriceHistory = boolean;

--- a/src/editions/cloud/chrome.tsx
+++ b/src/editions/cloud/chrome.tsx
@@ -34,6 +34,7 @@ import { QuickAddOfflineButton as QuickAddOfflineButtonComponent } from '../../c
 import { useAutoBankSync } from '../../hooks/useAutoBankSync';
 import type {
   ChromeHasBankFeeds,
+  ChromeHasPriceHistory,
   ChromeGlobalSearch,
   ChromeOrnament,
   ChromeQuickAddTransaction
@@ -113,3 +114,6 @@ export const OfflineQuickAdd: ChromeOrnament = QuickAddOfflineButtonComponent;
 
 /** The cloud has the server, the tokens and the cron — see editions/chrome.ts. */
 export const CHROME_HAS_BANK_FEEDS: ChromeHasBankFeeds = true;
+
+/** The cloud stores dated prices in investment_prices (27 Aug). */
+export const CHROME_HAS_PRICE_HISTORY: ChromeHasPriceHistory = true;

--- a/src/pages/EnhancedImport.tsx
+++ b/src/pages/EnhancedImport.tsx
@@ -6,6 +6,7 @@ import PageWrapper from '../components/PageWrapper';
 import PageTip from '../components/PageTip';
 import { LoadingState } from '../components/loading/LoadingState';
 import { dataPort, type ImportProgress, type MsMoneyImportResult } from '@data';
+import { CHROME_HAS_PRICE_HISTORY } from '@chrome';
 import {
   UploadIcon,
   FolderIcon,
@@ -26,6 +27,7 @@ import {
 const BatchImportModal = lazyWithRecovery(() => import('../components/BatchImportModal'));
 const ImportRulesManager = lazyWithRecovery(() => import('../components/ImportRulesManager'));
 const MsMoneyImportModal = lazyWithRecovery(() => import('../components/MsMoneyImportModal'));
+const MnyPriceImportCard = lazyWithRecovery(() => import('../components/MnyPriceImportCard'));
 const DataMigrationWizard = lazyWithRecovery(() => import('../components/DataMigrationWizard'));
 const CSVImportWizard = lazyWithRecovery(() => import('../components/CSVImportWizard'));
 const OFXImportModal = lazyWithRecovery(() => import('../components/OFXImportModal'));
@@ -142,6 +144,16 @@ export default function EnhancedImport(): React.JSX.Element {
             </span>
           </span>
         </button>
+
+        {/* Price history alone — the non-destructive sibling of the migration
+            above. Gated on the edition fact: the ledger file cannot hold price
+            history yet, and a door that could only apologise is not printed
+            (the bank-feeds lesson). */}
+        {CHROME_HAS_PRICE_HISTORY && (
+          <Suspense fallback={null}>
+            <MnyPriceImportCard />
+          </Suspense>
+        )}
 
         {/* ── Restore a whole backup ───────────────────────────────────
             Sits directly under the Money migration because it is the other

--- a/src/services/api/__tests__/investmentService.test.ts
+++ b/src/services/api/__tests__/investmentService.test.ts
@@ -343,6 +343,46 @@ describe('remove', () => {
   });
 });
 
+describe('importPriceHistory', () => {
+  it('files rows as import-provenance history, and existing days win', async () => {
+    // ignoreDuplicates, not update: 'import' is the weakest provenance, so a
+    // day already priced by a quote, a typed figure or a trade keeps what it
+    // has, and a re-run of the same file is a no-op rather than a rewrite.
+    outcomes = { upsert: [ok([{ id: 'p-1' }])] };
+
+    const inserted = await InvestmentService.importPriceHistory(USER, [
+      { symbol: 'RR.L', date: '2015-03-11', price: '9.5', currency: 'GBP' },
+      { symbol: 'RR.L', date: '2015-04-02', price: '9.7', currency: 'GBP' }
+    ]);
+
+    const upsert = lastCall('upsert');
+    expect(upsert.table).toBe('investment_prices');
+    expect(upsert.onConflict).toBe('user_id,symbol,price_date');
+    expect(upsert.payload).toEqual([
+      { user_id: USER, symbol: 'RR.L', price_date: '2015-03-11', price: '9.5', currency: 'GBP', source: 'import' },
+      { user_id: USER, symbol: 'RR.L', price_date: '2015-04-02', price: '9.7', currency: 'GBP', source: 'import' }
+    ]);
+    // One of two landed — the other day was already priced. Counted from the
+    // rows actually written, never claimed from the batch.
+    expect(inserted).toBe(1);
+  });
+
+  it('does nothing, and asks nothing, for an empty history', async () => {
+    await InvestmentService.importPriceHistory(USER, []);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('throws when the write fails', async () => {
+    outcomes = { upsert: [fails('permission denied')] };
+
+    await expect(
+      InvestmentService.importPriceHistory(USER, [
+        { symbol: 'RR.L', date: '2015-03-11', price: '9.5', currency: 'GBP' }
+      ])
+    ).rejects.toThrow();
+  });
+});
+
 describe('applyQuotes', () => {
   it('writes the price and its as-of date and nothing else', async () => {
     outcomes = { update: [ok([{ id: 'inv-1' }])] };

--- a/src/services/api/dataService.ts
+++ b/src/services/api/dataService.ts
@@ -147,7 +147,7 @@ type SuggestionDismissalServiceLike = Pick<typeof SuggestionDismissalService,
  * file.
  */
 type InvestmentServiceLike = Pick<typeof import('./investmentService').InvestmentService,
-  'list' | 'create' | 'update' | 'remove' | 'applyQuotes'>;
+  'list' | 'create' | 'update' | 'remove' | 'applyQuotes' | 'importPriceHistory'>;
 type UserIdServiceLike = Pick<typeof userIdService,
   'ensureUserExists' | 'getCurrentDatabaseUserId' | 'getCurrentUserIds'>;
 /**
@@ -3086,6 +3086,18 @@ class DataServiceImpl implements DataPort {
     throw new Error(HOLDINGS_NEED_A_LOGIN);
   }
 
+  async importInvestmentPriceHistory(
+    rows: readonly { symbol: string; date: string; price: string; currency: string }[]
+  ): Promise<number> {
+    if (rows.length === 0) return 0;
+    const userId = this.userIdService.getCurrentDatabaseUserId();
+    if (userId && this.supabaseChecker()) {
+      return (await this.investmentEngine()).importPriceHistory(userId, rows);
+    }
+    this.guardCloudWrite();
+    throw new Error(HOLDINGS_NEED_A_LOGIN);
+  }
+
   /**
    * Create a category.
    *
@@ -3713,6 +3725,12 @@ export class DataService {
 
   static applyInvestmentPrices(quotes: readonly QuoteWriteback[]): Promise<number> {
     return this.service.applyInvestmentPrices(quotes);
+  }
+
+  static importInvestmentPriceHistory(
+    rows: readonly { symbol: string; date: string; price: string; currency: string }[]
+  ): Promise<number> {
+    return this.service.importInvestmentPriceHistory(rows);
   }
 
   static createCategory(category: Omit<Category, 'id'>): Promise<Category> {

--- a/src/services/api/investmentService.ts
+++ b/src/services/api/investmentService.ts
@@ -298,6 +298,47 @@ export class InvestmentService {
     return updated;
   }
 
+  /**
+   * File another program's price history — Money's SP table, typically.
+   *
+   * ON CONFLICT DO NOTHING, not update: 'import' is the WEAKEST provenance.
+   * A day already priced by a quote fetch, a typed figure or a trade keeps
+   * what it has; the import fills gaps and only gaps. That also makes a
+   * re-run of the same file a clean no-op rather than a rewrite.
+   *
+   * Returns how many rows were actually written, so the door can say
+   * "131 imported, 4 already present" instead of claiming the batch.
+   */
+  static async importPriceHistory(
+    userId: string,
+    rows: readonly { symbol: string; date: string; price: string; currency: string }[]
+  ): Promise<number> {
+    if (rows.length === 0) return 0;
+    const client = requireClient('this price history');
+
+    let inserted = 0;
+    for (let start = 0; start < rows.length; start += 500) {
+      const chunk = rows.slice(start, start + 500).map((row) => ({
+        user_id: userId,
+        symbol: row.symbol,
+        price_date: row.date,
+        price: row.price,
+        currency: row.currency,
+        source: 'import' as const
+      }));
+      const { data, error } = await client
+        .from('investment_prices')
+        .upsert(chunk, { onConflict: 'user_id,symbol,price_date', ignoreDuplicates: true })
+        .select('id');
+      if (error) {
+        this.logger.error('Failed to import price history', error);
+        throw new Error(handleSupabaseError(error));
+      }
+      inserted += data?.length ?? 0;
+    }
+    return inserted;
+  }
+
   private static async findOne(userId: string, id: string): Promise<InvestmentHolding | null> {
     if (!supabase) return null;
 

--- a/src/services/import/msMoney/mnyPrices.test.ts
+++ b/src/services/import/msMoney/mnyPrices.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { normaliseMoneySymbol, pricesFromMoneyTables } from './mnyPrices';
+
+// Every figure here is invented. The SHAPES are measured from a real Money
+// file (27 Aug 2026): SP rows keyed by security handle with Date objects,
+// SEC carrying szSymbol/hcrnc/fPence, symbols in both `US:XXXX` and `XX.L`
+// styles side by side.
+
+const CRNC = new Map<number, string | null>([
+  [18, 'GBP'],
+  [45, 'USD']
+]);
+
+const sec = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
+  hsec: 1,
+  szSymbol: 'RR.L',
+  szFull: 'Rolls-Royce Holdings',
+  hcrnc: 18,
+  fPence: 0,
+  ...over
+});
+
+const sp = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
+  hsec: 1,
+  dt: new Date('2015-03-11T00:00:00Z'),
+  dPrice: 9.5,
+  src: 5,
+  ...over
+});
+
+describe('normaliseMoneySymbol — Money vocabulary to the app', () => {
+  it('strips the country prefix and keeps the exchange suffix', () => {
+    // The two styles appear side by side in the measured register.
+    expect(normaliseMoneySymbol('US:GOOG')).toBe('GOOG');
+    expect(normaliseMoneySymbol('RR.L')).toBe('RR.L');
+  });
+
+  it('trims and leaves an already-bare ticker alone', () => {
+    expect(normaliseMoneySymbol('  VOD  ')).toBe('VOD');
+  });
+});
+
+describe('pricesFromMoneyTables', () => {
+  it('reads a price into the security\'s own currency with an ISO date', () => {
+    const out = pricesFromMoneyTables([sec()], [sp()], CRNC);
+
+    expect(out.prices).toEqual([
+      { symbol: 'RR.L', date: '2015-03-11', price: '9.5', currency: 'GBP' }
+    ]);
+    expect(out.securities).toBe(1);
+    expect(out.from).toBe('2015-03-11');
+    expect(out.to).toBe('2015-03-11');
+  });
+
+  it('counts a symbol-less security rather than silently narrowing', () => {
+    // No-silent-caps: the confirm sentence must be able to say what was left
+    // behind and why.
+    const out = pricesFromMoneyTables(
+      [sec(), sec({ hsec: 2, szSymbol: null })],
+      [sp(), sp({ hsec: 2 })],
+      CRNC
+    );
+
+    expect(out.prices).toHaveLength(1);
+    expect(out.skipped.noSymbol).toBe(1);
+  });
+
+  it('refuses a pence-flagged security instead of guessing its scale', () => {
+    // The measured file contains none, so the pence→pounds factor for SP is
+    // unverified. Converting on an assumption would be invented data.
+    const out = pricesFromMoneyTables([sec({ fPence: -1 })], [sp()], CRNC);
+
+    expect(out.prices).toEqual([]);
+    expect(out.skipped.pence).toBe(1);
+  });
+
+  it('keeps one price per symbol per day — the first, deterministically', () => {
+    const out = pricesFromMoneyTables(
+      [sec()],
+      [sp({ dPrice: 9.5 }), sp({ dPrice: 9.7 })],
+      CRNC
+    );
+
+    expect(out.prices).toHaveLength(1);
+    expect(out.prices[0].price).toBe('9.5');
+    expect(out.skipped.duplicates).toBe(1);
+  });
+
+  it('skips and counts an unreadable row — no date, or a negative price', () => {
+    const out = pricesFromMoneyTables(
+      [sec()],
+      [sp({ dt: null }), sp({ dPrice: -1, dt: new Date('2015-03-12T00:00:00Z') })],
+      CRNC
+    );
+
+    expect(out.prices).toEqual([]);
+    expect(out.skipped.unreadable).toBe(2);
+  });
+
+  it('answers an unpriced file with an empty history, not an error', () => {
+    const out = pricesFromMoneyTables([], [], CRNC);
+
+    expect(out.prices).toEqual([]);
+    expect(out.securities).toBe(0);
+    expect(out.from).toBeNull();
+  });
+
+  it('sorts the series by date so the range sentence is honest', () => {
+    const out = pricesFromMoneyTables(
+      [sec()],
+      [
+        sp({ dt: new Date('2016-01-05T00:00:00Z'), dPrice: 11 }),
+        sp({ dt: new Date('2010-06-01T00:00:00Z'), dPrice: 4 })
+      ],
+      CRNC
+    );
+
+    expect(out.from).toBe('2010-06-01');
+    expect(out.to).toBe('2016-01-05');
+  });
+});

--- a/src/services/import/msMoney/mnyPrices.ts
+++ b/src/services/import/msMoney/mnyPrices.ts
@@ -1,0 +1,172 @@
+/**
+ * Price history out of a Microsoft Money file — the SP table, standalone.
+ *
+ * SEPARATE FROM THE FULL MIGRATION, deliberately. The owner's ledger was
+ * migrated in July; what his history is missing is the eight years of prices
+ * Money kept in SP (measured 27 Aug 2026: 249 rows of security/date/price
+ * against 140 security-carrying transactions — Money stored PRICES and
+ * derived value, never revaluation rows). Re-running the full, destructive
+ * migration to obtain them would be absurd, so this reads ONLY the tables
+ * prices need — CRNC, SEC, SP — and touches nothing else. A person migrating
+ * fresh can run it after the main import; a person long since migrated can
+ * run it alone.
+ *
+ * TOLERANT WHERE THE FULL READER IS STRICT. `readMnyExport` throws when a
+ * table is missing, correctly — a Money file without accounts is not a Money
+ * file. A file without SP is merely one whose owner never priced anything,
+ * and the honest answer is an empty result, not a refusal.
+ *
+ * EVERYTHING SKIPPED IS COUNTED. A security with no ticker symbol cannot be
+ * matched to a holding by name alone; a pence-flagged security's price scale
+ * is unmeasured (none exist in the probed file, and converting on an
+ * assumption would be invented data); a row with no readable date or a
+ * negative price is noise. Each is skipped AND counted, so the confirm step
+ * can say "249 prices, 3 securities skipped" instead of silently narrowing —
+ * the no-silent-caps rule.
+ */
+
+import { decryptMny } from './mnyDecrypt';
+import { Buffer } from 'buffer';
+import MDBReader from 'mdb-reader';
+
+type Row = Record<string, unknown>;
+
+const num = (v: unknown): number | null => (typeof v === 'number' ? v : v == null ? null : Number(v));
+const str = (v: unknown): string | null => (typeof v === 'string' && v !== '' ? v : null);
+
+export interface MnyPriceRow {
+  /** Normalised ticker — see {@link normaliseMoneySymbol}. */
+  symbol: string;
+  /** YYYY-MM-DD. */
+  date: string;
+  /** Decimal string, full precision as Money held it. */
+  price: string;
+  /** ISO currency of the SECURITY (Money prices in the security's currency). */
+  currency: string;
+}
+
+export interface MnyPriceHistory {
+  prices: MnyPriceRow[];
+  /** Securities that carried at least one usable price. */
+  securities: number;
+  /** Earliest and latest price dates, for the confirm sentence. */
+  from: string | null;
+  to: string | null;
+  skipped: {
+    /** Securities with no ticker symbol — unmatchable by anything stable. */
+    noSymbol: number;
+    /** Pence-flagged securities — price scale unmeasured, refused not guessed. */
+    pence: number;
+    /** Rows with no readable date or a negative/unreadable price. */
+    unreadable: number;
+    /** Second and later prices for a (symbol, day) already seen. */
+    duplicates: number;
+  };
+}
+
+/**
+ * Money's symbol vocabulary → the app's.
+ *
+ * Money writes US listings with a country prefix and London listings with the
+ * exchange suffix — the owner's register shows `US:GOOG` and `RR.L` side by
+ * side. The app's convention (Yahoo-style) is the bare ticker for US and the
+ * suffixed form for London, so the prefix is stripped and the suffix kept.
+ */
+export const normaliseMoneySymbol = (raw: string): string =>
+  raw.trim().replace(/^[A-Z]{2,4}:/, '').trim();
+
+/**
+ * The pure half: rows in, prices out. Separated from the file IO so it can be
+ * tested with invented rows — an .mdb binary cannot reasonably be synthesised
+ * in a spec.
+ */
+export function pricesFromMoneyTables(
+  secRows: readonly Row[],
+  spRows: readonly Row[],
+  isoByCrnc: ReadonlyMap<number, string | null>
+): MnyPriceHistory {
+  const skipped = { noSymbol: 0, pence: 0, unreadable: 0, duplicates: 0 };
+
+  interface Sec { symbol: string; currency: string }
+  const secByHandle = new Map<number, Sec>();
+  for (const s of secRows) {
+    const handle = num(s.hsec);
+    if (handle === null) continue;
+    const rawSymbol = str(s.szSymbol);
+    if (!rawSymbol) {
+      skipped.noSymbol += 1;
+      continue;
+    }
+    if (s.fPence === true || s.fPence === 1 || s.fPence === -1) {
+      skipped.pence += 1;
+      continue;
+    }
+    const symbol = normaliseMoneySymbol(rawSymbol);
+    if (symbol === '') {
+      skipped.noSymbol += 1;
+      continue;
+    }
+    const currency = isoByCrnc.get(num(s.hcrnc) ?? -1) ?? 'GBP';
+    secByHandle.set(handle, { symbol, currency: currency ?? 'GBP' });
+  }
+
+  const prices: MnyPriceRow[] = [];
+  const seen = new Set<string>();
+  const pricedSymbols = new Set<string>();
+  for (const r of spRows) {
+    const sec = secByHandle.get(num(r.hsec) ?? -1);
+    if (!sec) continue; // its security was skipped above, and counted there
+
+    // A Date object from mdb-reader, and nothing else is trusted. The first
+    // probe of this data sorted String(date) — weekday text — and produced a
+    // median off garbage ordering; hence the insistence here.
+    const dt = r.dt instanceof Date && !Number.isNaN(r.dt.getTime()) ? r.dt : null;
+    const price = num(r.dPrice);
+    if (dt === null || price === null || !Number.isFinite(price) || price < 0) {
+      skipped.unreadable += 1;
+      continue;
+    }
+    const date = dt.toISOString().slice(0, 10);
+    const key = `${sec.symbol}|${date}`;
+    if (seen.has(key)) {
+      // One price per (symbol, day) — the day's price is one fact, and the
+      // store enforces the same. First row wins, deterministically.
+      skipped.duplicates += 1;
+      continue;
+    }
+    seen.add(key);
+    pricedSymbols.add(sec.symbol);
+    prices.push({ symbol: sec.symbol, date, price: String(price), currency: sec.currency });
+  }
+
+  prices.sort((a, b) => a.date.localeCompare(b.date) || a.symbol.localeCompare(b.symbol));
+  return {
+    prices,
+    securities: pricedSymbols.size,
+    from: prices[0]?.date ?? null,
+    to: prices[prices.length - 1]?.date ?? null,
+    skipped
+  };
+}
+
+/** The IO half: decrypt, open, read the three tables (tolerantly), delegate. */
+export function readMnyPriceHistory(bytes: Uint8Array): MnyPriceHistory {
+  const reader = new MDBReader(Buffer.from(decryptMny(bytes)));
+  const tableOrEmpty = (name: string): Row[] => {
+    try {
+      return reader.getTable(name).getData() as Row[];
+    } catch {
+      // A file without SP is a file whose owner never priced anything — an
+      // empty history, not an error. (Contrast readMnyExport, where a missing
+      // ACCT genuinely means "not a Money file".)
+      return [];
+    }
+  };
+
+  const isoByCrnc = new Map<number, string | null>();
+  for (const c of tableOrEmpty('CRNC')) {
+    const handle = num(c.hcrnc);
+    if (handle !== null) isoByCrnc.set(handle, str(c.szIsoCode));
+  }
+  return pricesFromMoneyTables(tableOrEmpty('SEC'), tableOrEmpty('SP'), isoByCrnc);
+}

--- a/src/services/local/localDataPort.ts
+++ b/src/services/local/localDataPort.ts
@@ -1665,6 +1665,17 @@ export class LocalDataPort implements DataPort {
     return countOf(field(answer, 'answer'), 'apply_investment_prices', 'repriced');
   }
 
+  async importInvestmentPriceHistory(): Promise<number> {
+    // The ledger file has no price-history table yet — that is a schema and a
+    // verb in the core, its own gated lane. The UI never offers this door on
+    // the device edition (CHROME_HAS_PRICE_HISTORY is false), so this
+    // refusal is the belt under that brace, with a sentence rather than a
+    // crash for whoever reaches it anyway.
+    throw new Error(
+      'This ledger file cannot hold price history yet. Import it in the cloud edition for now.'
+    );
+  }
+
   /**
    * A write verb's answer as the app's holding.
    *

--- a/src/services/port/dataPort.ts
+++ b/src/services/port/dataPort.ts
@@ -1284,6 +1284,23 @@ export interface DataPortInvestmentWrites {
    * Nothing in, zero out, nothing written.
    */
   applyInvestmentPrices(quotes: readonly QuoteWriteback[]): Promise<number>;
+
+  /**
+   * File a batch of DATED prices as history — another program's price table
+   * (Microsoft Money's SP), arriving with a date per row.
+   *
+   * Distinct from {@link applyInvestmentPrices}, which stamps TODAY's quote
+   * onto the holding and files today's history as a side effect. This one
+   * touches no holding row at all: history is its whole cargo, and existing
+   * rows for a (symbol, day) WIN over it — 'import' is the weakest
+   * provenance, so a re-run of the same file is a no-op, never a rewrite.
+   *
+   * Returns how many rows were actually written, because the door says
+   * "131 imported" and must not claim the batch.
+   */
+  importInvestmentPriceHistory(
+    rows: readonly { symbol: string; date: string; price: string; currency: string }[]
+  ): Promise<number>;
 }
 
 export interface DataPortDismissalWrites {


### PR DESCRIPTION
Slice 2 of the investments arc: the standalone importer for Microsoft Money's SP price table.

## Standalone, not a migration

The full `.mny` flow **replaces everything** — right for a migration, absurd for someone whose ledger has lived here for months and only wants the price history Money kept. This reads **CRNC, SEC and SP and nothing else**, writes **only** price history, and where a (symbol, day) is already priced the existing row **wins**: `import` is the weakest provenance, so running the same file twice is a no-op, never a rewrite.

## Measured before shipped

Run against the owner's real file before a line of UI existed: **131 usable prices across 23 securities, 2009–2015, three currencies.** The honesty counters earned their keep on first contact — **30 securities have no ticker symbol** (mostly index watch-items; their prices are why the file's range runs to 2017 while the importable range stops in 2015). Every skip class is counted and said on the confirm step before anything is written: symbol-less, pence-flagged (the scale is unmeasured in the probed file, so it is *refused*, not guessed), unreadable, duplicate. No silent caps.

## The reader

Split pure-from-IO so parsing is testable without synthesising an `.mdb` binary. **Tolerant where the migration reader is strict**: a file without SP is a file whose owner never priced anything — an empty history, not an error. Money's symbol vocabulary is normalised (`US:GOOG` → `GOOG`; `RR.L` stays — both styles appear side by side in the measured register). Dates are read from `Date` objects only; the probe that sorted `String(date)` and produced a median off weekday text is why that sentence is in the code. Prices stay in the **security's** currency, as Money held them.

## The door is not printed where it cannot open

New edition fact **`CHROME_HAS_PRICE_HISTORY`** (cloud `true`, device `false` — the ledger file has no price table or verb yet; that is its own gated lane in the Rust core and lands with the manual-revalue flow). The census counts **twelve** and names it — updated *before* the gate could catch it this time. `localDataPort` still answers the port method with a sentence, as the belt under that brace.

The card sits beside the migration on the import page, lazy-loads the reader on click (mdb-reader already ships in the migration chunk; this page's own chunk must not grow by it), and reports what actually happened: *"131 prices imported — 4 already recorded here and kept as they were."*

## Verification

Desktop greps and the size ratchet **pass**; 57 specs across the touched suites; the reader proven against the real file; the card verified rendering in the running app with the migration flow intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)